### PR TITLE
feat: add theme-list ability (#4)

### DIFF
--- a/includes/abilities/theme-list.php
+++ b/includes/abilities/theme-list.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Theme List Ability
+ *
+ * Lists all installed themes with their status.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the theme-list ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_theme_list(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/theme-list',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'List Themes', 'wp-agentic-admin' ),
+			'description'         => __( 'List all installed themes with their activation status.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'themes' => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'name'    => array( 'type' => 'string' ),
+								'slug'    => array( 'type' => 'string' ),
+								'version' => array( 'type' => 'string' ),
+								'active'  => array( 'type' => 'boolean' ),
+								'parent'  => array( 'type' => 'string' ),
+							),
+						),
+						'description' => __( 'List of themes.', 'wp-agentic-admin' ),
+					),
+					'total'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Total number of themes.', 'wp-agentic-admin' ),
+					),
+					'active' => array(
+						'type'        => 'string',
+						'description' => __( 'Slug of the active theme.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_theme_list',
+			'permission_callback' => function () {
+				return current_user_can( 'switch_themes' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'theme', 'themes', 'template', 'templates', 'appearance' ),
+			'initialMessage' => __( "I'll check your installed themes...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the theme-list ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_theme_list( array $input = array() ): array {
+	$installed    = wp_get_themes();
+	$active_theme = get_stylesheet();
+	$themes       = array();
+
+	foreach ( $installed as $slug => $theme ) {
+		$themes[] = array(
+			'name'    => $theme->get( 'Name' ),
+			'slug'    => $slug,
+			'version' => $theme->get( 'Version' ),
+			'active'  => ( $slug === $active_theme ),
+			'parent'  => $theme->parent() ? $theme->parent()->get( 'Name' ) : '',
+		);
+	}
+
+	return array(
+		'themes' => $themes,
+		'total'  => count( $themes ),
+		'active' => $active_theme,
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -163,6 +163,10 @@ class Abilities {
 			wp_agentic_admin_register_revision_cleanup();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_theme_list' ) ) {
+			wp_agentic_admin_register_theme_list();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -22,6 +22,7 @@ import { registerCronList } from './cron-list';
 import { registerRewriteFlush } from './rewrite-flush';
 import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
+import { registerThemeList } from './theme-list';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -38,6 +39,7 @@ export { registerCronList } from './cron-list';
 export { registerRewriteFlush } from './rewrite-flush';
 export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
+export { registerThemeList } from './theme-list';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -63,6 +65,7 @@ export function registerAllAbilities() {
 	registerRewriteFlush();
 	registerRewriteList();
 	registerRevisionCleanup();
+	registerThemeList();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/theme-list.js
+++ b/src/extensions/abilities/theme-list.js
@@ -1,0 +1,85 @@
+/**
+ * Theme List Ability
+ *
+ * Lists all installed WordPress themes with their status.
+ *
+ * @see includes/abilities/theme-list.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the theme-list ability with the chat system.
+ */
+export function registerThemeList() {
+	registerAbility( 'wp-agentic-admin/theme-list', {
+		label: 'List installed themes',
+		description:
+			'List all installed WordPress themes with their active/inactive status and version. Use for questions about installed themes or which theme is active.',
+
+		keywords: [ 'theme', 'themes', 'template', 'templates', 'appearance' ],
+
+		initialMessage: "I'll check your installed themes...",
+
+		summarize: ( result ) => {
+			const { themes, total } = result;
+
+			const activeTheme = themes.find( ( t ) => t.active );
+			const inactiveThemes = themes
+				.filter( ( t ) => ! t.active )
+				.map( ( t ) => t.name );
+
+			let summary = `I found ${ total } theme${
+				total !== 1 ? 's' : ''
+			} installed.\n\n`;
+
+			if ( activeTheme ) {
+				summary += `**Active theme:** ${ activeTheme.name } (v${ activeTheme.version })`;
+				if ( activeTheme.parent ) {
+					summary += ` — child of ${ activeTheme.parent }`;
+				}
+				summary += '\n\n';
+			}
+
+			if ( inactiveThemes.length > 0 ) {
+				summary += `**Inactive themes:** ${ inactiveThemes.join(
+					', '
+				) }`;
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { themes, total } = result;
+			if ( ! themes || themes.length === 0 ) {
+				return 'No themes are installed on this site.';
+			}
+			const activeTheme = themes.find( ( t ) => t.active );
+			const inactiveNames = themes
+				.filter( ( t ) => ! t.active )
+				.map( ( t ) => t.name );
+			let text = `Found ${ total } theme${
+				total !== 1 ? 's' : ''
+			} installed.`;
+			if ( activeTheme ) {
+				text += ` Active: ${ activeTheme.name } (v${ activeTheme.version }).`;
+			}
+			if ( inactiveNames.length > 0 ) {
+				text += ` Inactive: ${ inactiveNames.join( ', ' ) }.`;
+			}
+			return text;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/theme-list', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerThemeList;

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -32,6 +32,20 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/plugin-deactivate',
 		},
 
+		// ── Theme management ──────────────────────────────────────
+		{
+			input: 'list installed themes',
+			expectTool: 'wp-agentic-admin/theme-list',
+		},
+		{
+			input: 'which theme is active on my site?',
+			expectTool: 'wp-agentic-admin/theme-list',
+		},
+		{
+			input: 'show me all themes',
+			expectTool: 'wp-agentic-admin/theme-list',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
List installed WordPress themes with active/inactive status, version, and parent theme info. Read-only ability using wp_get_themes().

## What does this PR do?

<!-- One or two sentences -->

## Type

- [ x ] New ability
- [ ] New workflow
- [ ] Bug fix
- [ ] Enhancement
- [ ] Docs

## How to test

<!-- Steps to verify this works -->

1. Check the Abilities tab and verify the ability works 
2. Try the chat and ask which themes are installed

## Screenshots (if UI changes)

<!-- Drop a screenshot or GIF here -->
