### PR TITLE
fix: implement dropdown menu for model unload action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@mlc-ai/web-llm": "^0.2.82",
+        "@wordpress/icons": "^12.0.0",
         "fastest-levenshtein": "^1.0.16"
       },
       "devDependencies": {
@@ -5203,7 +5204,6 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -5224,7 +5224,6 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5235,7 +5234,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -6488,15 +6486,14 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.41.0.tgz",
-      "integrity": "sha512-1rM2MhP2epOfsqOz2spOaGmCU/ZtwHdLEF5GkCNEih+Mt2v+oM1xWbSNvt8RoP7Fz7DepBfaDpl6rkVYZgAwkQ==",
-      "dev": true,
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.42.0.tgz",
+      "integrity": "sha512-aSuifJL9MF0xrAynWSWxIuhgagJcVwSWrqIpLwX0DZasQ0LKsJe08SmuDe/z3sgOymGG6cOd/GHv0fLwQe8VFQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.41.0",
+        "@wordpress/escape-html": "^3.42.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -6511,17 +6508,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.41.0.tgz",
-      "integrity": "sha512-xkif63w2OwcOZiJ+YKOmbuUnXAH0PM7YExA6UdQwxDGunED8L/4BY9f0nTEnDN9wFiUCYnqF4MIvMnWEnPwzUA==",
-      "dev": true,
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.42.0.tgz",
+      "integrity": "sha512-dykrMeKAxhwfEImrXfTqKREYGJP2qVIU8q3daUNyNLzrOdwhulAlBzUWXH9zYyY5qEQWrWsnjq4M9f77dO0p4w==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6589,6 +6584,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@wordpress/icons": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.0.0.tgz",
+      "integrity": "sha512-bDYsBGb1Ig/HWMt7aNrFWeABrD2wbReMazn9cZxUnXTf9ZFFrmG8PEdwmmJErDiEH9MvvAzLxadcNylWNNgeZA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.42.0",
+        "@wordpress/primitives": "^4.42.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/jest-console": {
@@ -6673,6 +6686,23 @@
       },
       "peerDependencies": {
         "prettier": ">=3"
+      }
+    },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.42.0.tgz",
+      "integrity": "sha512-kXqtXZcLNfMR3EiGm5XBilsDIf5+hmiQ+xPpJjYqcN7HHcyeE5+TwIzeuSdO2i8RnKnRYKV7yhj6EmmZr6ldYQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.42.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/private-apis": {
@@ -8181,7 +8211,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -8271,7 +8300,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -8300,7 +8328,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
@@ -8505,6 +8532,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -8697,7 +8733,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -9212,7 +9247,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cwd": {
@@ -9809,7 +9843,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -12534,7 +12567,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
@@ -14695,7 +14727,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -15304,7 +15335,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -15317,7 +15347,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -16093,7 +16122,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -16850,7 +16878,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -16945,7 +16972,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -16956,7 +16982,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -18319,7 +18344,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -18332,7 +18356,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19060,7 +19083,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19213,7 +19235,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -19619,7 +19640,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -21342,7 +21362,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -21686,7 +21705,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -21696,7 +21714,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@mlc-ai/web-llm": "^0.2.82",
+    "@wordpress/icons": "^12.0.0",
     "fastest-levenshtein": "^1.0.16"
   },
   "keywords": [

--- a/src/extensions/components/ModelStatus.jsx
+++ b/src/extensions/components/ModelStatus.jsx
@@ -6,7 +6,14 @@
  */
 
 import { useState, useEffect, useCallback } from '@wordpress/element';
-import { Button, Spinner } from '@wordpress/components';
+import {
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	Spinner,
+} from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 import modelLoader, {
 	ModelLoader,
 	DEFAULT_MODEL,
@@ -273,30 +280,6 @@ const ModelStatus = ( {
 		}
 	};
 
-	/**
-	 * Get button text based on status
-	 */
-	const getButtonText = () => {
-		switch ( status ) {
-			case 'error':
-				return 'Retry';
-			case 'ready':
-				return 'Unload Model';
-			default:
-				return 'Load Model';
-		}
-	};
-
-	/**
-	 * Get button click handler
-	 */
-	const getButtonHandler = () => {
-		if ( status === 'ready' ) {
-			return handleUnloadModel;
-		}
-		return handleLoadModel;
-	};
-
 	// Get current loading stage info - use init values during init phase, otherwise use model loader values
 	const isInInitPhase = initPhase === 'checking';
 	const displayProgress = isInInitPhase ? initProgress : progress;
@@ -427,49 +410,61 @@ const ModelStatus = ( {
 
 					{ status === 'checking' && <Spinner /> }
 
-					{ ( status === 'not-loaded' ||
-						status === 'error' ||
-						status === 'ready' ) && (
-						<div className="wp-agentic-admin-status__controls">
-							{ status !== 'ready' && (
-								<select
-									className="wp-agentic-admin-model-select"
-									value={ selectedModel }
-									onChange={ ( e ) => {
-										const modelId = e.target.value;
-										setSelectedModel( modelId );
-										saveModel( modelId );
-									} }
-									disabled={
-										status === 'loading' ||
-										status === 'checking'
-									}
-								>
-									{ availableModels.map( ( model ) => (
-										<option
-											key={ model.id }
-											value={ model.id }
-										>
-											{ model.name } ({ model.size })
-											{ model.recommended
-												? ' - Recommended'
-												: '' }
-										</option>
-									) ) }
-								</select>
+					{ status === 'ready' && (
+						<DropdownMenu
+							icon={ moreVertical }
+							label="Model options"
+							className="wp-agentic-admin-status__kebab-menu"
+						>
+							{ ( { onClose } ) => (
+								<MenuGroup>
+									<MenuItem
+										onClick={ () => {
+											handleUnloadModel();
+											onClose();
+										} }
+									>
+										Unload model
+									</MenuItem>
+								</MenuGroup>
 							) }
-							<Button
-								variant={
-									status === 'ready' ? 'secondary' : 'primary'
+						</DropdownMenu>
+					) }
+
+					{ ( status === 'not-loaded' || status === 'error' ) && (
+						<div className="wp-agentic-admin-status__controls">
+							<select
+								className="wp-agentic-admin-model-select"
+								value={ selectedModel }
+								onChange={ ( e ) => {
+									const modelId = e.target.value;
+									setSelectedModel( modelId );
+									saveModel( modelId );
+								} }
+								disabled={
+									status === 'loading' ||
+									status === 'checking'
 								}
-								onClick={ getButtonHandler() }
+							>
+								{ availableModels.map( ( model ) => (
+									<option key={ model.id } value={ model.id }>
+										{ model.name } ({ model.size })
+										{ model.recommended
+											? ' - Recommended'
+											: '' }
+									</option>
+								) ) }
+							</select>
+							<Button
+								variant="primary"
+								onClick={ handleLoadModel }
 								disabled={
 									status === 'loading' ||
 									status === 'checking'
 								}
 								className="wp-agentic-admin-load-model"
 							>
-								{ getButtonText() }
+								{ status === 'error' ? 'Retry' : 'Load Model' }
 							</Button>
 						</div>
 					) }

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -957,6 +957,27 @@
 		margin-left: auto;
 	}
 
+	.wp-agentic-admin-status__kebab-menu {
+		margin-left: auto;
+		flex-shrink: 0;
+
+		.components-button {
+			color: #646970;
+			min-width: 36px;
+			height: 36px;
+			padding: 0;
+
+			&:hover {
+				color: #1d2327;
+			}
+
+			&:focus {
+				box-shadow: none;
+				outline: 1px dotted #646970;
+			}
+		}
+	}
+
 	.wp-agentic-admin-model-select {
 		padding: 4px 8px;
 		border: 1px solid #8c8f94;


### PR DESCRIPTION
## What does this PR do?

Moves the "Unload Model" action from a prominent inline button into a subtle kebab menu (⋯) on the model status bar, reducing visual confusion with primary actions like sending a prompt.

**Rebased onto `dev`** to integrate with the external LLM provider UI (PR #86).

## Type

- [ ] New ability
- [ ] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

1. Load a model (local or remote) — verify the "Load Model" / "Connect" button and model select dropdown work as before
2. Once model is ready, confirm a subtle ⋯ icon appears at the right edge of the status bar (instead of "Unload Model" button)
3. Click ⋯ — verify a dropdown menu appears with "Unload model" as a menu item
4. Click "Unload model" — verify the model unloads and the UI returns to the not-loaded state with provider toggle + controls
5. Trigger an error state — verify "Retry" button still appears inline

## Note

Branch rebased from `fix/unload-button-ui` → `fix/unload-button-ui-rebased` to resolve conflicts with the external LLM provider feature. Original author: @Stefan0x