### PR TITLE
Add security-scan ability

### DIFF
--- a/includes/abilities/security-scan.php
+++ b/includes/abilities/security-scan.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Security Scan Ability
+ *
+ * Runs basic WordPress security checks.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the security-scan ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_security_scan(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/security-scan',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Security Scan', 'wp-agentic-admin' ),
+			'description'         => __( 'Run basic WordPress security checks.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'checks'   => array(
+						'type'        => 'array',
+						'description' => __( 'List of security check results.', 'wp-agentic-admin' ),
+					),
+					'summary'  => array(
+						'type'        => 'object',
+						'description' => __( 'Count by severity.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_security_scan',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'security', 'secure', 'scan', 'vulnerability', 'hardening', 'permissions' ),
+			'initialMessage' => __( "I'll run a basic security scan...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the security-scan ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_security_scan( array $input = array() ): array {
+	$checks = array();
+
+	// 1. Check WP_DEBUG in production.
+	$checks[] = array(
+		'check'    => 'Debug mode',
+		'status'   => defined( 'WP_DEBUG' ) && WP_DEBUG ? 'fail' : 'pass',
+		'severity' => 'warning',
+		'message'  => defined( 'WP_DEBUG' ) && WP_DEBUG
+			? 'WP_DEBUG is enabled. Disable in production.'
+			: 'WP_DEBUG is disabled.',
+	);
+
+	// 2. Check WP_DEBUG_DISPLAY.
+	$checks[] = array(
+		'check'    => 'Debug display',
+		'status'   => defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ? 'fail' : 'pass',
+		'severity' => 'critical',
+		'message'  => defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY
+			? 'WP_DEBUG_DISPLAY is on. Errors are visible to visitors.'
+			: 'WP_DEBUG_DISPLAY is off.',
+	);
+
+	// 3. Check wp-config.php file permissions.
+	$wp_config = ABSPATH . 'wp-config.php';
+	if ( file_exists( $wp_config ) ) {
+		$perms     = fileperms( $wp_config ) & 0777;
+		$is_secure = $perms <= 0640;
+		$checks[]  = array(
+			'check'    => 'wp-config.php permissions',
+			'status'   => $is_secure ? 'pass' : 'fail',
+			'severity' => 'critical',
+			'message'  => $is_secure
+				? sprintf( 'Permissions are %s (secure).', decoct( $perms ) )
+				: sprintf( 'Permissions are %s. Should be 640 or less.', decoct( $perms ) ),
+		);
+	}
+
+	// 4. Check for default auth salts.
+	$salt      = wp_salt( 'auth' );
+	$is_default = ( 'put your unique phrase here' === $salt );
+	$checks[]   = array(
+		'check'    => 'Authentication salts',
+		'status'   => $is_default ? 'fail' : 'pass',
+		'severity' => 'critical',
+		'message'  => $is_default
+			? 'Using default salts. Generate new ones immediately.'
+			: 'Custom salts are configured.',
+	);
+
+	// 5. Check WordPress version exposure.
+	$checks[] = array(
+		'check'    => 'Version in HTML',
+		'status'   => has_action( 'wp_head', 'wp_generator' ) ? 'fail' : 'pass',
+		'severity' => 'info',
+		'message'  => has_action( 'wp_head', 'wp_generator' )
+			? 'WordPress version is exposed in page source.'
+			: 'WordPress version is hidden.',
+	);
+
+	// 6. Check directory listing.
+	$uploads_dir  = wp_upload_dir();
+	$uploads_path = $uploads_dir['basedir'];
+	$htaccess     = $uploads_path . '/.htaccess';
+	$index_file   = $uploads_path . '/index.php';
+	$has_protect   = file_exists( $htaccess ) || file_exists( $index_file );
+	$checks[]      = array(
+		'check'    => 'Uploads directory listing',
+		'status'   => $has_protect ? 'pass' : 'fail',
+		'severity' => 'warning',
+		'message'  => $has_protect
+			? 'Uploads directory has listing protection.'
+			: 'Uploads directory may allow directory listing.',
+	);
+
+	// Summary by severity.
+	$summary = array(
+		'critical' => 0,
+		'warning'  => 0,
+		'info'     => 0,
+		'passed'   => 0,
+		'failed'   => 0,
+	);
+
+	foreach ( $checks as $check ) {
+		if ( 'fail' === $check['status'] ) {
+			++$summary['failed'];
+			++$summary[ $check['severity'] ];
+		} else {
+			++$summary['passed'];
+		}
+	}
+
+	return array(
+		'checks'  => $checks,
+		'summary' => $summary,
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_security_scan' ) ) {
+			wp_agentic_admin_register_security_scan();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerSecurityScan } from './security-scan';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerSecurityScan } from './security-scan';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerSecurityScan();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/security-scan.js
+++ b/src/extensions/abilities/security-scan.js
@@ -1,0 +1,101 @@
+/**
+ * Security Scan Ability
+ *
+ * Runs basic WordPress security checks.
+ *
+ * @see includes/abilities/security-scan.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the security-scan ability with the chat system.
+ */
+export function registerSecurityScan() {
+	registerAbility( 'wp-agentic-admin/security-scan', {
+		label: 'Run basic security scan',
+		description:
+			'Run basic WordPress security checks including debug mode, file permissions, salts, and version exposure. Use for security audits.',
+
+		keywords: [
+			'security',
+			'secure',
+			'scan',
+			'vulnerability',
+			'hardening',
+			'permissions',
+		],
+
+		initialMessage: "I'll run a basic security scan...",
+
+		summarize: ( result ) => {
+			const { checks, summary } = result;
+
+			let text = `**Security Scan Results:** ${ summary.passed } passed, ${ summary.failed } failed\n\n`;
+
+			const failed = checks.filter( ( c ) => c.status === 'fail' );
+			const passed = checks.filter( ( c ) => c.status === 'pass' );
+
+			// Group failures by severity.
+			const severities = [ 'critical', 'warning', 'info' ];
+			severities.forEach( ( sev ) => {
+				const items = failed.filter( ( c ) => c.severity === sev );
+				if ( items.length === 0 ) {
+					return;
+				}
+				const label = sev.charAt( 0 ).toUpperCase() + sev.slice( 1 );
+				text += `**${ label }:**\n`;
+				items.forEach( ( c ) => {
+					text += `- ${ c.check }: ${ c.message }\n`;
+				} );
+				text += '\n';
+			} );
+
+			if ( passed.length > 0 ) {
+				text += '**Passed:**\n';
+				passed.forEach( ( c ) => {
+					text += `- ${ c.check }: ${ c.message }\n`;
+				} );
+			}
+
+			return text;
+		},
+
+		interpretResult: ( result ) => {
+			const { checks, summary } = result;
+			if ( summary.failed === 0 ) {
+				return 'All security checks passed. No issues found.';
+			}
+			const parts = [];
+			if ( summary.critical > 0 ) {
+				parts.push( `${ summary.critical } critical` );
+			}
+			if ( summary.warning > 0 ) {
+				parts.push( `${ summary.warning } warning(s)` );
+			}
+			if ( summary.info > 0 ) {
+				parts.push( `${ summary.info } info` );
+			}
+			let text = `${ summary.failed } security issues: ${ parts.join(
+				', '
+			) }. `;
+			checks
+				.filter( ( c ) => c.status === 'fail' )
+				.forEach( ( c ) => {
+					text += `${ c.check } (${ c.severity }): ${ c.message } `;
+				} );
+			return text.trim();
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/security-scan', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerSecurityScan;

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Security ──────────────────────────────────────────────
+		{
+			input: 'run a security scan on my site',
+			expectTool: 'wp-agentic-admin/security-scan',
+		},
+		{
+			input: 'check for security vulnerabilities',
+			expectTool: 'wp-agentic-admin/security-scan',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add security-scan ability to run basic WordPress security checks (#9)
- Checks: WP_DEBUG, WP_DEBUG_DISPLAY, wp-config permissions, auth salts, version exposure, directory listing
- Results grouped by severity (critical/warning/info) with passed checks listed separately

## Changes
- `includes/abilities/security-scan.php` — PHP backend with 6 security checks and severity levels
- `src/extensions/abilities/security-scan.js` — JS frontend with severity-grouped summarize output
- `includes/class-abilities.php` — Register security-scan in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for security-related queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)