### PR TITLE
feat: implement editor sidebar and core editor blocks functionality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,14 +30,20 @@ module.exports = {
 		'jsdoc/require-param-description': 'warn',
 
 		// JSX type is valid in WordPress component returns
-		'jsdoc/no-undefined-types': [ 'error', {
-			definedTypes: [ 'JSX' ],
-		} ],
+		'jsdoc/no-undefined-types': [
+			'error',
+			{
+				definedTypes: [ 'JSX' ],
+			},
+		],
 
 		// @wordpress/* packages are WordPress-provided externals, not listed in package.json
 		'import/no-extraneous-dependencies': 'off',
-		'import/no-unresolved': [ 'error', {
-			ignore: [ '^@wordpress/' ],
-		} ],
+		'import/no-unresolved': [
+			'error',
+			{
+				ignore: [ '^@wordpress/' ],
+			},
+		],
 	},
 };

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,8 +11,11 @@ Live progress for the WP Agentic Admin hackathon project. Updated as milestones 
 - [x] **Cross-linked scaling issues** — #20 (tool selection at scale) ↔ #37 (contextual skill loading)
 - [x] **Contributor notes posted** on #37 with starting points, constraints, and dev setup
 
+### First PR Merged! — theme-list ability (PR #40 by @ivdimova)
+Our first hackathon contribution is in! ivdimova added a **theme-list ability** that lets the AI list all installed WordPress themes with their active/inactive status, version, and parent theme info. The ability uses `wp_get_themes()` on the PHP side and includes full chat integration (summarize, interpretResult) on the JS side. Three new test cases were added and the full suite passed **21/21 (100%)** against Qwen 3 1.7B via Ollama. This brings us to **15 abilities** total.
+
 ### Contributors
