### PR TITLE
Add comment-stats ability

### DIFF
--- a/includes/abilities/comment-stats.php
+++ b/includes/abilities/comment-stats.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Comment Stats Ability
+ *
+ * Shows comment counts by status.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the comment-stats ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_comment_stats(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/comment-stats',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Comment Statistics', 'wp-agentic-admin' ),
+			'description'         => __( 'Show comment counts by status.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'total'       => array(
+						'type'        => 'integer',
+						'description' => __( 'Total comments.', 'wp-agentic-admin' ),
+					),
+					'approved'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Approved comments.', 'wp-agentic-admin' ),
+					),
+					'pending'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Pending comments.', 'wp-agentic-admin' ),
+					),
+					'spam'        => array(
+						'type'        => 'integer',
+						'description' => __( 'Spam comments.', 'wp-agentic-admin' ),
+					),
+					'trash'       => array(
+						'type'        => 'integer',
+						'description' => __( 'Trashed comments.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_comment_stats',
+			'permission_callback' => function () {
+				return current_user_can( 'moderate_comments' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'comment', 'comments', 'spam', 'pending', 'moderation' ),
+			'initialMessage' => __( "I'll check your comment statistics...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the comment-stats ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_comment_stats( array $input = array() ): array {
+	$counts = wp_count_comments();
+
+	return array(
+		'total'    => (int) $counts->total_comments,
+		'approved' => (int) $counts->approved,
+		'pending'  => (int) $counts->moderated,
+		'spam'     => (int) $counts->spam,
+		'trash'    => (int) $counts->trash,
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_comment_stats' ) ) {
+			wp_agentic_admin_register_comment_stats();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/comment-stats.js
+++ b/src/extensions/abilities/comment-stats.js
@@ -1,0 +1,52 @@
+/**
+ * Comment Stats Ability
+ *
+ * Shows comment counts by status.
+ *
+ * @see includes/abilities/comment-stats.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the comment-stats ability with the chat system.
+ */
+export function registerCommentStats() {
+	registerAbility( 'wp-agentic-admin/comment-stats', {
+		label: 'Show comment statistics',
+		description:
+			'Show comment counts by status including approved, pending, spam, and trash. Use for questions about comments or moderation.',
+
+		keywords: [ 'comment', 'comments', 'spam', 'pending', 'moderation' ],
+
+		initialMessage: "I'll check your comment statistics...",
+
+		summarize: ( result ) => {
+			const { total, approved, pending, spam, trash } = result;
+
+			let summary = `**Total comments:** ${ total }\n\n`;
+			summary += `- Approved: ${ approved }\n`;
+			summary += `- Pending: ${ pending }\n`;
+			summary += `- Spam: ${ spam }\n`;
+			summary += `- Trash: ${ trash }`;
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { total, approved, pending, spam, trash } = result;
+			return `${ total } total comments. ${ approved } approved, ${ pending } pending, ${ spam } spam, ${ trash } trash.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/comment-stats', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerCommentStats;

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerCommentStats } from './comment-stats';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerCommentStats } from './comment-stats';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerCommentStats();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Comment stats ─────────────────────────────────────────
+		{
+			input: 'how many comments does my site have?',
+			expectTool: 'wp-agentic-admin/comment-stats',
+		},
+		{
+			input: 'show me the spam comment count',
+			expectTool: 'wp-agentic-admin/comment-stats',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add comment-stats ability to show comment statistics (#8)
- Reports approved, pending, spam, and trash comment counts using `wp_count_comments()`
- Read-only ability with `moderate_comments` permission check

## Changes
- `includes/abilities/comment-stats.php` — PHP backend using `wp_count_comments()`
- `src/extensions/abilities/comment-stats.js` — JS frontend with summarize, interpretResult, execute
- `includes/class-abilities.php` — Register comment-stats in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for comment-related queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)