### PR TITLE
Add disk-usage ability

### DIFF
--- a/includes/abilities/disk-usage.php
+++ b/includes/abilities/disk-usage.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Disk Usage Ability
+ *
+ * Checks wp-content disk usage breakdown.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the disk-usage ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_disk_usage(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/disk-usage',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Check Disk Usage', 'wp-agentic-admin' ),
+			'description'         => __( 'Check wp-content disk usage for uploads, plugins, and themes.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'directories' => array(
+						'type'        => 'array',
+						'description' => __( 'Size breakdown by directory.', 'wp-agentic-admin' ),
+					),
+					'total'       => array(
+						'type'        => 'string',
+						'description' => __( 'Total wp-content size.', 'wp-agentic-admin' ),
+					),
+					'total_bytes' => array(
+						'type'        => 'integer',
+						'description' => __( 'Total size in bytes.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_disk_usage',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'disk', 'storage', 'space', 'size', 'usage' ),
+			'initialMessage' => __( "I'll check your disk usage...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Calculate directory size with depth limit.
+ *
+ * @param string $dir   Directory path.
+ * @param int    $depth Max recursion depth.
+ * @return int Size in bytes.
+ */
+function wp_agentic_admin_dir_size( string $dir, int $depth = 10 ): int {
+	$size = 0;
+
+	if ( $depth < 0 || ! is_dir( $dir ) || ! is_readable( $dir ) ) {
+		return $size;
+	}
+
+	$iterator = new DirectoryIterator( $dir );
+
+	foreach ( $iterator as $item ) {
+		if ( $item->isDot() ) {
+			continue;
+		}
+
+		if ( $item->isFile() ) {
+			$size += $item->getSize();
+		} elseif ( $item->isDir() ) {
+			$size += wp_agentic_admin_dir_size( $item->getPathname(), $depth - 1 );
+		}
+	}
+
+	return $size;
+}
+
+/**
+ * Format bytes into human-readable string.
+ *
+ * @param int $bytes Byte count.
+ * @return string Formatted size.
+ */
+function wp_agentic_admin_format_bytes( int $bytes ): string {
+	$units = array( 'B', 'KB', 'MB', 'GB' );
+	$i     = 0;
+	$size  = (float) $bytes;
+
+	while ( $size >= 1024 && $i < count( $units ) - 1 ) {
+		$size /= 1024;
+		++$i;
+	}
+
+	return round( $size, 2 ) . ' ' . $units[ $i ];
+}
+
+/**
+ * Execute the disk-usage ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_disk_usage( array $input = array() ): array {
+	$wp_content = WP_CONTENT_DIR;
+	$dirs       = array(
+		'uploads' => $wp_content . '/uploads',
+		'plugins' => $wp_content . '/plugins',
+		'themes'  => $wp_content . '/themes',
+		'cache'   => $wp_content . '/cache',
+	);
+
+	$directories = array();
+	$total_bytes = 0;
+
+	foreach ( $dirs as $name => $path ) {
+		if ( is_dir( $path ) ) {
+			$size          = wp_agentic_admin_dir_size( $path );
+			$total_bytes  += $size;
+			$directories[] = array(
+				'name'  => $name,
+				'path'  => $path,
+				'bytes' => $size,
+				'size'  => wp_agentic_admin_format_bytes( $size ),
+			);
+		}
+	}
+
+	return array(
+		'directories' => $directories,
+		'total'       => wp_agentic_admin_format_bytes( $total_bytes ),
+		'total_bytes' => $total_bytes,
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_disk_usage' ) ) {
+			wp_agentic_admin_register_disk_usage();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/disk-usage.js
+++ b/src/extensions/abilities/disk-usage.js
@@ -1,0 +1,60 @@
+/**
+ * Disk Usage Ability
+ *
+ * Checks wp-content disk usage breakdown.
+ *
+ * @see includes/abilities/disk-usage.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the disk-usage ability with the chat system.
+ */
+export function registerDiskUsage() {
+	registerAbility( 'wp-agentic-admin/disk-usage', {
+		label: 'Check wp-content disk usage',
+		description:
+			'Check disk usage for uploads, plugins, themes, and cache directories. Use when users ask about storage or disk space.',
+
+		keywords: [ 'disk', 'storage', 'space', 'size', 'usage' ],
+
+		initialMessage: "I'll check your disk usage...",
+
+		summarize: ( result ) => {
+			const { directories, total } = result;
+
+			let summary = `**Total wp-content size:** ${ total }\n\n`;
+
+			directories.forEach( ( dir ) => {
+				summary += `- **${ dir.name }:** ${ dir.size }\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { directories, total } = result;
+			if ( ! directories || directories.length === 0 ) {
+				return 'Could not determine disk usage.';
+			}
+			const parts = directories.map(
+				( d ) => `${ d.name }: ${ d.size }`
+			);
+			return `Total wp-content: ${ total }. Breakdown: ${ parts.join(
+				', '
+			) }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/disk-usage', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerDiskUsage;

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerDiskUsage } from './disk-usage';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerDiskUsage } from './disk-usage';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerDiskUsage();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Disk usage ────────────────────────────────────────────
+		{
+			input: 'how much disk space is my site using?',
+			expectTool: 'wp-agentic-admin/disk-usage',
+		},
+		{
+			input: 'check storage usage',
+			expectTool: 'wp-agentic-admin/disk-usage',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add disk-usage ability to report disk space usage for WordPress directories (#7)
- Read-only ability with `manage_options` permission check
- Recursive directory size calculation with depth limit and human-readable formatting

## Changes
- `includes/abilities/disk-usage.php` — PHP backend with `wp_agentic_admin_dir_size()` and `wp_agentic_admin_format_bytes()` helpers
- `src/extensions/abilities/disk-usage.js` — JS frontend with summarize, interpretResult, execute
- `includes/class-abilities.php` — Register disk-usage in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for disk/storage queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)