### PR TITLE
Add user-list ability

### DIFF
--- a/includes/abilities/user-list.php
+++ b/includes/abilities/user-list.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * User List Ability
+ *
+ * Lists all WordPress users with their roles.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the user-list ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_user_list(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/user-list',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'List Users', 'wp-agentic-admin' ),
+			'description'         => __( 'List all WordPress users with their roles and registration dates.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'users' => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'username'    => array( 'type' => 'string' ),
+								'display_name' => array( 'type' => 'string' ),
+								'email'       => array( 'type' => 'string' ),
+								'role'        => array( 'type' => 'string' ),
+								'registered'  => array( 'type' => 'string' ),
+							),
+						),
+						'description' => __( 'List of users.', 'wp-agentic-admin' ),
+					),
+					'total' => array(
+						'type'        => 'integer',
+						'description' => __( 'Total number of users.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_user_list',
+			'permission_callback' => function () {
+				return current_user_can( 'list_users' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'user', 'users', 'members', 'accounts', 'admins', 'authors' ),
+			'initialMessage' => __( "I'll check your WordPress users...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the user-list ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_user_list( array $input = array() ): array {
+	$wp_users = get_users( array( 'orderby' => 'registered', 'order' => 'DESC' ) );
+	$users    = array();
+
+	foreach ( $wp_users as $user ) {
+		$roles = $user->roles;
+		// Sanitize email — mask the local part for privacy.
+		$email_parts = explode( '@', $user->user_email );
+		$masked      = substr( $email_parts[0], 0, 2 ) . '***@' . ( $email_parts[1] ?? '' );
+
+		$users[] = array(
+			'username'     => $user->user_login,
+			'display_name' => $user->display_name,
+			'email'        => $masked,
+			'role'         => ! empty( $roles ) ? implode( ', ', $roles ) : 'none',
+			'registered'   => $user->user_registered,
+		);
+	}
+
+	return array(
+		'users' => $users,
+		'total' => count( $users ),
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -163,6 +163,10 @@ class Abilities {
 			wp_agentic_admin_register_revision_cleanup();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_user_list' ) ) {
+			wp_agentic_admin_register_user_list();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -22,6 +22,7 @@ import { registerCronList } from './cron-list';
 import { registerRewriteFlush } from './rewrite-flush';
 import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
+import { registerUserList } from './user-list';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -38,6 +39,7 @@ export { registerCronList } from './cron-list';
 export { registerRewriteFlush } from './rewrite-flush';
 export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
+export { registerUserList } from './user-list';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -63,6 +65,7 @@ export function registerAllAbilities() {
 	registerRewriteFlush();
 	registerRewriteList();
 	registerRevisionCleanup();
+	registerUserList();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/user-list.js
+++ b/src/extensions/abilities/user-list.js
@@ -1,0 +1,78 @@
+/**
+ * User List Ability
+ *
+ * Lists all WordPress users with their roles.
+ *
+ * @see includes/abilities/user-list.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the user-list ability with the chat system.
+ */
+export function registerUserList() {
+	registerAbility( 'wp-agentic-admin/user-list', {
+		label: 'List WordPress users',
+		description:
+			'List all WordPress users with their roles, registration dates, and masked emails. Use for questions about site users or user counts.',
+
+		keywords: [
+			'user',
+			'users',
+			'members',
+			'accounts',
+			'admins',
+			'authors',
+		],
+
+		initialMessage: "I'll check your WordPress users...",
+
+		summarize: ( result ) => {
+			const { users, total } = result;
+
+			const byRole = {};
+			users.forEach( ( u ) => {
+				const role = u.role || 'none';
+				byRole[ role ] = ( byRole[ role ] || 0 ) + 1;
+			} );
+
+			let summary = `I found ${ total } user${
+				total !== 1 ? 's' : ''
+			} on your site.\n\n`;
+
+			const roleList = Object.entries( byRole )
+				.map( ( [ role, count ] ) => `${ role }: ${ count }` )
+				.join( ', ' );
+			summary += `**By role:** ${ roleList }\n\n`;
+
+			users.forEach( ( u ) => {
+				summary += `- **${ u.display_name }** (${ u.username }) — ${ u.role }\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { users, total } = result;
+			if ( ! users || users.length === 0 ) {
+				return 'No users found on this site.';
+			}
+			const names = users.map(
+				( u ) => `${ u.display_name } (${ u.role })`
+			);
+			return `Found ${ total } users: ${ names.join( ', ' ) }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/user-list', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerUserList;

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -32,6 +32,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/plugin-deactivate',
 		},
 
+		// ── User management ───────────────────────────────────────
+		{
+			input: 'list all users on this site',
+			expectTool: 'wp-agentic-admin/user-list',
+		},
+		{
+			input: 'show me the admin users',
+			expectTool: 'wp-agentic-admin/user-list',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add user-list ability to list all WordPress users with roles, registration dates, and masked emails (#5)
- Read-only ability with `list_users` permission check
- Includes keyword-based chat routing and LLM-friendly result interpretation

## Changes
- `includes/abilities/user-list.php` — PHP backend with email masking and role aggregation
- `src/extensions/abilities/user-list.js` — JS frontend with summarize, interpretResult, execute
- `includes/class-abilities.php` — Register user-list in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for user-related queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities -- --file tests/abilities/core-abilities.test.js`)
- [x] JS lint clean (`npx wp-scripts lint-js`)
- [ ] PHP lint clean (`composer lint`) — pre-existing PHPCS config issue
- [x] Manually tested in browser

## Notes
- Email addresses are masked (e.g., `iv***@example.com`) for privacy
- Users are sorted by registration date (newest first)
- Keywords: user, users, members, accounts, admins, authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)