### PR TITLE
Add error-log-search ability

### DIFF
--- a/includes/abilities/error-log-search.php
+++ b/includes/abilities/error-log-search.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Error Log Search Ability
+ *
+ * Filters debug.log by keyword and severity.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the error-log-search ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_error_log_search(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/error-log-search',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Search Error Log', 'wp-agentic-admin' ),
+			'description'         => __( 'Filter debug.log by keyword and severity level.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(
+					'keyword' => '',
+					'level'   => '',
+					'lines'   => 100,
+				),
+				'properties'           => array(
+					'keyword' => array(
+						'type'        => 'string',
+						'default'     => '',
+						'description' => __( 'Search keyword.', 'wp-agentic-admin' ),
+					),
+					'level'   => array(
+						'type'        => 'string',
+						'default'     => '',
+						'enum'        => array( '', 'fatal', 'warning', 'notice', 'deprecated' ),
+						'description' => __( 'Error severity level filter.', 'wp-agentic-admin' ),
+					),
+					'lines'   => array(
+						'type'        => 'integer',
+						'default'     => 100,
+						'description' => __( 'Number of log lines to scan.', 'wp-agentic-admin' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'matches' => array(
+						'type'        => 'array',
+						'description' => __( 'Matching log lines.', 'wp-agentic-admin' ),
+					),
+					'total'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of matches.', 'wp-agentic-admin' ),
+					),
+					'scanned' => array(
+						'type'        => 'integer',
+						'description' => __( 'Lines scanned.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_error_log_search',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'search', 'filter', 'error', 'fatal', 'warning', 'log' ),
+			'initialMessage' => __( "I'll search the error log...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the error-log-search ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_error_log_search( array $input = array() ): array {
+	$keyword   = isset( $input['keyword'] ) ? sanitize_text_field( $input['keyword'] ) : '';
+	$level     = isset( $input['level'] ) ? sanitize_text_field( $input['level'] ) : '';
+	$max_lines = isset( $input['lines'] ) ? min( absint( $input['lines'] ), 500 ) : 100;
+
+	$log_file = \WPAgenticAdmin\Utils::get_debug_log_path();
+
+	if ( ! file_exists( $log_file ) || ! is_readable( $log_file ) ) {
+		return array(
+			'matches' => array(),
+			'total'   => 0,
+			'scanned' => 0,
+			'message' => 'debug.log not found or not readable.',
+		);
+	}
+
+	// Read last N lines.
+	$lines   = file( $log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+	$lines   = array_slice( $lines, -$max_lines );
+	$scanned = count( $lines );
+
+	// Level mapping to PHP error prefixes.
+	$level_map = array(
+		'fatal'      => array( 'Fatal error', 'PHP Fatal' ),
+		'warning'    => array( 'Warning', 'PHP Warning' ),
+		'notice'     => array( 'Notice', 'PHP Notice' ),
+		'deprecated' => array( 'Deprecated', 'PHP Deprecated' ),
+	);
+
+	$matches = array();
+
+	foreach ( $lines as $line ) {
+		$match = true;
+
+		// Keyword filter.
+		if ( '' !== $keyword && false === stripos( $line, $keyword ) ) {
+			$match = false;
+		}
+
+		// Level filter.
+		if ( $match && '' !== $level && isset( $level_map[ $level ] ) ) {
+			$level_match = false;
+			foreach ( $level_map[ $level ] as $prefix ) {
+				if ( false !== stripos( $line, $prefix ) ) {
+					$level_match = true;
+					break;
+				}
+			}
+			if ( ! $level_match ) {
+				$match = false;
+			}
+		}
+
+		if ( $match ) {
+			$matches[] = $line;
+		}
+	}
+
+	// Limit output.
+	$matches = array_slice( $matches, -50 );
+
+	return array(
+		'matches' => $matches,
+		'total'   => count( $matches ),
+		'scanned' => $scanned,
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -183,6 +183,10 @@ class Abilities {
 			wp_agentic_admin_register_comment_stats();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_error_log_search' ) ) {
+			wp_agentic_admin_register_error_log_search();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/error-log-search.js
+++ b/src/extensions/abilities/error-log-search.js
@@ -1,0 +1,140 @@
+/**
+ * Error Log Search Ability
+ *
+ * Filters debug.log by keyword and severity.
+ *
+ * @see includes/abilities/error-log-search.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the error-log-search ability with the chat system.
+ */
+export function registerErrorLogSearch() {
+	registerAbility( 'wp-agentic-admin/error-log-search', {
+		label: 'Search and filter error log',
+		description:
+			'Search debug.log by keyword or severity level (fatal, warning, notice, deprecated). Use when users want to filter or search error logs.',
+
+		keywords: [ 'search', 'filter', 'error', 'fatal', 'warning', 'log' ],
+
+		initialMessage: "I'll search the error log...",
+
+		parseIntent: ( message ) => {
+			const lower = message.toLowerCase();
+			const params = {};
+
+			// Detect severity level.
+			if ( lower.includes( 'fatal' ) ) {
+				params.level = 'fatal';
+			} else if ( lower.includes( 'warning' ) ) {
+				params.level = 'warning';
+			} else if ( lower.includes( 'notice' ) ) {
+				params.level = 'notice';
+			} else if ( lower.includes( 'deprecated' ) ) {
+				params.level = 'deprecated';
+			}
+
+			// Extract keyword — look for quoted strings or "for X" pattern.
+			const quoted = message.match( /['"]([^'"]+)['"]/ );
+			if ( quoted ) {
+				params.keyword = quoted[ 1 ];
+			} else {
+				const forMatch = lower.match(
+					/(?:search|filter|find|look)\s+(?:for|errors?)\s+(.+?)(?:\s+in|\s+error|$)/i
+				);
+				if ( forMatch ) {
+					params.keyword = forMatch[ 1 ].trim();
+				}
+			}
+
+			return params;
+		},
+
+		summarize: ( result ) => {
+			const { matches, total, scanned } = result;
+
+			if ( result.message ) {
+				return result.message;
+			}
+
+			if ( total === 0 ) {
+				return `No matches found in the last ${ scanned } log lines.`;
+			}
+
+			let summary = `Found **${ total }** matching entries (scanned ${ scanned } lines):\n\n`;
+			summary += '```\n';
+			matches.slice( -20 ).forEach( ( line ) => {
+				summary += line + '\n';
+			} );
+			summary += '```';
+
+			if ( total > 20 ) {
+				summary += `\n\n_Showing last 20 of ${ total } matches._`;
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( result.message ) {
+				return result.message;
+			}
+			const { matches, total, scanned } = result;
+			if ( ! matches || total === 0 ) {
+				return `No matches found in ${ scanned } log lines scanned.`;
+			}
+			// Include actual entries so the LLM can present them.
+			const shown = matches.slice( -10 );
+			let text = `Found ${ total } matching entries (scanned ${ scanned } lines):\n`;
+			shown.forEach( ( line ) => {
+				text += `${ line }\n`;
+			} );
+			if ( total > 10 ) {
+				text += `(${ total - 10 } more entries not shown)`;
+			}
+			return text;
+		},
+
+		execute: async ( params ) => {
+			// ReAct agent passes { userMessage, ...llmArgs }.
+			// Small LLMs often send empty args, so fall back to parseIntent.
+			let keyword = params.keyword;
+			let level = params.level;
+
+			if ( ! keyword && ! level && params.userMessage ) {
+				const lower = params.userMessage.toLowerCase();
+				if ( lower.includes( 'fatal' ) ) {
+					level = 'fatal';
+				} else if ( lower.includes( 'warning' ) ) {
+					level = 'warning';
+				} else if ( lower.includes( 'notice' ) ) {
+					level = 'notice';
+				} else if ( lower.includes( 'deprecated' ) ) {
+					level = 'deprecated';
+				}
+				const quoted = params.userMessage.match( /['"]([^'"]+)['"]/ );
+				if ( quoted ) {
+					keyword = quoted[ 1 ];
+				}
+			}
+
+			const input = {};
+			if ( keyword ) {
+				input.keyword = keyword;
+			}
+			if ( level ) {
+				input.level = level;
+			}
+			return executeAbility( 'wp-agentic-admin/error-log-search', input );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerErrorLogSearch;

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -27,6 +27,7 @@ import { registerUserList } from './user-list';
 import { registerUpdateCheck } from './update-check';
 import { registerDiskUsage } from './disk-usage';
 import { registerCommentStats } from './comment-stats';
+import { registerErrorLogSearch } from './error-log-search';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -48,6 +49,7 @@ export { registerUserList } from './user-list';
 export { registerUpdateCheck } from './update-check';
 export { registerDiskUsage } from './disk-usage';
 export { registerCommentStats } from './comment-stats';
+export { registerErrorLogSearch } from './error-log-search';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -78,6 +80,7 @@ export function registerAllAbilities() {
 	registerUpdateCheck();
 	registerDiskUsage();
 	registerCommentStats();
+	registerErrorLogSearch();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -66,6 +66,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/update-check',
 		},
 
+		// ── Error log search ──────────────────────────────────────
+		{
+			input: 'search the error log for fatal errors',
+			expectTool: 'wp-agentic-admin/error-log-search',
+		},
+		{
+			input: 'filter the log for database warnings',
+			expectTool: 'wp-agentic-admin/error-log-search',
+		},
+
 		// ── Disk usage ────────────────────────────────────────────
 		{
 			input: 'how much disk space is my site using?',


### PR DESCRIPTION
## Summary
- Add error-log-search ability to search and filter WordPress debug.log (#11)
- Supports keyword and severity (fatal/warning/notice/deprecated) filtering
- Uses `Utils::get_debug_log_path()` for correct log file resolution
- `execute` extracts level/keyword from `userMessage` when LLM sends empty args
- `interpretResult` includes actual log entries so the LLM can present them

## Changes
- `includes/abilities/error-log-search.php` — PHP backend with keyword + severity filtering
- `src/extensions/abilities/error-log-search.js` — JS frontend with parseIntent, userMessage fallback, content-rich interpretResult
- `includes/class-abilities.php` — Register error-log-search in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for log search queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [x] Manually tested in browser — fatal error filtering works in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)