### PR TITLE
Add post-list ability

### DIFF
--- a/includes/abilities/post-list.php
+++ b/includes/abilities/post-list.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Post List Ability
+ *
+ * Lists recent WordPress posts.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the post-list ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_post_list(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/post-list',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'List Posts', 'wp-agentic-admin' ),
+			'description'         => __( 'List recent WordPress posts with their status.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(
+					'status'    => 'any',
+					'post_type' => 'post',
+					'count'     => 10,
+				),
+				'properties'           => array(
+					'status'    => array(
+						'type'        => 'string',
+						'default'     => 'any',
+						'description' => __( 'Post status filter.', 'wp-agentic-admin' ),
+					),
+					'post_type' => array(
+						'type'        => 'string',
+						'default'     => 'post',
+						'description' => __( 'Post type filter.', 'wp-agentic-admin' ),
+					),
+					'count'     => array(
+						'type'        => 'integer',
+						'default'     => 10,
+						'description' => __( 'Number of posts to return.', 'wp-agentic-admin' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'posts' => array(
+						'type'        => 'array',
+						'description' => __( 'List of posts.', 'wp-agentic-admin' ),
+					),
+					'total' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of posts returned.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_post_list',
+			'permission_callback' => function () {
+				return current_user_can( 'edit_posts' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'post', 'posts', 'articles', 'content', 'drafts', 'published' ),
+			'initialMessage' => __( "I'll fetch your recent posts...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the post-list ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_post_list( array $input = array() ): array {
+	$status    = isset( $input['status'] ) ? sanitize_text_field( $input['status'] ) : 'any';
+	$post_type = isset( $input['post_type'] ) ? sanitize_text_field( $input['post_type'] ) : 'post';
+	$count     = isset( $input['count'] ) ? min( absint( $input['count'] ), 50 ) : 10;
+
+	$wp_posts = get_posts(
+		array(
+			'post_type'      => $post_type,
+			'post_status'    => $status,
+			'posts_per_page' => $count,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		)
+	);
+
+	$posts = array();
+
+	foreach ( $wp_posts as $post ) {
+		$author  = get_userdata( $post->post_author );
+		$posts[] = array(
+			'id'        => $post->ID,
+			'title'     => $post->post_title,
+			'status'    => $post->post_status,
+			'author'    => $author ? $author->display_name : 'Unknown',
+			'date'      => $post->post_date,
+			'post_type' => $post->post_type,
+		);
+	}
+
+	return array(
+		'posts' => $posts,
+		'total' => count( $posts ),
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -171,6 +171,10 @@ class Abilities {
 			wp_agentic_admin_register_user_list();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_post_list' ) ) {
+			wp_agentic_admin_register_post_list();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -24,6 +24,7 @@ import { registerRewriteList } from './rewrite-list';
 import { registerRevisionCleanup } from './revision-cleanup';
 import { registerThemeList } from './theme-list';
 import { registerUserList } from './user-list';
+import { registerPostList } from './post-list';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -42,6 +43,7 @@ export { registerRewriteList } from './rewrite-list';
 export { registerRevisionCleanup } from './revision-cleanup';
 export { registerThemeList } from './theme-list';
 export { registerUserList } from './user-list';
+export { registerPostList } from './post-list';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -69,6 +71,7 @@ export function registerAllAbilities() {
 	registerRevisionCleanup();
 	registerThemeList();
 	registerUserList();
+	registerPostList();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/post-list.js
+++ b/src/extensions/abilities/post-list.js
@@ -1,0 +1,103 @@
+/**
+ * Post List Ability
+ *
+ * Lists recent WordPress posts.
+ *
+ * @see includes/abilities/post-list.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the post-list ability with the chat system.
+ */
+export function registerPostList() {
+	registerAbility( 'wp-agentic-admin/post-list', {
+		label: 'List recent WordPress posts',
+		description:
+			'List recent WordPress posts with title, status, author, and date. Supports filtering by status and post type. Use for questions about posts or content.',
+
+		keywords: [
+			'post',
+			'posts',
+			'articles',
+			'content',
+			'drafts',
+			'published',
+		],
+
+		initialMessage: "I'll fetch your recent posts...",
+
+		parseIntent: ( message ) => {
+			const lower = message.toLowerCase();
+			const params = {};
+
+			// Detect status filter.
+			if ( lower.includes( 'draft' ) ) {
+				params.status = 'draft';
+			} else if ( lower.includes( 'publish' ) ) {
+				params.status = 'publish';
+			} else if ( lower.includes( 'pending' ) ) {
+				params.status = 'pending';
+			} else if ( lower.includes( 'trash' ) ) {
+				params.status = 'trash';
+			}
+
+			// Detect post type.
+			if ( lower.includes( 'page' ) ) {
+				params.post_type = 'page';
+			}
+
+			return params;
+		},
+
+		summarize: ( result ) => {
+			const { posts, total } = result;
+
+			if ( total === 0 ) {
+				return 'No posts found matching your criteria.';
+			}
+
+			let summary = `Found **${ total }** post${
+				total !== 1 ? 's' : ''
+			}:\n\n`;
+
+			posts.forEach( ( p ) => {
+				summary += `- **${ p.title }** — ${ p.status } by ${
+					p.author
+				} (${ p.date.split( ' ' )[ 0 ] })\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			const { posts, total } = result;
+			if ( total === 0 ) {
+				return 'No posts found.';
+			}
+			const titles = posts.map(
+				( p ) => `"${ p.title }" (${ p.status })`
+			);
+			return `Found ${ total } posts: ${ titles.join( ', ' ) }.`;
+		},
+
+		execute: async ( params ) => {
+			const input = {};
+			if ( params.status ) {
+				input.status = params.status;
+			}
+			if ( params.post_type ) {
+				input.post_type = params.post_type;
+			}
+			return executeAbility( 'wp-agentic-admin/post-list', input );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerPostList;

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -56,6 +56,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/user-list',
 		},
 
+		// ── Post management ───────────────────────────────────────
+		{
+			input: 'list my recent posts',
+			expectTool: 'wp-agentic-admin/post-list',
+		},
+		{
+			input: 'show me all draft posts',
+			expectTool: 'wp-agentic-admin/post-list',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add post-list ability to list WordPress posts with optional filters (#10)
- Supports status (draft/publish/pending/trash) and post type (post/page) filtering
- Includes `parseIntent` for natural language extraction of filters from user messages

## Changes
- `includes/abilities/post-list.php` — PHP backend using `get_posts()` with status/type/count params
- `src/extensions/abilities/post-list.js` — JS frontend with parseIntent, summarize, interpretResult
- `includes/class-abilities.php` — Register post-list in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for post-related queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)