-- ivdimova — self-assigned to #29 (web-search ability)
+- ivdimova — theme-list ability (PR #40, merged), self-assigned to #29 (web-search ability)
 
 ---
 
@@ -26,8 +29,8 @@ Live progress for the WP Agentic Admin hackathon project. Updated as milestones 
 - [x] Streaming `<think>` blocks with collapsible UI
 - [x] Post-tool nothink optimization for faster answers
 
-### Abilities (14 total)
-- [x] 12 plugin abilities: plugin list/activate/deactivate, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
+### Abilities (15 total)
+- [x] 13 plugin abilities: plugin list/activate/deactivate, theme list, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
 - [x] 2 core WordPress wrappers: get-site-info, get-environment-info
 
 ### Testing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,6 +11,15 @@ Live progress for the WP Agentic Admin hackathon project. Updated as milestones 
 - [x] **Cross-linked scaling issues** — #20 (tool selection at scale) ↔ #37 (contextual skill loading)
 - [x] **Contributor notes posted** on #37 with starting points, constraints, and dev setup
 
+### 2 More Abilities + Gutenberg Sidebar Approved! — security-scan, post-list, editor sidebar
+- **security-scan** (PR #57 by @ivdimova) — 6 security checks (WP_DEBUG, file permissions, auth salts, version exposure, directory listing), grouped by severity
+- **post-list** (PR #59 by @ivdimova) — list posts with status/type filters, `parseIntent` for natural language extraction ("show me draft posts")
+- **editor sidebar** (PR #52 by @Stefan0x) — Gutenberg `PluginSidebar` with AI chat, `core/get-editor-blocks` ability, shares WebLLM via Service Worker. Approved, merging after conflict resolution.
+- **f32 fallback model** (PR #61 by @AlexanderMelde) — auto-detect `shader-f16` support and fall back to f32 models. Changes requested on WPCS formatting.
+- **HTTP error message** (PR #50 by @robert81) — specific error when accessing over HTTP. Changes requested to remove debug file.
+
+Full suite **32/33 (97%)** — one pre-existing flaky test. That's **21 abilities**, **8 PRs merged**, and **3 more in review**.
+
 ### 4 More PRs Merged! — update-check, disk-usage, comment-stats, debug tooling
 A batch of 4 PRs merged in one round — all tested together against Qwen 3 1.7B via Ollama, **29/29 (100%)** across all abilities:
 - **update-check** (PR #42) — checks for available WordPress core, plugin, and theme updates
@@ -27,7 +36,10 @@ A **user-list ability** that lists all WordPress users with roles, registration 
 Our first hackathon contribution! A **theme-list ability** listing installed themes with active/inactive status, version, and parent theme info. Full suite **21/21 (100%)**.
 
 ### Contributors
-- ivdimova — theme-list (PR #40), user-list (PR #41), update-check (PR #42), disk-usage (PR #46), comment-stats (PR #49), testing-prompt (PR #47)
+- ivdimova — theme-list (#40), user-list (#41), update-check (#42), disk-usage (#46), comment-stats (#49), testing-prompt (#47), security-scan (#57), post-list (#59)
+- Stefan0x — editor sidebar (#52)
+- AlexanderMelde — f32 fallback model (#61, in review)
+- robert81 — HTTP error message (#50, in review)
 
 ---
 
@@ -41,8 +53,8 @@ Our first hackathon contribution! A **theme-list ability** listing installed the
 - [x] Streaming `<think>` blocks with collapsible UI
 - [x] Post-tool nothink optimization for faster answers
 
-### Abilities (19 total)
-- [x] 17 plugin abilities: plugin list/activate/deactivate, theme list, user list, update check, disk usage, comment stats, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
+### Abilities (21 total)
+- [x] 19 plugin abilities: plugin list/activate/deactivate, theme list, user list, update check, disk usage, comment stats, security scan, post list, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
 - [x] 2 core WordPress wrappers: get-site-info, get-environment-info
 
 ### Testing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,63 @@
+# CloudFest Hackathon 2026 — Progress Tracker
+
+Live progress for the WP Agentic Admin hackathon project. Updated as milestones are reached.
+
+## Day 1 — March 20 (Hackathon Kickoff)
+
+### Infrastructure
+- [x] **Dev branch workflow** — established `feature/*` → `dev` → `main` branching strategy
+- [x] **`npm run playground`** — one-command WordPress Playground with plugin activated (PHP 8.3, WP 6.9, debug mode)
+- [x] **`/assign` GitHub Action** — contributors can self-assign issues by commenting `/assign`
+- [x] **Cross-linked scaling issues** — #20 (tool selection at scale) ↔ #37 (contextual skill loading)
+- [x] **Contributor notes posted** on #37 with starting points, constraints, and dev setup
+
+### Contributors
+- ivdimova — self-assigned to #29 (web-search ability)
+
+---
+
+## Pre-Hackathon (through v0.9.5)
+
+### Core Engine
+- [x] Local LLM via WebLLM + WebGPU (Qwen 3 1.7B default, Qwen 2.5 7B alternative)
+- [x] Service Worker model hosting — persists across page navigations
+- [x] ReAct agent loop with 3-tier routing (workflow → ReAct → conversational)
+- [x] Dual-mode: function-calling (Qwen 3) and prompt-based JSON (Qwen 2.5)
+- [x] Streaming `<think>` blocks with collapsible UI
+- [x] Post-tool nothink optimization for faster answers
+
+### Abilities (14 total)
+- [x] 12 plugin abilities: plugin list/activate/deactivate, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
+- [x] 2 core WordPress wrappers: get-site-info, get-environment-info
+
+### Testing
+- [x] 43 unit tests (Jest, mock LLM)
+- [x] Ability test suite via Ollama (real Qwen 3 1.7B, 100% accuracy)
+- [x] E2E test infrastructure
+
+### Documentation
+- [x] Architecture guide, Abilities guide, Workflows guide
+- [x] 12-topic AI Fundamentals guide
+- [x] CONTRIBUTING.md, SECURITY.md, LICENSE
+
+---
+
+## Planned / In Progress
+
+| Issue | Title | Assignee | Status |
+|-------|-------|----------|--------|
+| #29 | web-search ability | ivdimova | Assigned |
+| #37 | Contextual skill loading | — | Open |
+| #12 | Sidebar toggle + slide-out panel | — | Open |
+| #33 | Gutenberg sidebar integration | — | Open |
+| #28 | query-database ability | — | Open |
+| #26 | read-file ability | — | Open |
+| #27 | write-file ability | — | Open |
+| #30 | Edge AI consultation | — | Open |
+| #31 | Google Prompt API bridge | — | Open |
+| #32 | WebMCP integration | — | Open |
+| #22 | CI/CD GitHub Actions | — | Open |
+
+---
+
+*Last updated: March 20, 2026*

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,11 +11,14 @@ Live progress for the WP Agentic Admin hackathon project. Updated as milestones 
 - [x] **Cross-linked scaling issues** — #20 (tool selection at scale) ↔ #37 (contextual skill loading)
 - [x] **Contributor notes posted** on #37 with starting points, constraints, and dev setup
 
+### Second PR Merged! — user-list ability (PR #41 by @ivdimova)
+Two abilities in one session! A **user-list ability** that lets the AI list all WordPress users with roles, registration dates, and **masked emails** for privacy (e.g., `iv***@example.com`). Uses `list_users` permission check and sorts by registration date (newest first). Merge conflicts with theme-list resolved, full suite passed **23/23 (100%)** against Qwen 3 1.7B. We're now at **16 abilities**.
+
 ### First PR Merged! — theme-list ability (PR #40 by @ivdimova)
 Our first hackathon contribution is in! ivdimova added a **theme-list ability** that lets the AI list all installed WordPress themes with their active/inactive status, version, and parent theme info. The ability uses `wp_get_themes()` on the PHP side and includes full chat integration (summarize, interpretResult) on the JS side. Three new test cases were added and the full suite passed **21/21 (100%)** against Qwen 3 1.7B via Ollama. This brings us to **15 abilities** total.
 
 ### Contributors
-- ivdimova — theme-list ability (PR #40, merged), self-assigned to #29 (web-search ability)
+- ivdimova — theme-list (PR #40), user-list (PR #41), assigned to #29 (web-search)
 
 ---
 
@@ -29,8 +32,8 @@ Our first hackathon contribution is in! ivdimova added a **theme-list ability** 
 - [x] Streaming `<think>` blocks with collapsible UI
 - [x] Post-tool nothink optimization for faster answers
 
-### Abilities (15 total)
-- [x] 13 plugin abilities: plugin list/activate/deactivate, theme list, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
+### Abilities (16 total)
+- [x] 14 plugin abilities: plugin list/activate/deactivate, theme list, user list, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
 - [x] 2 core WordPress wrappers: get-site-info, get-environment-info
 
 ### Testing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,14 +11,23 @@ Live progress for the WP Agentic Admin hackathon project. Updated as milestones 
 - [x] **Cross-linked scaling issues** — #20 (tool selection at scale) ↔ #37 (contextual skill loading)
 - [x] **Contributor notes posted** on #37 with starting points, constraints, and dev setup
 
+### 4 More PRs Merged! — update-check, disk-usage, comment-stats, debug tooling
+A batch of 4 PRs merged in one round — all tested together against Qwen 3 1.7B via Ollama, **29/29 (100%)** across all abilities:
+- **update-check** (PR #42) — checks for available WordPress core, plugin, and theme updates
+- **disk-usage** (PR #46) — wp-content disk usage breakdown (uploads, plugins, themes, cache) with recursive size calculation and depth limiting
+- **comment-stats** (PR #49) — comment counts by status (approved, pending, spam, trash) via `wp_count_comments()`
+- **system prompt printer** (PR #47) — debug utility to inspect the exact system prompt sent to the LLM
+
+That's **19 abilities** total and **6 PRs merged** on Day 1.
+
 ### Second PR Merged! — user-list ability (PR #41 by @ivdimova)
-Two abilities in one session! A **user-list ability** that lets the AI list all WordPress users with roles, registration dates, and **masked emails** for privacy (e.g., `iv***@example.com`). Uses `list_users` permission check and sorts by registration date (newest first). Merge conflicts with theme-list resolved, full suite passed **23/23 (100%)** against Qwen 3 1.7B. We're now at **16 abilities**.
+A **user-list ability** that lists all WordPress users with roles, registration dates, and **masked emails** for privacy. Full suite **23/23 (100%)**.
 
 ### First PR Merged! — theme-list ability (PR #40 by @ivdimova)
-Our first hackathon contribution is in! ivdimova added a **theme-list ability** that lets the AI list all installed WordPress themes with their active/inactive status, version, and parent theme info. The ability uses `wp_get_themes()` on the PHP side and includes full chat integration (summarize, interpretResult) on the JS side. Three new test cases were added and the full suite passed **21/21 (100%)** against Qwen 3 1.7B via Ollama. This brings us to **15 abilities** total.
+Our first hackathon contribution! A **theme-list ability** listing installed themes with active/inactive status, version, and parent theme info. Full suite **21/21 (100%)**.
 
 ### Contributors
-- ivdimova — theme-list (PR #40), user-list (PR #41), assigned to #29 (web-search)
+- ivdimova — theme-list (PR #40), user-list (PR #41), update-check (PR #42), disk-usage (PR #46), comment-stats (PR #49), testing-prompt (PR #47)
 
 ---
 
@@ -32,8 +41,8 @@ Our first hackathon contribution is in! ivdimova added a **theme-list ability** 
 - [x] Streaming `<think>` blocks with collapsible UI
 - [x] Post-tool nothink optimization for faster answers
 
-### Abilities (16 total)
-- [x] 14 plugin abilities: plugin list/activate/deactivate, theme list, user list, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
+### Abilities (19 total)
+- [x] 17 plugin abilities: plugin list/activate/deactivate, theme list, user list, update check, disk usage, comment stats, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
 - [x] 2 core WordPress wrappers: get-site-info, get-environment-info
 
 ### Testing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,14 +11,19 @@ Live progress for the WP Agentic Admin hackathon project. Updated as milestones 
 - [x] **Cross-linked scaling issues** — #20 (tool selection at scale) ↔ #37 (contextual skill loading)
 - [x] **Contributor notes posted** on #37 with starting points, constraints, and dev setup
 
-### 2 More Abilities + Gutenberg Sidebar Approved! — security-scan, post-list, editor sidebar
-- **security-scan** (PR #57 by @ivdimova) — 6 security checks (WP_DEBUG, file permissions, auth salts, version exposure, directory listing), grouped by severity
-- **post-list** (PR #59 by @ivdimova) — list posts with status/type filters, `parseIntent` for natural language extraction ("show me draft posts")
-- **editor sidebar** (PR #52 by @Stefan0x) — Gutenberg `PluginSidebar` with AI chat, `core/get-editor-blocks` ability, shares WebLLM via Service Worker. Approved, merging after conflict resolution.
-- **f32 fallback model** (PR #61 by @AlexanderMelde) — auto-detect `shader-f16` support and fall back to f32 models. Changes requested on WPCS formatting.
-- **HTTP error message** (PR #50 by @robert81) — specific error when accessing over HTTP. Changes requested to remove debug file.
+### 3 More Abilities Merged! — error-log-search, opcode-cache-status, backup-check
+- **error-log-search** (PR #65) — search/filter the error log by keyword with context lines
+- **opcode-cache-status** (PR #67) — check PHP OPcache status and hit rates
+- **backup-check** (PR #72) — detect installed backup plugins and last backup status
 
-Full suite **32/33 (97%)** — one pre-existing flaky test. That's **21 abilities**, **8 PRs merged**, and **3 more in review**.
+Full suite **37/39 (95%)** — 2 pre-existing flaky tests. That's **24 abilities**, **11 PRs merged**, 5 contributors, and 3 more PRs in review.
+
+### 2 More Abilities + Gutenberg Sidebar Approved! — security-scan, post-list, editor sidebar
+- **security-scan** (PR #57) — 6 security checks grouped by severity
+- **post-list** (PR #59) — list posts with natural language filters
+- **editor sidebar** (PR #52 by @Stefan0x) — Gutenberg `PluginSidebar` with AI chat. Approved, merging after conflict resolution.
+- **f32 fallback model** (PR #61 by @AlexanderMelde) — auto-detect `shader-f16` and fall back to f32. Changes requested on formatting.
+- **HTTP error message** (PR #50 by @robert81) — specific error over HTTP. Changes requested to remove debug file.
 
 ### 4 More PRs Merged! — update-check, disk-usage, comment-stats, debug tooling
 A batch of 4 PRs merged in one round — all tested together against Qwen 3 1.7B via Ollama, **29/29 (100%)** across all abilities:
@@ -36,10 +41,11 @@ A **user-list ability** that lists all WordPress users with roles, registration 
 Our first hackathon contribution! A **theme-list ability** listing installed themes with active/inactive status, version, and parent theme info. Full suite **21/21 (100%)**.
 
 ### Contributors
-- ivdimova — theme-list (#40), user-list (#41), update-check (#42), disk-usage (#46), comment-stats (#49), testing-prompt (#47), security-scan (#57), post-list (#59)
-- Stefan0x — editor sidebar (#52)
+- ivdimova — theme-list (#40), user-list (#41), update-check (#42), disk-usage (#46), comment-stats (#49), testing-prompt (#47), security-scan (#57), post-list (#59), error-log-search (#65), opcode-cache-status (#67), backup-check (#72)
+- Stefan0x — editor sidebar (#52, approved), model unload dropdown (#71, in review)
 - AlexanderMelde — f32 fallback model (#61, in review)
 - robert81 — HTTP error message (#50, in review)
+- janvogt — feedback thumbs up/down (#70, in review)
 
 ---
 
@@ -53,8 +59,8 @@ Our first hackathon contribution! A **theme-list ability** listing installed the
 - [x] Streaming `<think>` blocks with collapsible UI
 - [x] Post-tool nothink optimization for faster answers
 
-### Abilities (21 total)
-- [x] 19 plugin abilities: plugin list/activate/deactivate, theme list, user list, update check, disk usage, comment stats, security scan, post list, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
+### Abilities (24 total)
+- [x] 22 plugin abilities: plugin list/activate/deactivate, theme list, user list, update check, disk usage, comment stats, security scan, post list, error log search, opcode cache status, backup check, cache flush, db optimize, error log, cron list, revision cleanup, rewrite list/flush, site health, transient flush
 - [x] 2 core WordPress wrappers: get-site-info, get-environment-info
 
 ### Testing

--- a/docs/ai-fundamentals/09-tools-and-abilities.md
+++ b/docs/ai-fundamentals/09-tools-and-abilities.md
@@ -182,6 +182,7 @@ WP Agentic Admin ships with 14 abilities across different categories:
 |---------|-------------|------|
 | `revision-cleanup` | Remove old post revisions | Destructive |
 | `core/get-site-info` | Get site name/URL/version | Read-only |
+| `core/get-editor-blocks` | List available Gutenberg blocks | Read-only |
 
 ### Hackathon Goal: 17 More Abilities
 

--- a/includes/abilities/backup-check.php
+++ b/includes/abilities/backup-check.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Backup Check Ability
+ *
+ * Checks backup plugin status and last backup time.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the backup-check ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_backup_check(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/backup-check',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Check Backup Status', 'wp-agentic-admin' ),
+			'description'         => __( 'Check backup plugin status and last backup time.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'has_backup_plugin' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether a backup plugin is detected.', 'wp-agentic-admin' ),
+					),
+					'plugin'            => array(
+						'type'        => 'string',
+						'description' => __( 'Detected backup plugin name.', 'wp-agentic-admin' ),
+					),
+					'last_backup'       => array(
+						'type'        => 'string',
+						'description' => __( 'Last backup date if available.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_backup_check',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'backup', 'backups', 'restore', 'recovery' ),
+			'initialMessage' => __( "I'll check your backup status...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the backup-check ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_backup_check( array $input = array() ): array {
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	// Known backup plugins.
+	$backup_plugins = array(
+		array(
+			'slug' => 'updraftplus/updraftplus.php',
+			'name' => 'UpdraftPlus',
+		),
+		array(
+			'slug' => 'backwpup/backwpup.php',
+			'name' => 'BackWPup',
+		),
+		array(
+			'slug' => 'jetpack/jetpack.php',
+			'name' => 'Jetpack (VaultPress)',
+		),
+		array(
+			'slug' => 'blogvault-real-time-backup/developer_developer.php',
+			'name' => 'BlogVault',
+		),
+		array(
+			'slug' => 'duplicator/duplicator.php',
+			'name' => 'Duplicator',
+		),
+		array(
+			'slug' => 'all-in-one-wp-migration/all-in-one-wp-migration.php',
+			'name' => 'All-in-One WP Migration',
+		),
+	);
+
+	$detected = array();
+
+	foreach ( $backup_plugins as $plugin ) {
+		if ( is_plugin_active( $plugin['slug'] ) ) {
+			$info = array(
+				'name'        => $plugin['name'],
+				'active'      => true,
+				'last_backup' => wp_agentic_admin_get_last_backup_time( $plugin['slug'] ),
+			);
+
+			$detected[] = $info;
+		}
+	}
+
+	if ( empty( $detected ) ) {
+		return array(
+			'has_backup_plugin' => false,
+			'plugin'            => '',
+			'last_backup'       => '',
+			'detected'          => array(),
+			'message'           => 'No backup plugin detected. Consider installing one for data safety.',
+		);
+	}
+
+	return array(
+		'has_backup_plugin' => true,
+		'plugin'            => $detected[0]['name'],
+		'last_backup'       => $detected[0]['last_backup'],
+		'detected'          => $detected,
+	);
+}
+
+/**
+ * Get last backup time for a specific backup plugin.
+ *
+ * @param string $plugin_slug Plugin file slug.
+ * @return string Date string or 'Unknown'.
+ */
+function wp_agentic_admin_get_last_backup_time( string $plugin_slug ): string {
+	global $wpdb;
+
+	switch ( $plugin_slug ) {
+		case 'updraftplus/updraftplus.php':
+			$option = get_option( 'updraft_last_backup' );
+			if ( is_array( $option ) && isset( $option['last_backup'] ) ) {
+				return gmdate( 'Y-m-d H:i:s', $option['last_backup'] );
+			}
+			break;
+
+		case 'backwpup/backwpup.php':
+			$option = get_site_option( 'backwpup_last_backup' );
+			if ( is_numeric( $option ) ) {
+				return gmdate( 'Y-m-d H:i:s', (int) $option );
+			}
+			break;
+
+		case 'duplicator/duplicator.php':
+			// Duplicator stores packages in its own table.
+			$table = $wpdb->prefix . 'duplicator_packages';
+			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$last = $wpdb->get_var( "SELECT MAX(created) FROM `$table` WHERE status = 100" );
+				if ( $last ) {
+					return $last;
+				}
+			}
+			// Duplicator Lite stores in options.
+			$packages = get_option( 'duplicator_package_active', array() );
+			if ( ! empty( $packages ) && is_array( $packages ) && isset( $packages['Created'] ) ) {
+				return $packages['Created'];
+			}
+			break;
+
+		case 'jetpack/jetpack.php':
+			// VaultPress/Jetpack Backup stores timestamp in option.
+			$option = get_option( 'vaultpress_backup_last' );
+			if ( is_numeric( $option ) ) {
+				return gmdate( 'Y-m-d H:i:s', (int) $option );
+			}
+			break;
+
+		case 'blogvault-real-time-backup/developer_developer.php':
+			// BlogVault stores last backup info in option.
+			$option = get_option( 'bv_last_backup_time' );
+			if ( is_numeric( $option ) ) {
+				return gmdate( 'Y-m-d H:i:s', (int) $option );
+			}
+			break;
+
+		case 'all-in-one-wp-migration/all-in-one-wp-migration.php':
+			// All-in-One WP Migration stores exports in its backups dir.
+			$backups_dir = WP_CONTENT_DIR . '/ai1wm-backups/';
+			if ( is_dir( $backups_dir ) ) {
+				$files = glob( $backups_dir . '*.wpress' );
+				if ( ! empty( $files ) ) {
+					$latest = 0;
+					foreach ( $files as $file ) {
+						$mtime = filemtime( $file );
+						if ( $mtime > $latest ) {
+							$latest = $mtime;
+						}
+					}
+					if ( $latest > 0 ) {
+						return gmdate( 'Y-m-d H:i:s', $latest );
+					}
+				}
+			}
+			break;
+	}
+
+	return 'Unknown';
+}

--- a/includes/abilities/comment-stats.php
+++ b/includes/abilities/comment-stats.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Comment Stats Ability
+ *
+ * Shows comment counts by status.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the comment-stats ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_comment_stats(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/comment-stats',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Comment Statistics', 'wp-agentic-admin' ),
+			'description'         => __( 'Show comment counts by status.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'total'       => array(
+						'type'        => 'integer',
+						'description' => __( 'Total comments.', 'wp-agentic-admin' ),
+					),
+					'approved'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Approved comments.', 'wp-agentic-admin' ),
+					),
+					'pending'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Pending comments.', 'wp-agentic-admin' ),
+					),
+					'spam'        => array(
+						'type'        => 'integer',
+						'description' => __( 'Spam comments.', 'wp-agentic-admin' ),
+					),
+					'trash'       => array(
+						'type'        => 'integer',
+						'description' => __( 'Trashed comments.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_comment_stats',
+			'permission_callback' => function () {
+				return current_user_can( 'moderate_comments' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'comment', 'comments', 'spam', 'pending', 'moderation' ),
+			'initialMessage' => __( "I'll check your comment statistics...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the comment-stats ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_comment_stats( array $input = array() ): array {
+	$counts = wp_count_comments();
+
+	return array(
+		'total'    => (int) $counts->total_comments,
+		'approved' => (int) $counts->approved,
+		'pending'  => (int) $counts->moderated,
+		'spam'     => (int) $counts->spam,
+		'trash'    => (int) $counts->trash,
+	);
+}

--- a/includes/abilities/disk-usage.php
+++ b/includes/abilities/disk-usage.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Disk Usage Ability
+ *
+ * Checks wp-content disk usage breakdown.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the disk-usage ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_disk_usage(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/disk-usage',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Check Disk Usage', 'wp-agentic-admin' ),
+			'description'         => __( 'Check wp-content disk usage for uploads, plugins, and themes.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'directories' => array(
+						'type'        => 'array',
+						'description' => __( 'Size breakdown by directory.', 'wp-agentic-admin' ),
+					),
+					'total'       => array(
+						'type'        => 'string',
+						'description' => __( 'Total wp-content size.', 'wp-agentic-admin' ),
+					),
+					'total_bytes' => array(
+						'type'        => 'integer',
+						'description' => __( 'Total size in bytes.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_disk_usage',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'disk', 'storage', 'space', 'size', 'usage' ),
+			'initialMessage' => __( "I'll check your disk usage...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Calculate directory size with depth limit.
+ *
+ * @param string $dir   Directory path.
+ * @param int    $depth Max recursion depth.
+ * @return int Size in bytes.
+ */
+function wp_agentic_admin_dir_size( string $dir, int $depth = 10 ): int {
+	$size = 0;
+
+	if ( $depth < 0 || ! is_dir( $dir ) || ! is_readable( $dir ) ) {
+		return $size;
+	}
+
+	$iterator = new DirectoryIterator( $dir );
+
+	foreach ( $iterator as $item ) {
+		if ( $item->isDot() ) {
+			continue;
+		}
+
+		if ( $item->isFile() ) {
+			$size += $item->getSize();
+		} elseif ( $item->isDir() ) {
+			$size += wp_agentic_admin_dir_size( $item->getPathname(), $depth - 1 );
+		}
+	}
+
+	return $size;
+}
+
+/**
+ * Format bytes into human-readable string.
+ *
+ * @param int $bytes Byte count.
+ * @return string Formatted size.
+ */
+function wp_agentic_admin_format_bytes( int $bytes ): string {
+	$units = array( 'B', 'KB', 'MB', 'GB' );
+	$i     = 0;
+	$size  = (float) $bytes;
+
+	while ( $size >= 1024 && $i < count( $units ) - 1 ) {
+		$size /= 1024;
+		++$i;
+	}
+
+	return round( $size, 2 ) . ' ' . $units[ $i ];
+}
+
+/**
+ * Execute the disk-usage ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_disk_usage( array $input = array() ): array {
+	$wp_content = WP_CONTENT_DIR;
+	$dirs       = array(
+		'uploads' => $wp_content . '/uploads',
+		'plugins' => $wp_content . '/plugins',
+		'themes'  => $wp_content . '/themes',
+		'cache'   => $wp_content . '/cache',
+	);
+
+	$directories = array();
+	$total_bytes = 0;
+
+	foreach ( $dirs as $name => $path ) {
+		if ( is_dir( $path ) ) {
+			$size          = wp_agentic_admin_dir_size( $path );
+			$total_bytes  += $size;
+			$directories[] = array(
+				'name'  => $name,
+				'path'  => $path,
+				'bytes' => $size,
+				'size'  => wp_agentic_admin_format_bytes( $size ),
+			);
+		}
+	}
+
+	return array(
+		'directories' => $directories,
+		'total'       => wp_agentic_admin_format_bytes( $total_bytes ),
+		'total_bytes' => $total_bytes,
+	);
+}

--- a/includes/abilities/error-log-search.php
+++ b/includes/abilities/error-log-search.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Error Log Search Ability
+ *
+ * Filters debug.log by keyword and severity.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the error-log-search ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_error_log_search(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/error-log-search',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Search Error Log', 'wp-agentic-admin' ),
+			'description'         => __( 'Filter debug.log by keyword and severity level.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(
+					'keyword' => '',
+					'level'   => '',
+					'lines'   => 100,
+				),
+				'properties'           => array(
+					'keyword' => array(
+						'type'        => 'string',
+						'default'     => '',
+						'description' => __( 'Search keyword.', 'wp-agentic-admin' ),
+					),
+					'level'   => array(
+						'type'        => 'string',
+						'default'     => '',
+						'enum'        => array( '', 'fatal', 'warning', 'notice', 'deprecated' ),
+						'description' => __( 'Error severity level filter.', 'wp-agentic-admin' ),
+					),
+					'lines'   => array(
+						'type'        => 'integer',
+						'default'     => 100,
+						'description' => __( 'Number of log lines to scan.', 'wp-agentic-admin' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'matches' => array(
+						'type'        => 'array',
+						'description' => __( 'Matching log lines.', 'wp-agentic-admin' ),
+					),
+					'total'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of matches.', 'wp-agentic-admin' ),
+					),
+					'scanned' => array(
+						'type'        => 'integer',
+						'description' => __( 'Lines scanned.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_error_log_search',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'search', 'filter', 'error', 'fatal', 'warning', 'log' ),
+			'initialMessage' => __( "I'll search the error log...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the error-log-search ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_error_log_search( array $input = array() ): array {
+	$keyword   = isset( $input['keyword'] ) ? sanitize_text_field( $input['keyword'] ) : '';
+	$level     = isset( $input['level'] ) ? sanitize_text_field( $input['level'] ) : '';
+	$max_lines = isset( $input['lines'] ) ? min( absint( $input['lines'] ), 500 ) : 100;
+
+	$log_file = \WPAgenticAdmin\Utils::get_debug_log_path();
+
+	if ( ! file_exists( $log_file ) || ! is_readable( $log_file ) ) {
+		return array(
+			'matches' => array(),
+			'total'   => 0,
+			'scanned' => 0,
+			'message' => 'debug.log not found or not readable.',
+		);
+	}
+
+	// Read last N lines.
+	$lines   = file( $log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+	$lines   = array_slice( $lines, -$max_lines );
+	$scanned = count( $lines );
+
+	// Level mapping to PHP error prefixes.
+	$level_map = array(
+		'fatal'      => array( 'Fatal error', 'PHP Fatal' ),
+		'warning'    => array( 'Warning', 'PHP Warning' ),
+		'notice'     => array( 'Notice', 'PHP Notice' ),
+		'deprecated' => array( 'Deprecated', 'PHP Deprecated' ),
+	);
+
+	$matches = array();
+
+	foreach ( $lines as $line ) {
+		$match = true;
+
+		// Keyword filter.
+		if ( '' !== $keyword && false === stripos( $line, $keyword ) ) {
+			$match = false;
+		}
+
+		// Level filter.
+		if ( $match && '' !== $level && isset( $level_map[ $level ] ) ) {
+			$level_match = false;
+			foreach ( $level_map[ $level ] as $prefix ) {
+				if ( false !== stripos( $line, $prefix ) ) {
+					$level_match = true;
+					break;
+				}
+			}
+			if ( ! $level_match ) {
+				$match = false;
+			}
+		}
+
+		if ( $match ) {
+			$matches[] = $line;
+		}
+	}
+
+	// Limit output.
+	$matches = array_slice( $matches, -50 );
+
+	return array(
+		'matches' => $matches,
+		'total'   => count( $matches ),
+		'scanned' => $scanned,
+	);
+}

--- a/includes/abilities/opcode-cache-status.php
+++ b/includes/abilities/opcode-cache-status.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * OPcache Status Ability
+ *
+ * Checks OPcache status and configuration.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the opcode-cache-status ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_opcode_cache_status(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/opcode-cache-status',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'OPcache Status', 'wp-agentic-admin' ),
+			'description'         => __( 'Check OPcache status and configuration.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'enabled'        => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether OPcache is enabled.', 'wp-agentic-admin' ),
+					),
+					'memory'         => array(
+						'type'        => 'object',
+						'description' => __( 'Memory usage info.', 'wp-agentic-admin' ),
+					),
+					'statistics'     => array(
+						'type'        => 'object',
+						'description' => __( 'Cache statistics.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_opcode_cache_status',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'opcache', 'opcode', 'cache', 'php', 'performance' ),
+			'initialMessage' => __( "I'll check your OPcache status...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the opcode-cache-status ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_opcode_cache_status( array $input = array() ): array {
+	if ( ! function_exists( 'opcache_get_status' ) ) {
+		return array(
+			'enabled'    => false,
+			'message'    => 'OPcache extension is not loaded.',
+			'memory'     => array(),
+			'statistics' => array(),
+		);
+	}
+
+	$status = opcache_get_status( false );
+
+	if ( false === $status ) {
+		return array(
+			'enabled'    => false,
+			'message'    => 'OPcache is installed but disabled.',
+			'memory'     => array(),
+			'statistics' => array(),
+		);
+	}
+
+	$memory = $status['memory_usage'];
+	$stats  = $status['opcache_statistics'];
+
+	$total_memory = $memory['used_memory'] + $memory['free_memory'];
+	$hit_rate     = $stats['opcache_hit_rate'];
+
+	return array(
+		'enabled'    => true,
+		'memory'     => array(
+			'used'       => round( $memory['used_memory'] / 1048576, 2 ) . ' MB',
+			'free'       => round( $memory['free_memory'] / 1048576, 2 ) . ' MB',
+			'total'      => round( $total_memory / 1048576, 2 ) . ' MB',
+			'percentage' => round( ( $memory['used_memory'] / $total_memory ) * 100, 1 ),
+		),
+		'statistics' => array(
+			'cached_scripts' => $stats['num_cached_scripts'],
+			'hits'           => $stats['hits'],
+			'misses'         => $stats['misses'],
+			'hit_rate'       => round( $hit_rate, 2 ) . '%',
+		),
+	);
+}

--- a/includes/abilities/post-list.php
+++ b/includes/abilities/post-list.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Post List Ability
+ *
+ * Lists recent WordPress posts.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the post-list ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_post_list(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/post-list',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'List Posts', 'wp-agentic-admin' ),
+			'description'         => __( 'List recent WordPress posts with their status.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(
+					'status'    => 'any',
+					'post_type' => 'post',
+					'count'     => 10,
+				),
+				'properties'           => array(
+					'status'    => array(
+						'type'        => 'string',
+						'default'     => 'any',
+						'description' => __( 'Post status filter.', 'wp-agentic-admin' ),
+					),
+					'post_type' => array(
+						'type'        => 'string',
+						'default'     => 'post',
+						'description' => __( 'Post type filter.', 'wp-agentic-admin' ),
+					),
+					'count'     => array(
+						'type'        => 'integer',
+						'default'     => 10,
+						'description' => __( 'Number of posts to return.', 'wp-agentic-admin' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'posts' => array(
+						'type'        => 'array',
+						'description' => __( 'List of posts.', 'wp-agentic-admin' ),
+					),
+					'total' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of posts returned.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_post_list',
+			'permission_callback' => function () {
+				return current_user_can( 'edit_posts' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'post', 'posts', 'articles', 'content', 'drafts', 'published' ),
+			'initialMessage' => __( "I'll fetch your recent posts...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the post-list ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_post_list( array $input = array() ): array {
+	$status    = isset( $input['status'] ) ? sanitize_text_field( $input['status'] ) : 'any';
+	$post_type = isset( $input['post_type'] ) ? sanitize_text_field( $input['post_type'] ) : 'post';
+	$count     = isset( $input['count'] ) ? min( absint( $input['count'] ), 50 ) : 10;
+
+	$wp_posts = get_posts(
+		array(
+			'post_type'      => $post_type,
+			'post_status'    => $status,
+			'posts_per_page' => $count,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		)
+	);
+
+	$posts = array();
+
+	foreach ( $wp_posts as $post ) {
+		$author  = get_userdata( $post->post_author );
+		$posts[] = array(
+			'id'        => $post->ID,
+			'title'     => $post->post_title,
+			'status'    => $post->post_status,
+			'author'    => $author ? $author->display_name : 'Unknown',
+			'date'      => $post->post_date,
+			'post_type' => $post->post_type,
+		);
+	}
+
+	return array(
+		'posts' => $posts,
+		'total' => count( $posts ),
+	);
+}

--- a/includes/abilities/security-scan.php
+++ b/includes/abilities/security-scan.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Security Scan Ability
+ *
+ * Runs basic WordPress security checks.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the security-scan ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_security_scan(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/security-scan',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Security Scan', 'wp-agentic-admin' ),
+			'description'         => __( 'Run basic WordPress security checks.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'checks'   => array(
+						'type'        => 'array',
+						'description' => __( 'List of security check results.', 'wp-agentic-admin' ),
+					),
+					'summary'  => array(
+						'type'        => 'object',
+						'description' => __( 'Count by severity.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_security_scan',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'security', 'secure', 'scan', 'vulnerability', 'hardening', 'permissions' ),
+			'initialMessage' => __( "I'll run a basic security scan...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the security-scan ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_security_scan( array $input = array() ): array {
+	$checks = array();
+
+	// 1. Check WP_DEBUG in production.
+	$checks[] = array(
+		'check'    => 'Debug mode',
+		'status'   => defined( 'WP_DEBUG' ) && WP_DEBUG ? 'fail' : 'pass',
+		'severity' => 'warning',
+		'message'  => defined( 'WP_DEBUG' ) && WP_DEBUG
+			? 'WP_DEBUG is enabled. Disable in production.'
+			: 'WP_DEBUG is disabled.',
+	);
+
+	// 2. Check WP_DEBUG_DISPLAY.
+	$checks[] = array(
+		'check'    => 'Debug display',
+		'status'   => defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ? 'fail' : 'pass',
+		'severity' => 'critical',
+		'message'  => defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY
+			? 'WP_DEBUG_DISPLAY is on. Errors are visible to visitors.'
+			: 'WP_DEBUG_DISPLAY is off.',
+	);
+
+	// 3. Check wp-config.php file permissions.
+	$wp_config = ABSPATH . 'wp-config.php';
+	if ( file_exists( $wp_config ) ) {
+		$perms     = fileperms( $wp_config ) & 0777;
+		$is_secure = $perms <= 0640;
+		$checks[]  = array(
+			'check'    => 'wp-config.php permissions',
+			'status'   => $is_secure ? 'pass' : 'fail',
+			'severity' => 'critical',
+			'message'  => $is_secure
+				? sprintf( 'Permissions are %s (secure).', decoct( $perms ) )
+				: sprintf( 'Permissions are %s. Should be 640 or less.', decoct( $perms ) ),
+		);
+	}
+
+	// 4. Check for default auth salts.
+	$salt      = wp_salt( 'auth' );
+	$is_default = ( 'put your unique phrase here' === $salt );
+	$checks[]   = array(
+		'check'    => 'Authentication salts',
+		'status'   => $is_default ? 'fail' : 'pass',
+		'severity' => 'critical',
+		'message'  => $is_default
+			? 'Using default salts. Generate new ones immediately.'
+			: 'Custom salts are configured.',
+	);
+
+	// 5. Check WordPress version exposure.
+	$checks[] = array(
+		'check'    => 'Version in HTML',
+		'status'   => has_action( 'wp_head', 'wp_generator' ) ? 'fail' : 'pass',
+		'severity' => 'info',
+		'message'  => has_action( 'wp_head', 'wp_generator' )
+			? 'WordPress version is exposed in page source.'
+			: 'WordPress version is hidden.',
+	);
+
+	// 6. Check directory listing.
+	$uploads_dir  = wp_upload_dir();
+	$uploads_path = $uploads_dir['basedir'];
+	$htaccess     = $uploads_path . '/.htaccess';
+	$index_file   = $uploads_path . '/index.php';
+	$has_protect   = file_exists( $htaccess ) || file_exists( $index_file );
+	$checks[]      = array(
+		'check'    => 'Uploads directory listing',
+		'status'   => $has_protect ? 'pass' : 'fail',
+		'severity' => 'warning',
+		'message'  => $has_protect
+			? 'Uploads directory has listing protection.'
+			: 'Uploads directory may allow directory listing.',
+	);
+
+	// Summary by severity.
+	$summary = array(
+		'critical' => 0,
+		'warning'  => 0,
+		'info'     => 0,
+		'passed'   => 0,
+		'failed'   => 0,
+	);
+
+	foreach ( $checks as $check ) {
+		if ( 'fail' === $check['status'] ) {
+			++$summary['failed'];
+			++$summary[ $check['severity'] ];
+		} else {
+			++$summary['passed'];
+		}
+	}
+
+	return array(
+		'checks'  => $checks,
+		'summary' => $summary,
+	);
+}

--- a/includes/abilities/update-check.php
+++ b/includes/abilities/update-check.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Update Check Ability
+ *
+ * Checks for available WordPress core, plugin, and theme updates.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the update-check ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_update_check(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/update-check',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Check Updates', 'wp-agentic-admin' ),
+			'description'         => __( 'Check for available WordPress core, plugin, and theme updates.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'core'    => array(
+						'type'        => 'object',
+						'description' => __( 'Core update info.', 'wp-agentic-admin' ),
+					),
+					'plugins' => array(
+						'type'        => 'array',
+						'description' => __( 'Plugins with available updates.', 'wp-agentic-admin' ),
+					),
+					'themes'  => array(
+						'type'        => 'array',
+						'description' => __( 'Themes with available updates.', 'wp-agentic-admin' ),
+					),
+					'total'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Total number of available updates.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_update_check',
+			'permission_callback' => function () {
+				return current_user_can( 'update_core' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'update', 'updates', 'outdated', 'upgrade', 'version' ),
+			'initialMessage' => __( "I'll check for available updates...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the update-check ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_update_check( array $input = array() ): array {
+	// Ensure update functions are available.
+	if ( ! function_exists( 'get_core_updates' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+	}
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	// Core updates.
+	$core_updates = get_core_updates();
+	$core_info    = array(
+		'current'   => get_bloginfo( 'version' ),
+		'available' => false,
+		'new_version' => '',
+	);
+
+	if ( ! empty( $core_updates ) && 'upgrade' === $core_updates[0]->response ) {
+		$core_info['available']   = true;
+		$core_info['new_version'] = $core_updates[0]->version;
+	}
+
+	// Plugin updates.
+	$plugin_updates  = get_plugin_updates();
+	$plugins_needing = array();
+
+	foreach ( $plugin_updates as $file => $data ) {
+		$plugins_needing[] = array(
+			'name'        => $data->Name,
+			'slug'        => $file,
+			'current'     => $data->Version,
+			'new_version' => $data->update->new_version,
+		);
+	}
+
+	// Theme updates.
+	$theme_updates  = get_theme_updates();
+	$themes_needing = array();
+
+	foreach ( $theme_updates as $slug => $theme ) {
+		$themes_needing[] = array(
+			'name'        => $theme->get( 'Name' ),
+			'slug'        => $slug,
+			'current'     => $theme->get( 'Version' ),
+			'new_version' => $theme->update['new_version'],
+		);
+	}
+
+	$total = ( $core_info['available'] ? 1 : 0 ) + count( $plugins_needing ) + count( $themes_needing );
+
+	return array(
+		'core'    => $core_info,
+		'plugins' => $plugins_needing,
+		'themes'  => $themes_needing,
+		'total'   => $total,
+	);
+}

--- a/includes/abilities/user-list.php
+++ b/includes/abilities/user-list.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * User List Ability
+ *
+ * Lists all WordPress users with their roles.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the user-list ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_user_list(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/user-list',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'List Users', 'wp-agentic-admin' ),
+			'description'         => __( 'List all WordPress users with their roles and registration dates.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'users' => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'username'    => array( 'type' => 'string' ),
+								'display_name' => array( 'type' => 'string' ),
+								'email'       => array( 'type' => 'string' ),
+								'role'        => array( 'type' => 'string' ),
+								'registered'  => array( 'type' => 'string' ),
+							),
+						),
+						'description' => __( 'List of users.', 'wp-agentic-admin' ),
+					),
+					'total' => array(
+						'type'        => 'integer',
+						'description' => __( 'Total number of users.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_user_list',
+			'permission_callback' => function () {
+				return current_user_can( 'list_users' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'user', 'users', 'members', 'accounts', 'admins', 'authors' ),
+			'initialMessage' => __( "I'll check your WordPress users...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the user-list ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_user_list( array $input = array() ): array {
+	$wp_users = get_users( array( 'orderby' => 'registered', 'order' => 'DESC' ) );
+	$users    = array();
+
+	foreach ( $wp_users as $user ) {
+		$roles = $user->roles;
+		// Sanitize email — mask the local part for privacy.
+		$email_parts = explode( '@', $user->user_email );
+		$masked      = substr( $email_parts[0], 0, 2 ) . '***@' . ( $email_parts[1] ?? '' );
+
+		$users[] = array(
+			'username'     => $user->user_login,
+			'display_name' => $user->display_name,
+			'email'        => $masked,
+			'role'         => ! empty( $roles ) ? implode( ', ', $roles ) : 'none',
+			'registered'   => $user->user_registered,
+		);
+	}
+
+	return array(
+		'users' => $users,
+		'total' => count( $users ),
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -183,6 +183,10 @@ class Abilities {
 			wp_agentic_admin_register_comment_stats();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_opcode_cache_status' ) ) {
+			wp_agentic_admin_register_opcode_cache_status();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_update_check' ) ) {
+			wp_agentic_admin_register_update_check();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_security_scan' ) ) {
+			wp_agentic_admin_register_security_scan();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_comment_stats' ) ) {
+			wp_agentic_admin_register_comment_stats();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -163,6 +163,10 @@ class Abilities {
 			wp_agentic_admin_register_revision_cleanup();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_user_list' ) ) {
+			wp_agentic_admin_register_user_list();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -183,6 +183,10 @@ class Abilities {
 			wp_agentic_admin_register_comment_stats();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_error_log_search' ) ) {
+			wp_agentic_admin_register_error_log_search();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_disk_usage' ) ) {
+			wp_agentic_admin_register_disk_usage();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_post_list' ) ) {
+			wp_agentic_admin_register_post_list();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -183,6 +183,10 @@ class Abilities {
 			wp_agentic_admin_register_comment_stats();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_backup_check' ) ) {
+			wp_agentic_admin_register_backup_check();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -113,7 +113,7 @@ class Admin_Page {
 		wp_localize_script(
 			'wp-agentic-admin',
 			'wpAgenticAdmin',
-			$this->get_localized_data()
+			self::get_localized_data()
 		);
 
 		wp_enqueue_script( 'wp-agentic-admin' );
@@ -124,16 +124,18 @@ class Admin_Page {
 	 *
 	 * @return bool True if permalinks are properly configured.
 	 */
-	private function has_pretty_permalinks(): bool {
+	private static function has_pretty_permalinks(): bool {
 		return ! empty( get_option( 'permalink_structure' ) );
 	}
 
 	/**
 	 * Get data to pass to JavaScript.
 	 *
+	 * Shared between the admin page and editor sidebar.
+	 *
 	 * @return array
 	 */
-	private function get_localized_data(): array {
+	public static function get_localized_data(): array {
 		$settings = Settings::get_instance();
 
 		// Get JS configurations for registered abilities.
@@ -149,7 +151,7 @@ class Admin_Page {
 			'pluginUrl'           => esc_url( WP_AGENTIC_ADMIN_PLUGIN_URL ),
 			'swUrl'               => esc_url( WP_AGENTIC_ADMIN_PLUGIN_URL . 'sw-loader.php' ),
 			'version'             => WP_AGENTIC_ADMIN_VERSION,
-			'hasPrettyPermalinks' => $this->has_pretty_permalinks(),
+			'hasPrettyPermalinks' => self::has_pretty_permalinks(),
 			'permalinksUrl'       => esc_url( admin_url( 'options-permalink.php' ) ),
 			'settings'            => array(
 				'modelId'            => $settings->get_field( 'wp_agentic_admin_model_id', 'Qwen2.5-7B-Instruct-q4f16_1-MLC' ),

--- a/includes/class-editor-sidebar.php
+++ b/includes/class-editor-sidebar.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Editor Sidebar class
+ *
+ * Enqueues the AI chat sidebar plugin for the Gutenberg block editor.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+namespace WPAgenticAdmin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Editor Sidebar class.
+ *
+ * Registers and enqueues the editor plugin that provides
+ * an AI chat sidebar in the block editor.
+ *
+ * @since 0.9.6
+ */
+class Editor_Sidebar {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Editor_Sidebar|null
+	 */
+	private static ?Editor_Sidebar $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Editor_Sidebar
+	 */
+	public static function get_instance(): Editor_Sidebar {
+		if ( null === self::$instance ) {
+			self::$instance = new Editor_Sidebar();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the class.
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueue scripts and styles for the block editor sidebar.
+	 */
+	public function enqueue_scripts(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$asset_file = WP_AGENTIC_ADMIN_PLUGIN_DIR . 'build-extensions/editor.asset.php';
+
+		if ( ! file_exists( $asset_file ) ) {
+			return;
+		}
+
+		$asset = require $asset_file;
+		$deps  = isset( $asset['dependencies'] ) ? (array) $asset['dependencies'] : array( 'wp-plugins', 'wp-editor', 'wp-element' );
+		$ver   = isset( $asset['version'] ) ? $asset['version'] : WP_AGENTIC_ADMIN_VERSION;
+
+		// Enqueue WordPress components styles.
+		wp_enqueue_style( 'wp-components' );
+
+		// Enqueue editor sidebar styles.
+		$css_file = WP_AGENTIC_ADMIN_PLUGIN_DIR . 'build-extensions/editor.css';
+		if ( file_exists( $css_file ) ) {
+			wp_enqueue_style(
+				'wp-agentic-admin-editor-style',
+				WP_AGENTIC_ADMIN_PLUGIN_URL . 'build-extensions/editor.css',
+				array( 'wp-components' ),
+				filemtime( $css_file )
+			);
+		}
+
+		// Register and enqueue the editor script.
+		wp_register_script(
+			'wp-agentic-admin-editor',
+			WP_AGENTIC_ADMIN_PLUGIN_URL . 'build-extensions/editor.js',
+			$deps,
+			$ver,
+			true
+		);
+
+		// Localize with the same data as the admin page.
+		wp_localize_script(
+			'wp-agentic-admin-editor',
+			'wpAgenticAdmin',
+			Admin_Page::get_localized_data()
+		);
+
+		wp_enqueue_script( 'wp-agentic-admin-editor' );
+	}
+}

--- a/src/extensions/abilities/backup-check.js
+++ b/src/extensions/abilities/backup-check.js
@@ -1,0 +1,61 @@
+/**
+ * Backup Check Ability
+ *
+ * Checks backup plugin status and last backup time.
+ *
+ * @see includes/abilities/backup-check.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the backup-check ability with the chat system.
+ */
+export function registerBackupCheck() {
+	registerAbility( 'wp-agentic-admin/backup-check', {
+		label: 'Check backup plugin status',
+		description:
+			'Check if a backup plugin is installed and when the last backup ran. Use when users ask about backups or data safety.',
+
+		keywords: [ 'backup', 'backups', 'restore', 'recovery' ],
+
+		initialMessage: "I'll check your backup status...",
+
+		summarize: ( result ) => {
+			if ( ! result.has_backup_plugin ) {
+				return result.message || 'No backup plugin detected.';
+			}
+
+			const { detected } = result;
+			let summary = `**Backup plugin detected:** ${ result.plugin }\n`;
+			summary += `**Last backup:** ${ result.last_backup }\n`;
+
+			if ( detected && detected.length > 1 ) {
+				summary += `\n_${ detected.length } backup plugins found:_\n`;
+				detected.forEach( ( d ) => {
+					summary += `- ${ d.name } (last: ${ d.last_backup })\n`;
+				} );
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( ! result.has_backup_plugin ) {
+				return 'No backup plugin detected. The site has no automated backup solution.';
+			}
+			return `Backup plugin: ${ result.plugin }. Last backup: ${ result.last_backup }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/backup-check', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerBackupCheck;

--- a/src/extensions/abilities/comment-stats.js
+++ b/src/extensions/abilities/comment-stats.js
@@ -1,0 +1,52 @@
+/**
+ * Comment Stats Ability
+ *
+ * Shows comment counts by status.
+ *
+ * @see includes/abilities/comment-stats.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the comment-stats ability with the chat system.
+ */
+export function registerCommentStats() {
+	registerAbility( 'wp-agentic-admin/comment-stats', {
+		label: 'Show comment statistics',
+		description:
+			'Show comment counts by status including approved, pending, spam, and trash. Use for questions about comments or moderation.',
+
+		keywords: [ 'comment', 'comments', 'spam', 'pending', 'moderation' ],
+
+		initialMessage: "I'll check your comment statistics...",
+
+		summarize: ( result ) => {
+			const { total, approved, pending, spam, trash } = result;
+
+			let summary = `**Total comments:** ${ total }\n\n`;
+			summary += `- Approved: ${ approved }\n`;
+			summary += `- Pending: ${ pending }\n`;
+			summary += `- Spam: ${ spam }\n`;
+			summary += `- Trash: ${ trash }`;
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { total, approved, pending, spam, trash } = result;
+			return `${ total } total comments. ${ approved } approved, ${ pending } pending, ${ spam } spam, ${ trash } trash.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/comment-stats', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerCommentStats;

--- a/src/extensions/abilities/core-editor-blocks.js
+++ b/src/extensions/abilities/core-editor-blocks.js
@@ -1,0 +1,184 @@
+/**
+ * Core Editor Blocks Ability
+ *
+ * Lists all blocks on the current page in the block editor.
+ * JS-only ability (no PHP needed) — uses wp.data to query the editor store.
+ *
+ * ABILITY OVERVIEW:
+ * =================
+ * Provides a chat-friendly interface for querying the block editor contents.
+ * Only works on block editor screens where the core/block-editor store exists.
+ * Demonstrates:
+ * - JS-only ability (like core/get-site-info)
+ * - Accessing wp.data stores from the chat interface
+ * - Recursive block tree summarization
+ *
+ * READ-ONLY: This ability only reads data, no confirmation needed.
+ *
+ * @since 0.9.6
+ */
+
+import { registerAbility } from '../services/agentic-abilities-api';
+
+/**
+ * Recursively summarize a block tree for LLM consumption.
+ *
+ * @param {Array} blocks - Array of block objects from the editor store.
+ * @return {Array} Simplified block summaries.
+ */
+function summarizeBlocks( blocks ) {
+	return blocks.map( ( block ) => {
+		const summary = { name: block.name };
+
+		// Include text content when available (truncated)
+		if ( block.attributes?.content ) {
+			// Strip HTML tags for cleaner output
+			const text = block.attributes.content
+				.replace( /<[^>]*>/g, '' )
+				.substring( 0, 120 );
+			if ( text ) {
+				summary.content = text;
+			}
+		}
+
+		// Include heading level
+		if ( block.attributes?.level ) {
+			summary.level = block.attributes.level;
+		}
+
+		// Include image alt text or URL
+		if ( block.attributes?.alt ) {
+			summary.alt = block.attributes.alt;
+		}
+		if ( block.attributes?.url ) {
+			summary.url = block.attributes.url;
+		}
+
+		// Recurse into inner blocks
+		if ( block.innerBlocks?.length ) {
+			summary.innerBlocks = summarizeBlocks( block.innerBlocks );
+		}
+
+		return summary;
+	} );
+}
+
+/**
+ * Register the core/get-editor-blocks ability with the chat system.
+ */
+export function registerCoreEditorBlocks() {
+	registerAbility( 'core/get-editor-blocks', {
+		label: 'List editor blocks',
+		description:
+			'List all blocks on the current page in the block editor. Shows block types, content previews, and nesting structure.',
+
+		keywords: [
+			'blocks',
+			'editor blocks',
+			'page blocks',
+			'content blocks',
+			'what blocks',
+			'gutenberg',
+			'block list',
+			'page content',
+		],
+
+		initialMessage: 'Reading editor blocks...',
+
+		/**
+		 * Generate summary from the result.
+		 *
+		 * @param {Object} result - The ability result.
+		 * @return {string} Human-readable summary.
+		 */
+		summarize: ( result ) => {
+			if ( ! result?.success ) {
+				return result?.message || 'Unable to read editor blocks.';
+			}
+
+			if ( result.count === 0 ) {
+				return 'The editor is empty — no blocks found.';
+			}
+
+			const lines = [ `Found **${ result.count }** block(s):` ];
+
+			const formatBlock = ( block, indent = '' ) => {
+				let line = `${ indent }- **${ block.name }**`;
+				if ( block.level ) {
+					line += ` (H${ block.level })`;
+				}
+				if ( block.content ) {
+					line += `: "${ block.content }"`;
+				}
+				if ( block.alt ) {
+					line += ` [alt: ${ block.alt }]`;
+				}
+				lines.push( line );
+
+				if ( block.innerBlocks ) {
+					block.innerBlocks.forEach( ( inner ) =>
+						formatBlock( inner, indent + '  ' )
+					);
+				}
+			};
+
+			result.blocks.forEach( ( block ) => formatBlock( block ) );
+			return lines.join( '\n' );
+		},
+
+		/**
+		 * Plain-English interpretation of the result for the LLM.
+		 *
+		 * @param {Object} result - The ability result.
+		 * @return {string} Plain-English interpretation.
+		 */
+		interpretResult: ( result ) => {
+			if ( ! result?.success ) {
+				return result?.message || 'Unable to read editor blocks.';
+			}
+
+			if ( result.count === 0 ) {
+				return 'The editor is empty with no blocks.';
+			}
+
+			const blockNames = result.blocks.map( ( b ) => b.name );
+			const uniqueNames = [ ...new Set( blockNames ) ];
+			return `The editor has ${
+				result.count
+			} block(s) using these types: ${ uniqueNames.join( ', ' ) }.`;
+		},
+
+		/**
+		 * Execute the ability by reading the block editor store.
+		 *
+		 * @return {Object} Result with block data.
+		 */
+		execute: async () => {
+			// Check if wp.data and the block-editor store are available
+			if (
+				typeof wp === 'undefined' ||
+				! wp.data ||
+				! wp.data.select( 'core/block-editor' )
+			) {
+				return {
+					success: false,
+					message:
+						'Block editor is not available. This ability only works inside the Gutenberg editor.',
+				};
+			}
+
+			const blocks = wp.data.select( 'core/block-editor' ).getBlocks();
+			const summarized = summarizeBlocks( blocks );
+
+			return {
+				success: true,
+				blocks: summarized,
+				count: blocks.length,
+			};
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerCoreEditorBlocks;

--- a/src/extensions/abilities/disk-usage.js
+++ b/src/extensions/abilities/disk-usage.js
@@ -1,0 +1,60 @@
+/**
+ * Disk Usage Ability
+ *
+ * Checks wp-content disk usage breakdown.
+ *
+ * @see includes/abilities/disk-usage.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the disk-usage ability with the chat system.
+ */
+export function registerDiskUsage() {
+	registerAbility( 'wp-agentic-admin/disk-usage', {
+		label: 'Check wp-content disk usage',
+		description:
+			'Check disk usage for uploads, plugins, themes, and cache directories. Use when users ask about storage or disk space.',
+
+		keywords: [ 'disk', 'storage', 'space', 'size', 'usage' ],
+
+		initialMessage: "I'll check your disk usage...",
+
+		summarize: ( result ) => {
+			const { directories, total } = result;
+
+			let summary = `**Total wp-content size:** ${ total }\n\n`;
+
+			directories.forEach( ( dir ) => {
+				summary += `- **${ dir.name }:** ${ dir.size }\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { directories, total } = result;
+			if ( ! directories || directories.length === 0 ) {
+				return 'Could not determine disk usage.';
+			}
+			const parts = directories.map(
+				( d ) => `${ d.name }: ${ d.size }`
+			);
+			return `Total wp-content: ${ total }. Breakdown: ${ parts.join(
+				', '
+			) }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/disk-usage', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerDiskUsage;

--- a/src/extensions/abilities/error-log-search.js
+++ b/src/extensions/abilities/error-log-search.js
@@ -1,0 +1,140 @@
+/**
+ * Error Log Search Ability
+ *
+ * Filters debug.log by keyword and severity.
+ *
+ * @see includes/abilities/error-log-search.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the error-log-search ability with the chat system.
+ */
+export function registerErrorLogSearch() {
+	registerAbility( 'wp-agentic-admin/error-log-search', {
+		label: 'Search and filter error log',
+		description:
+			'Search debug.log by keyword or severity level (fatal, warning, notice, deprecated). Use when users want to filter or search error logs.',
+
+		keywords: [ 'search', 'filter', 'error', 'fatal', 'warning', 'log' ],
+
+		initialMessage: "I'll search the error log...",
+
+		parseIntent: ( message ) => {
+			const lower = message.toLowerCase();
+			const params = {};
+
+			// Detect severity level.
+			if ( lower.includes( 'fatal' ) ) {
+				params.level = 'fatal';
+			} else if ( lower.includes( 'warning' ) ) {
+				params.level = 'warning';
+			} else if ( lower.includes( 'notice' ) ) {
+				params.level = 'notice';
+			} else if ( lower.includes( 'deprecated' ) ) {
+				params.level = 'deprecated';
+			}
+
+			// Extract keyword — look for quoted strings or "for X" pattern.
+			const quoted = message.match( /['"]([^'"]+)['"]/ );
+			if ( quoted ) {
+				params.keyword = quoted[ 1 ];
+			} else {
+				const forMatch = lower.match(
+					/(?:search|filter|find|look)\s+(?:for|errors?)\s+(.+?)(?:\s+in|\s+error|$)/i
+				);
+				if ( forMatch ) {
+					params.keyword = forMatch[ 1 ].trim();
+				}
+			}
+
+			return params;
+		},
+
+		summarize: ( result ) => {
+			const { matches, total, scanned } = result;
+
+			if ( result.message ) {
+				return result.message;
+			}
+
+			if ( total === 0 ) {
+				return `No matches found in the last ${ scanned } log lines.`;
+			}
+
+			let summary = `Found **${ total }** matching entries (scanned ${ scanned } lines):\n\n`;
+			summary += '```\n';
+			matches.slice( -20 ).forEach( ( line ) => {
+				summary += line + '\n';
+			} );
+			summary += '```';
+
+			if ( total > 20 ) {
+				summary += `\n\n_Showing last 20 of ${ total } matches._`;
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( result.message ) {
+				return result.message;
+			}
+			const { matches, total, scanned } = result;
+			if ( ! matches || total === 0 ) {
+				return `No matches found in ${ scanned } log lines scanned.`;
+			}
+			// Include actual entries so the LLM can present them.
+			const shown = matches.slice( -10 );
+			let text = `Found ${ total } matching entries (scanned ${ scanned } lines):\n`;
+			shown.forEach( ( line ) => {
+				text += `${ line }\n`;
+			} );
+			if ( total > 10 ) {
+				text += `(${ total - 10 } more entries not shown)`;
+			}
+			return text;
+		},
+
+		execute: async ( params ) => {
+			// ReAct agent passes { userMessage, ...llmArgs }.
+			// Small LLMs often send empty args, so fall back to parseIntent.
+			let keyword = params.keyword;
+			let level = params.level;
+
+			if ( ! keyword && ! level && params.userMessage ) {
+				const lower = params.userMessage.toLowerCase();
+				if ( lower.includes( 'fatal' ) ) {
+					level = 'fatal';
+				} else if ( lower.includes( 'warning' ) ) {
+					level = 'warning';
+				} else if ( lower.includes( 'notice' ) ) {
+					level = 'notice';
+				} else if ( lower.includes( 'deprecated' ) ) {
+					level = 'deprecated';
+				}
+				const quoted = params.userMessage.match( /['"]([^'"]+)['"]/ );
+				if ( quoted ) {
+					keyword = quoted[ 1 ];
+				}
+			}
+
+			const input = {};
+			if ( keyword ) {
+				input.keyword = keyword;
+			}
+			if ( level ) {
+				input.level = level;
+			}
+			return executeAbility( 'wp-agentic-admin/error-log-search', input );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerErrorLogSearch;

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerCommentStats } from './comment-stats';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerCommentStats } from './comment-stats';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerCommentStats();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -27,6 +27,7 @@ import { registerUserList } from './user-list';
 import { registerUpdateCheck } from './update-check';
 import { registerDiskUsage } from './disk-usage';
 import { registerCommentStats } from './comment-stats';
+import { registerErrorLogSearch } from './error-log-search';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -48,6 +49,7 @@ export { registerUserList } from './user-list';
 export { registerUpdateCheck } from './update-check';
 export { registerDiskUsage } from './disk-usage';
 export { registerCommentStats } from './comment-stats';
+export { registerErrorLogSearch } from './error-log-search';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -78,6 +80,7 @@ export function registerAllAbilities() {
 	registerUpdateCheck();
 	registerDiskUsage();
 	registerCommentStats();
+	registerErrorLogSearch();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerSecurityScan } from './security-scan';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerSecurityScan } from './security-scan';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerSecurityScan();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -22,6 +22,7 @@ import { registerCronList } from './cron-list';
 import { registerRewriteFlush } from './rewrite-flush';
 import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
+import { registerUserList } from './user-list';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -38,6 +39,7 @@ export { registerCronList } from './cron-list';
 export { registerRewriteFlush } from './rewrite-flush';
 export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
+export { registerUserList } from './user-list';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -63,6 +65,7 @@ export function registerAllAbilities() {
 	registerRewriteFlush();
 	registerRewriteList();
 	registerRevisionCleanup();
+	registerUserList();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -27,6 +27,7 @@ import { registerUserList } from './user-list';
 import { registerUpdateCheck } from './update-check';
 import { registerDiskUsage } from './disk-usage';
 import { registerCommentStats } from './comment-stats';
+import { registerOpcodeCacheStatus } from './opcode-cache-status';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -48,6 +49,7 @@ export { registerUserList } from './user-list';
 export { registerUpdateCheck } from './update-check';
 export { registerDiskUsage } from './disk-usage';
 export { registerCommentStats } from './comment-stats';
+export { registerOpcodeCacheStatus } from './opcode-cache-status';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -78,6 +80,7 @@ export function registerAllAbilities() {
 	registerUpdateCheck();
 	registerDiskUsage();
 	registerCommentStats();
+	registerOpcodeCacheStatus();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerUpdateCheck } from './update-check';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerUpdateCheck } from './update-check';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerUpdateCheck();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -27,6 +27,7 @@ import { registerUserList } from './user-list';
 import { registerUpdateCheck } from './update-check';
 import { registerDiskUsage } from './disk-usage';
 import { registerCommentStats } from './comment-stats';
+import { registerBackupCheck } from './backup-check';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -48,6 +49,7 @@ export { registerUserList } from './user-list';
 export { registerUpdateCheck } from './update-check';
 export { registerDiskUsage } from './disk-usage';
 export { registerCommentStats } from './comment-stats';
+export { registerBackupCheck } from './backup-check';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -78,6 +80,7 @@ export function registerAllAbilities() {
 	registerUpdateCheck();
 	registerDiskUsage();
 	registerCommentStats();
+	registerBackupCheck();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerDiskUsage } from './disk-usage';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerDiskUsage } from './disk-usage';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerDiskUsage();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -25,6 +25,7 @@ import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
+import { registerCoreEditorBlocks } from './core-editor-blocks';
 
 // Re-export individual functions for external use
 export { registerErrorLogRead } from './error-log-read';
@@ -42,6 +43,7 @@ export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
+export { registerCoreEditorBlocks } from './core-editor-blocks';
 
 /**
  * Register all abilities.
@@ -72,6 +74,7 @@ export function registerAllAbilities() {
 	// Note: core/get-user-info is not included as it has show_in_rest=false
 	registerCoreSiteInfo();
 	registerCoreEnvironmentInfo();
+	registerCoreEditorBlocks();
 
 	log.info( 'All abilities registered (including WordPress core wrappers)' );
 }

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerPostList } from './post-list';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerPostList } from './post-list';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerPostList();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/opcode-cache-status.js
+++ b/src/extensions/abilities/opcode-cache-status.js
@@ -1,0 +1,57 @@
+/**
+ * OPcache Status Ability
+ *
+ * Checks OPcache status and configuration.
+ *
+ * @see includes/abilities/opcode-cache-status.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the opcode-cache-status ability with the chat system.
+ */
+export function registerOpcodeCacheStatus() {
+	registerAbility( 'wp-agentic-admin/opcode-cache-status', {
+		label: 'Check OPcache status',
+		description:
+			'Check OPcache status including memory usage, hit rate, and cached scripts count. Use when users ask about opcache or PHP performance.',
+
+		keywords: [ 'opcache', 'opcode', 'cache', 'php', 'performance' ],
+
+		initialMessage: "I'll check your OPcache status...",
+
+		summarize: ( result ) => {
+			if ( ! result.enabled ) {
+				return result.message || 'OPcache is not enabled.';
+			}
+
+			const { memory, statistics } = result;
+			let summary = '**OPcache is enabled**\n\n';
+			summary += `**Memory:** ${ memory.used } / ${ memory.total } (${ memory.percentage }% used)\n`;
+			summary += `**Cached scripts:** ${ statistics.cached_scripts }\n`;
+			summary += `**Hit rate:** ${ statistics.hit_rate }\n`;
+			summary += `**Hits:** ${ statistics.hits } | **Misses:** ${ statistics.misses }`;
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( ! result.enabled ) {
+				return result.message || 'OPcache is not enabled.';
+			}
+			return `OPcache enabled. ${ result.memory.percentage }% memory used. ${ result.statistics.cached_scripts } scripts cached. Hit rate: ${ result.statistics.hit_rate }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/opcode-cache-status', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerOpcodeCacheStatus;

--- a/src/extensions/abilities/post-list.js
+++ b/src/extensions/abilities/post-list.js
@@ -1,0 +1,103 @@
+/**
+ * Post List Ability
+ *
+ * Lists recent WordPress posts.
+ *
+ * @see includes/abilities/post-list.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the post-list ability with the chat system.
+ */
+export function registerPostList() {
+	registerAbility( 'wp-agentic-admin/post-list', {
+		label: 'List recent WordPress posts',
+		description:
+			'List recent WordPress posts with title, status, author, and date. Supports filtering by status and post type. Use for questions about posts or content.',
+
+		keywords: [
+			'post',
+			'posts',
+			'articles',
+			'content',
+			'drafts',
+			'published',
+		],
+
+		initialMessage: "I'll fetch your recent posts...",
+
+		parseIntent: ( message ) => {
+			const lower = message.toLowerCase();
+			const params = {};
+
+			// Detect status filter.
+			if ( lower.includes( 'draft' ) ) {
+				params.status = 'draft';
+			} else if ( lower.includes( 'publish' ) ) {
+				params.status = 'publish';
+			} else if ( lower.includes( 'pending' ) ) {
+				params.status = 'pending';
+			} else if ( lower.includes( 'trash' ) ) {
+				params.status = 'trash';
+			}
+
+			// Detect post type.
+			if ( lower.includes( 'page' ) ) {
+				params.post_type = 'page';
+			}
+
+			return params;
+		},
+
+		summarize: ( result ) => {
+			const { posts, total } = result;
+
+			if ( total === 0 ) {
+				return 'No posts found matching your criteria.';
+			}
+
+			let summary = `Found **${ total }** post${
+				total !== 1 ? 's' : ''
+			}:\n\n`;
+
+			posts.forEach( ( p ) => {
+				summary += `- **${ p.title }** — ${ p.status } by ${
+					p.author
+				} (${ p.date.split( ' ' )[ 0 ] })\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { posts, total } = result;
+			if ( total === 0 ) {
+				return 'No posts found.';
+			}
+			const titles = posts.map(
+				( p ) => `"${ p.title }" (${ p.status })`
+			);
+			return `Found ${ total } posts: ${ titles.join( ', ' ) }.`;
+		},
+
+		execute: async ( params ) => {
+			const input = {};
+			if ( params.status ) {
+				input.status = params.status;
+			}
+			if ( params.post_type ) {
+				input.post_type = params.post_type;
+			}
+			return executeAbility( 'wp-agentic-admin/post-list', input );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerPostList;

--- a/src/extensions/abilities/security-scan.js
+++ b/src/extensions/abilities/security-scan.js
@@ -1,0 +1,101 @@
+/**
+ * Security Scan Ability
+ *
+ * Runs basic WordPress security checks.
+ *
+ * @see includes/abilities/security-scan.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the security-scan ability with the chat system.
+ */
+export function registerSecurityScan() {
+	registerAbility( 'wp-agentic-admin/security-scan', {
+		label: 'Run basic security scan',
+		description:
+			'Run basic WordPress security checks including debug mode, file permissions, salts, and version exposure. Use for security audits.',
+
+		keywords: [
+			'security',
+			'secure',
+			'scan',
+			'vulnerability',
+			'hardening',
+			'permissions',
+		],
+
+		initialMessage: "I'll run a basic security scan...",
+
+		summarize: ( result ) => {
+			const { checks, summary } = result;
+
+			let text = `**Security Scan Results:** ${ summary.passed } passed, ${ summary.failed } failed\n\n`;
+
+			const failed = checks.filter( ( c ) => c.status === 'fail' );
+			const passed = checks.filter( ( c ) => c.status === 'pass' );
+
+			// Group failures by severity.
+			const severities = [ 'critical', 'warning', 'info' ];
+			severities.forEach( ( sev ) => {
+				const items = failed.filter( ( c ) => c.severity === sev );
+				if ( items.length === 0 ) {
+					return;
+				}
+				const label = sev.charAt( 0 ).toUpperCase() + sev.slice( 1 );
+				text += `**${ label }:**\n`;
+				items.forEach( ( c ) => {
+					text += `- ${ c.check }: ${ c.message }\n`;
+				} );
+				text += '\n';
+			} );
+
+			if ( passed.length > 0 ) {
+				text += '**Passed:**\n';
+				passed.forEach( ( c ) => {
+					text += `- ${ c.check }: ${ c.message }\n`;
+				} );
+			}
+
+			return text;
+		},
+
+		interpretResult: ( result ) => {
+			const { checks, summary } = result;
+			if ( summary.failed === 0 ) {
+				return 'All security checks passed. No issues found.';
+			}
+			const parts = [];
+			if ( summary.critical > 0 ) {
+				parts.push( `${ summary.critical } critical` );
+			}
+			if ( summary.warning > 0 ) {
+				parts.push( `${ summary.warning } warning(s)` );
+			}
+			if ( summary.info > 0 ) {
+				parts.push( `${ summary.info } info` );
+			}
+			let text = `${ summary.failed } security issues: ${ parts.join(
+				', '
+			) }. `;
+			checks
+				.filter( ( c ) => c.status === 'fail' )
+				.forEach( ( c ) => {
+					text += `${ c.check } (${ c.severity }): ${ c.message } `;
+				} );
+			return text.trim();
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/security-scan', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerSecurityScan;

--- a/src/extensions/abilities/update-check.js
+++ b/src/extensions/abilities/update-check.js
@@ -1,0 +1,86 @@
+/**
+ * Update Check Ability
+ *
+ * Checks for available WordPress core, plugin, and theme updates.
+ *
+ * @see includes/abilities/update-check.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the update-check ability with the chat system.
+ */
+export function registerUpdateCheck() {
+	registerAbility( 'wp-agentic-admin/update-check', {
+		label: 'Check for available updates',
+		description:
+			'Check for available WordPress core, plugin, and theme updates. Use when users ask about outdated software or available upgrades.',
+
+		keywords: [ 'update', 'updates', 'outdated', 'upgrade', 'version' ],
+
+		initialMessage: "I'll check for available updates...",
+
+		summarize: ( result ) => {
+			const { core, plugins, themes, total } = result;
+
+			if ( total === 0 ) {
+				return 'Everything is up to date! No updates available for core, plugins, or themes.';
+			}
+
+			let summary = `Found **${ total } update${
+				total !== 1 ? 's' : ''
+			}** available.\n\n`;
+
+			if ( core.available ) {
+				summary += `**WordPress core:** ${ core.current } → ${ core.new_version }\n\n`;
+			}
+
+			if ( plugins.length > 0 ) {
+				summary += `**Plugins (${ plugins.length }):**\n`;
+				plugins.forEach( ( p ) => {
+					summary += `- ${ p.name }: ${ p.current } → ${ p.new_version }\n`;
+				} );
+				summary += '\n';
+			}
+
+			if ( themes.length > 0 ) {
+				summary += `**Themes (${ themes.length }):**\n`;
+				themes.forEach( ( t ) => {
+					summary += `- ${ t.name }: ${ t.current } → ${ t.new_version }\n`;
+				} );
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { core, plugins, themes, total } = result;
+			if ( total === 0 ) {
+				return 'All software is up to date. No updates available.';
+			}
+			let text = `${ total } updates available.`;
+			if ( core.available ) {
+				text += ` Core: ${ core.current } to ${ core.new_version }.`;
+			}
+			if ( plugins.length > 0 ) {
+				text += ` ${ plugins.length } plugin updates.`;
+			}
+			if ( themes.length > 0 ) {
+				text += ` ${ themes.length } theme updates.`;
+			}
+			return text;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/update-check', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerUpdateCheck;

--- a/src/extensions/abilities/user-list.js
+++ b/src/extensions/abilities/user-list.js
@@ -1,0 +1,78 @@
+/**
+ * User List Ability
+ *
+ * Lists all WordPress users with their roles.
+ *
+ * @see includes/abilities/user-list.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the user-list ability with the chat system.
+ */
+export function registerUserList() {
+	registerAbility( 'wp-agentic-admin/user-list', {
+		label: 'List WordPress users',
+		description:
+			'List all WordPress users with their roles, registration dates, and masked emails. Use for questions about site users or user counts.',
+
+		keywords: [
+			'user',
+			'users',
+			'members',
+			'accounts',
+			'admins',
+			'authors',
+		],
+
+		initialMessage: "I'll check your WordPress users...",
+
+		summarize: ( result ) => {
+			const { users, total } = result;
+
+			const byRole = {};
+			users.forEach( ( u ) => {
+				const role = u.role || 'none';
+				byRole[ role ] = ( byRole[ role ] || 0 ) + 1;
+			} );
+
+			let summary = `I found ${ total } user${
+				total !== 1 ? 's' : ''
+			} on your site.\n\n`;
+
+			const roleList = Object.entries( byRole )
+				.map( ( [ role, count ] ) => `${ role }: ${ count }` )
+				.join( ', ' );
+			summary += `**By role:** ${ roleList }\n\n`;
+
+			users.forEach( ( u ) => {
+				summary += `- **${ u.display_name }** (${ u.username }) — ${ u.role }\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { users, total } = result;
+			if ( ! users || users.length === 0 ) {
+				return 'No users found on this site.';
+			}
+			const names = users.map(
+				( u ) => `${ u.display_name } (${ u.role })`
+			);
+			return `Found ${ total } users: ${ names.join( ', ' ) }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/user-list', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerUserList;

--- a/src/extensions/components/EditorSidebar.jsx
+++ b/src/extensions/components/EditorSidebar.jsx
@@ -1,0 +1,115 @@
+/**
+ * Editor Sidebar Component
+ *
+ * Simplified version of App.jsx for the block editor PluginSidebar.
+ * No TabPanel, no AbilityBrowser, no permalink check, no beforeunload warning.
+ * Renders ModelStatus (compact) + ChatContainer within the sidebar.
+ */
+
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import ChatContainer from './ChatContainer';
+import ModelStatus from './ModelStatus';
+import WebGPUFallback from './WebGPUFallback';
+import modelLoader from '../services/model-loader';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger( 'EditorSidebar' );
+
+const EditorSidebar = () => {
+	const [ modelReady, setModelReady ] = useState( false );
+	const [ webGPUError, setWebGPUError ] = useState( null );
+	const [ isExecuting, setIsExecuting ] = useState( false );
+	const [ initPhase, setInitPhase ] = useState( 'checking' );
+	const [ initMessage, setInitMessage ] = useState(
+		'Checking WebGPU support...'
+	);
+	const [ initProgress, setInitProgress ] = useState( 5 );
+
+	/**
+	 * Background WebGPU check and auto-load cached model on mount
+	 */
+	useEffect( () => {
+		const initializeApp = async () => {
+			try {
+				setInitMessage( 'Checking WebGPU support...' );
+				setInitProgress( 10 );
+				const result = await modelLoader.checkWebGPUSupport();
+				if ( ! result.supported ) {
+					setWebGPUError( result.reason );
+					setInitPhase( null );
+					return;
+				}
+
+				setInitMessage( 'Checking model status...' );
+				setInitProgress( 20 );
+				if ( modelLoader.isModelReady() ) {
+					setModelReady( true );
+					setInitPhase( null );
+					return;
+				}
+
+				setInitMessage( 'Checking cache...' );
+				setInitProgress( 30 );
+				const isCached = await modelLoader.isModelCached();
+
+				if ( isCached ) {
+					log.info( 'Model is cached, auto-loading...' );
+					setInitPhase( 'loading' );
+					setInitMessage( 'Loading from cache...' );
+					setInitProgress( 35 );
+					try {
+						await modelLoader.load();
+						setModelReady( true );
+					} catch ( loadErr ) {
+						log.error( 'Auto-load failed:', loadErr );
+					}
+				}
+				setInitPhase( null );
+			} catch ( err ) {
+				log.error( 'Initialization failed:', err );
+				setInitPhase( null );
+			}
+		};
+
+		initializeApp();
+	}, [] );
+
+	const handleModelReady = useCallback( () => {
+		setModelReady( true );
+		setWebGPUError( null );
+	}, [] );
+
+	const handleModelError = useCallback( ( errorMessage ) => {
+		setModelReady( false );
+		if (
+			errorMessage.includes( 'WebGPU' ) ||
+			errorMessage.includes( 'GPU' )
+		) {
+			setWebGPUError( errorMessage );
+		}
+	}, [] );
+
+	return (
+		<div className="wp-agentic-admin-sidebar">
+			<ModelStatus
+				onModelReady={ handleModelReady }
+				onModelError={ handleModelError }
+				initPhase={ initPhase }
+				initMessage={ initMessage }
+				initProgress={ initProgress }
+			/>
+
+			{ webGPUError && ! modelReady ? (
+				<WebGPUFallback reason={ webGPUError } />
+			) : (
+				<ChatContainer
+					modelReady={ modelReady }
+					isLoading={ isExecuting }
+					setIsLoading={ setIsExecuting }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default EditorSidebar;

--- a/src/extensions/editor.js
+++ b/src/extensions/editor.js
@@ -1,0 +1,27 @@
+/**
+ * WP Agentic Admin - Block Editor Plugin Entry Point
+ *
+ * Registers a PluginSidebar in the Gutenberg block editor,
+ * providing AI chat functionality while editing content.
+ * Shares the WebLLM instance via the existing Service Worker.
+ *
+ * @version 0.9.5
+ */
+
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginSidebar } from '@wordpress/editor';
+import EditorSidebar from './components/EditorSidebar';
+import './styles/editor-sidebar.scss';
+
+registerPlugin( 'wp-agentic-admin', {
+	icon: 'superhero-alt',
+	render: () => (
+		<PluginSidebar
+			name="wp-agentic-admin-chat"
+			title="AI Assistant"
+			icon="superhero-alt"
+		>
+			<EditorSidebar />
+		</PluginSidebar>
+	),
+} );

--- a/src/extensions/styles/editor-sidebar.scss
+++ b/src/extensions/styles/editor-sidebar.scss
@@ -1,0 +1,226 @@
+/* stylelint-disable no-descending-specificity, no-duplicate-selectors */
+
+/**
+ * WP Agentic Admin - Editor Sidebar Styles
+ *
+ * Imports base styles and adds overrides for the narrow
+ * PluginSidebar panel (~280px width).
+ *
+ * @package WPAgenticAdmin
+ */
+
+@import './main.scss';
+
+// Wider sidebar panel (~30% more than default 280px)
+.interface-complementary-area {
+	width: 364px;
+}
+
+// Editor sidebar wrapper — scopes all overrides
+.wp-agentic-admin-sidebar {
+	display: flex;
+	flex-direction: column;
+	height: calc(100vh - 100px);
+	overflow: hidden;
+
+	// Override admin app styles that assume full-width page
+	.wp-agentic-admin-app {
+		max-width: 100%;
+		margin: 0;
+		min-height: auto;
+		flex: 1;
+	}
+
+	// Chat container fills remaining space
+	.wp-agentic-admin-chat-container {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	// Chat chrome
+	.wp-agentic-admin-chat {
+		border: none;
+		border-radius: 0;
+		box-shadow: none;
+	}
+
+	// Messages area — compact padding
+	.wp-agentic-admin-messages {
+		min-height: 150px;
+		padding: 12px;
+
+		// Full-width messages in narrow sidebar
+		.agentic-message--user {
+			padding-left: 20px;
+
+			.agentic-message__bubble {
+				max-width: 95%;
+			}
+		}
+
+		// Compact system/welcome message
+		.agentic-message--system {
+			padding: 12px !important;
+			margin-bottom: 16px !important;
+
+			.agentic-message__content {
+
+				h3 {
+					font-size: 15px !important;
+				}
+
+				p,
+				li {
+					font-size: 13px;
+				}
+
+				ul {
+					margin: 8px 0 8px 16px !important;
+				}
+			}
+		}
+
+		// Compact timeline
+		.agentic-timeline {
+			width: 22px;
+		}
+	}
+
+	// Input area — fixed at bottom, never scrolls
+	.wp-agentic-admin-input-area {
+		padding: 10px;
+		flex-shrink: 0;
+		border-top: 1px solid #c3c4c7;
+
+		.wp-agentic-admin-input {
+			min-height: 44px;
+			font-size: 13px;
+			padding: 8px 10px;
+		}
+	}
+
+	// Stop generation bar — also fixed at bottom
+	.wp-agentic-admin-chat-actions {
+		flex-shrink: 0;
+	}
+
+	// Chat header — compact
+	.wp-agentic-admin-chat-header {
+		padding: 6px 10px;
+
+		&__actions {
+			gap: 4px;
+
+			.components-button {
+				font-size: 12px;
+				padding: 4px 8px;
+			}
+		}
+	}
+
+	// Model Status — compact for sidebar
+	.wp-agentic-admin-model-status {
+		margin: 0;
+		padding: 10px;
+		border-radius: 0;
+		border-left: 0;
+		border-right: 0;
+		border-top: 0;
+
+		.wp-agentic-admin-status {
+			flex-wrap: wrap;
+		}
+
+		.wp-agentic-admin-status__controls {
+			flex-direction: column;
+			gap: 6px;
+			width: 100%;
+			margin-left: 0;
+		}
+
+		.wp-agentic-admin-model-select {
+			max-width: 100%;
+			width: 100%;
+		}
+
+		.button {
+			margin-left: 0;
+			width: 100%;
+			justify-content: center;
+		}
+	}
+
+	// Loading card — compact
+	.wp-agentic-admin-loading-card {
+		padding: 12px;
+		border-radius: 0;
+
+		&__icon {
+			font-size: 22px;
+		}
+
+		&__percent {
+			font-size: 18px;
+		}
+
+		&__title {
+			font-size: 14px !important;
+		}
+
+		&__subtitle {
+			font-size: 12px;
+		}
+
+		&__description {
+			font-size: 12px;
+		}
+	}
+
+	// Model info notice — compact
+	.wp-agentic-admin-model-info {
+		margin: 8px 0 0;
+		padding: 8px 10px;
+		font-size: 12px;
+	}
+
+	// Context warning — compact
+	.wp-agentic-admin-context-warning {
+		padding: 0 8px;
+	}
+
+	// Confirmation modal — narrower in sidebar context
+	.wp-agentic-admin-confirm-modal {
+
+		.wp-agentic-admin-confirm-actions {
+			padding: 12px 16px;
+			gap: 6px;
+		}
+	}
+
+	// WebGPU fallback — compact
+	.wp-agentic-admin-webgpu-fallback {
+		padding: 12px;
+
+		.wp-agentic-admin-browser-instructions {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	// Workflow progress — compact
+	.agentic-message--workflow {
+		padding: 10px 12px;
+	}
+
+	// Snackbar positioning for sidebar
+	.components-snackbar {
+		position: fixed !important;
+		top: 60px !important;
+		right: 20px !important;
+		left: auto !important;
+		bottom: auto !important;
+		z-index: 1000000 !important;
+	}
+}

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -117,6 +117,16 @@ module.exports = {
 			expectTool: 'core/get-environment-info',
 		},
 
+		// ── Editor blocks ─────────────────────────────────────────
+		{
+			input: 'what blocks are on this page?',
+			expectTool: 'core/get-editor-blocks',
+		},
+		{
+			input: 'list the blocks in the editor',
+			expectTool: 'core/get-editor-blocks',
+		},
+
 		// ── No-tool tests (pure knowledge questions) ───────────────
 		{
 			input: 'what is a transient in WordPress?',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -76,6 +76,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/disk-usage',
 		},
 
+		// ── OPcache status ────────────────────────────────────────
+		{
+			input: 'what is the opcache status?',
+			expectTool: 'wp-agentic-admin/opcode-cache-status',
+		},
+		{
+			input: 'is PHP opcode caching enabled?',
+			expectTool: 'wp-agentic-admin/opcode-cache-status',
+		},
+
 		// ── Comment stats ─────────────────────────────────────────
 		{
 			input: 'how many comments does my site have?',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Update management ─────────────────────────────────────
+		{
+			input: 'are there any updates available?',
+			expectTool: 'wp-agentic-admin/update-check',
+		},
+		{
+			input: 'check for outdated plugins',
+			expectTool: 'wp-agentic-admin/update-check',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Security ──────────────────────────────────────────────
+		{
+			input: 'run a security scan on my site',
+			expectTool: 'wp-agentic-admin/security-scan',
+		},
+		{
+			input: 'check for security vulnerabilities',
+			expectTool: 'wp-agentic-admin/security-scan',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Comment stats ─────────────────────────────────────────
+		{
+			input: 'how many comments does my site have?',
+			expectTool: 'wp-agentic-admin/comment-stats',
+		},
+		{
+			input: 'show me the spam comment count',
+			expectTool: 'wp-agentic-admin/comment-stats',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -66,6 +66,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/update-check',
 		},
 
+		// ── Error log search ──────────────────────────────────────
+		{
+			input: 'search the error log for fatal errors',
+			expectTool: 'wp-agentic-admin/error-log-search',
+		},
+		{
+			input: 'filter the log for database warnings',
+			expectTool: 'wp-agentic-admin/error-log-search',
+		},
+
 		// ── Disk usage ────────────────────────────────────────────
 		{
 			input: 'how much disk space is my site using?',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -32,6 +32,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/plugin-deactivate',
 		},
 
+		// ── User management ───────────────────────────────────────
+		{
+			input: 'list all users on this site',
+			expectTool: 'wp-agentic-admin/user-list',
+		},
+		{
+			input: 'show me the admin users',
+			expectTool: 'wp-agentic-admin/user-list',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Disk usage ────────────────────────────────────────────
+		{
+			input: 'how much disk space is my site using?',
+			expectTool: 'wp-agentic-admin/disk-usage',
+		},
+		{
+			input: 'check storage usage',
+			expectTool: 'wp-agentic-admin/disk-usage',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Post management ───────────────────────────────────────
+		{
+			input: 'list my recent posts',
+			expectTool: 'wp-agentic-admin/post-list',
+		},
+		{
+			input: 'show me all draft posts',
+			expectTool: 'wp-agentic-admin/post-list',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -86,6 +86,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/comment-stats',
 		},
 
+		// ── Backup check ──────────────────────────────────────────
+		{
+			input: 'do I have a backup plugin installed?',
+			expectTool: 'wp-agentic-admin/backup-check',
+		},
+		{
+			input: 'check my backup status',
+			expectTool: 'wp-agentic-admin/backup-check',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,9 @@ module.exports = {
 		// Main application bundle
 		index: path.resolve( __dirname, 'src/extensions/index.js' ),
 
+		// Block editor sidebar plugin
+		editor: path.resolve( __dirname, 'src/extensions/editor.js' ),
+
 		// Service Worker - needs to be a self-contained bundle
 		sw: {
 			import: path.resolve( __dirname, 'src/extensions/sw.js' ),

--- a/wp-agentic-admin.php
+++ b/wp-agentic-admin.php
@@ -72,6 +72,7 @@ if ( ! class_exists( 'WPAgenticAdmin' ) ) {
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-utils.php';
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-settings.php';
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-admin-page.php';
+			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-editor-sidebar.php';
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-abilities.php';
 
 			// Initialize Utility Hooks (Cache Invalidation).
@@ -85,6 +86,10 @@ if ( ! class_exists( 'WPAgenticAdmin' ) ) {
 
 			if ( class_exists( '\\WPAgenticAdmin\\Admin_Page' ) ) {
 				\WPAgenticAdmin\Admin_Page::get_instance();
+			}
+
+			if ( class_exists( '\\WPAgenticAdmin\\Editor_Sidebar' ) ) {
+				\WPAgenticAdmin\Editor_Sidebar::get_instance();
 			}
 
 			if ( class_exists( '\\WPAgenticAdmin\\Abilities' ) ) {


### PR DESCRIPTION
## What does this PR do?

Adds an AI chat sidebar to the Gutenberg block editor via PluginSidebar, reusing the existing WebLLM instance through the Service Worker. Also adds a core/get-editor-blocks ability that lets users ask "what blocks are on this page?" while editing.

## Type

- [x] New ability
- [ ] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

  1. Run npm run build and activate the plugin on a WordPress 6.9+ site                                                                             
  2. Go to Posts → Add New Post (or edit any existing post)
  3. In the top-right toolbar, click the superhero icon to open the AI Assistant sidebar                                                            
  4. Verify the sidebar is ~30% wider than a standard WP sidebar                                                                                    
  5. Verify the chat input stays fixed at the bottom while messages scroll                                                                          
  6. If the model was previously loaded on the admin page, it should auto-connect via the Service Worker                                            
  7. If not, click Load Model in the compact ModelStatus at the top of the sidebar                                                                  
  8. Type "what blocks are on this page?" — should return a list of blocks in the editor                                                            
  9. Type "list plugins" — existing abilities work from the editor sidebar too                                                                      
  10. Navigate back to WP Agentic Admin settings page — verify the main chat UI still works normally  

## Screenshots (if UI changes)

<img width="2098" height="1950" alt="CleanShot 2026-03-20 at 15 09 15@2x" src="https://github.com/user-attachments/assets/df284d81-6438-409a-888a-8dfb8767acb2" />
