### PR TITLE
Add update-check ability

### DIFF
--- a/includes/abilities/update-check.php
+++ b/includes/abilities/update-check.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Update Check Ability
+ *
+ * Checks for available WordPress core, plugin, and theme updates.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the update-check ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_update_check(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/update-check',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Check Updates', 'wp-agentic-admin' ),
+			'description'         => __( 'Check for available WordPress core, plugin, and theme updates.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'core'    => array(
+						'type'        => 'object',
+						'description' => __( 'Core update info.', 'wp-agentic-admin' ),
+					),
+					'plugins' => array(
+						'type'        => 'array',
+						'description' => __( 'Plugins with available updates.', 'wp-agentic-admin' ),
+					),
+					'themes'  => array(
+						'type'        => 'array',
+						'description' => __( 'Themes with available updates.', 'wp-agentic-admin' ),
+					),
+					'total'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Total number of available updates.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_update_check',
+			'permission_callback' => function () {
+				return current_user_can( 'update_core' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'update', 'updates', 'outdated', 'upgrade', 'version' ),
+			'initialMessage' => __( "I'll check for available updates...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the update-check ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_update_check( array $input = array() ): array {
+	// Ensure update functions are available.
+	if ( ! function_exists( 'get_core_updates' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+	}
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	// Core updates.
+	$core_updates = get_core_updates();
+	$core_info    = array(
+		'current'   => get_bloginfo( 'version' ),
+		'available' => false,
+		'new_version' => '',
+	);
+
+	if ( ! empty( $core_updates ) && 'upgrade' === $core_updates[0]->response ) {
+		$core_info['available']   = true;
+		$core_info['new_version'] = $core_updates[0]->version;
+	}
+
+	// Plugin updates.
+	$plugin_updates  = get_plugin_updates();
+	$plugins_needing = array();
+
+	foreach ( $plugin_updates as $file => $data ) {
+		$plugins_needing[] = array(
+			'name'        => $data->Name,
+			'slug'        => $file,
+			'current'     => $data->Version,
+			'new_version' => $data->update->new_version,
+		);
+	}
+
+	// Theme updates.
+	$theme_updates  = get_theme_updates();
+	$themes_needing = array();
+
+	foreach ( $theme_updates as $slug => $theme ) {
+		$themes_needing[] = array(
+			'name'        => $theme->get( 'Name' ),
+			'slug'        => $slug,
+			'current'     => $theme->get( 'Version' ),
+			'new_version' => $theme->update['new_version'],
+		);
+	}
+
+	$total = ( $core_info['available'] ? 1 : 0 ) + count( $plugins_needing ) + count( $themes_needing );
+
+	return array(
+		'core'    => $core_info,
+		'plugins' => $plugins_needing,
+		'themes'  => $themes_needing,
+		'total'   => $total,
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_update_check' ) ) {
+			wp_agentic_admin_register_update_check();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerUpdateCheck } from './update-check';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerUpdateCheck } from './update-check';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerUpdateCheck();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/update-check.js
+++ b/src/extensions/abilities/update-check.js
@@ -1,0 +1,86 @@
+/**
+ * Update Check Ability
+ *
+ * Checks for available WordPress core, plugin, and theme updates.
+ *
+ * @see includes/abilities/update-check.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the update-check ability with the chat system.
+ */
+export function registerUpdateCheck() {
+	registerAbility( 'wp-agentic-admin/update-check', {
+		label: 'Check for available updates',
+		description:
+			'Check for available WordPress core, plugin, and theme updates. Use when users ask about outdated software or available upgrades.',
+
+		keywords: [ 'update', 'updates', 'outdated', 'upgrade', 'version' ],
+
+		initialMessage: "I'll check for available updates...",
+
+		summarize: ( result ) => {
+			const { core, plugins, themes, total } = result;
+
+			if ( total === 0 ) {
+				return 'Everything is up to date! No updates available for core, plugins, or themes.';
+			}
+
+			let summary = `Found **${ total } update${
+				total !== 1 ? 's' : ''
+			}** available.\n\n`;
+
+			if ( core.available ) {
+				summary += `**WordPress core:** ${ core.current } → ${ core.new_version }\n\n`;
+			}
+
+			if ( plugins.length > 0 ) {
+				summary += `**Plugins (${ plugins.length }):**\n`;
+				plugins.forEach( ( p ) => {
+					summary += `- ${ p.name }: ${ p.current } → ${ p.new_version }\n`;
+				} );
+				summary += '\n';
+			}
+
+			if ( themes.length > 0 ) {
+				summary += `**Themes (${ themes.length }):**\n`;
+				themes.forEach( ( t ) => {
+					summary += `- ${ t.name }: ${ t.current } → ${ t.new_version }\n`;
+				} );
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { core, plugins, themes, total } = result;
+			if ( total === 0 ) {
+				return 'All software is up to date. No updates available.';
+			}
+			let text = `${ total } updates available.`;
+			if ( core.available ) {
+				text += ` Core: ${ core.current } to ${ core.new_version }.`;
+			}
+			if ( plugins.length > 0 ) {
+				text += ` ${ plugins.length } plugin updates.`;
+			}
+			if ( themes.length > 0 ) {
+				text += ` ${ themes.length } theme updates.`;
+			}
+			return text;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/update-check', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerUpdateCheck;

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Update management ─────────────────────────────────────
+		{
+			input: 'are there any updates available?',
+			expectTool: 'wp-agentic-admin/update-check',
+		},
+		{
+			input: 'check for outdated plugins',
+			expectTool: 'wp-agentic-admin/update-check',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add update-check ability to check for available WordPress core, plugin, and theme updates (#6)
- Read-only ability with `update_core` permission check
- Reports core version, plugin updates, and theme updates with version details

## Changes
- `includes/abilities/update-check.php` — PHP backend using `get_core_updates()`, `get_plugin_updates()`, `get_theme_updates()`
- `src/extensions/abilities/update-check.js` — JS frontend with summarize, interpretResult, execute
- `includes/class-abilities.php` — Register update-check in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for update-related queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)