### PR TITLE
Add backup-check ability

### DIFF
--- a/includes/abilities/backup-check.php
+++ b/includes/abilities/backup-check.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Backup Check Ability
+ *
+ * Checks backup plugin status and last backup time.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the backup-check ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_backup_check(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/backup-check',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Check Backup Status', 'wp-agentic-admin' ),
+			'description'         => __( 'Check backup plugin status and last backup time.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'has_backup_plugin' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether a backup plugin is detected.', 'wp-agentic-admin' ),
+					),
+					'plugin'            => array(
+						'type'        => 'string',
+						'description' => __( 'Detected backup plugin name.', 'wp-agentic-admin' ),
+					),
+					'last_backup'       => array(
+						'type'        => 'string',
+						'description' => __( 'Last backup date if available.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_backup_check',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'backup', 'backups', 'restore', 'recovery' ),
+			'initialMessage' => __( "I'll check your backup status...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the backup-check ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_backup_check( array $input = array() ): array {
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	// Known backup plugins.
+	$backup_plugins = array(
+		array(
+			'slug' => 'updraftplus/updraftplus.php',
+			'name' => 'UpdraftPlus',
+		),
+		array(
+			'slug' => 'backwpup/backwpup.php',
+			'name' => 'BackWPup',
+		),
+		array(
+			'slug' => 'jetpack/jetpack.php',
+			'name' => 'Jetpack (VaultPress)',
+		),
+		array(
+			'slug' => 'blogvault-real-time-backup/developer_developer.php',
+			'name' => 'BlogVault',
+		),
+		array(
+			'slug' => 'duplicator/duplicator.php',
+			'name' => 'Duplicator',
+		),
+		array(
+			'slug' => 'all-in-one-wp-migration/all-in-one-wp-migration.php',
+			'name' => 'All-in-One WP Migration',
+		),
+	);
+
+	$detected = array();
+
+	foreach ( $backup_plugins as $plugin ) {
+		if ( is_plugin_active( $plugin['slug'] ) ) {
+			$info = array(
+				'name'        => $plugin['name'],
+				'active'      => true,
+				'last_backup' => wp_agentic_admin_get_last_backup_time( $plugin['slug'] ),
+			);
+
+			$detected[] = $info;
+		}
+	}
+
+	if ( empty( $detected ) ) {
+		return array(
+			'has_backup_plugin' => false,
+			'plugin'            => '',
+			'last_backup'       => '',
+			'detected'          => array(),
+			'message'           => 'No backup plugin detected. Consider installing one for data safety.',
+		);
+	}
+
+	return array(
+		'has_backup_plugin' => true,
+		'plugin'            => $detected[0]['name'],
+		'last_backup'       => $detected[0]['last_backup'],
+		'detected'          => $detected,
+	);
+}
+
+/**
+ * Get last backup time for a specific backup plugin.
+ *
+ * @param string $plugin_slug Plugin file slug.
+ * @return string Date string or 'Unknown'.
+ */
+function wp_agentic_admin_get_last_backup_time( string $plugin_slug ): string {
+	global $wpdb;
+
+	switch ( $plugin_slug ) {
+		case 'updraftplus/updraftplus.php':
+			$option = get_option( 'updraft_last_backup' );
+			if ( is_array( $option ) && isset( $option['last_backup'] ) ) {
+				return gmdate( 'Y-m-d H:i:s', $option['last_backup'] );
+			}
+			break;
+
+		case 'backwpup/backwpup.php':
+			$option = get_site_option( 'backwpup_last_backup' );
+			if ( is_numeric( $option ) ) {
+				return gmdate( 'Y-m-d H:i:s', (int) $option );
+			}
+			break;
+
+		case 'duplicator/duplicator.php':
+			// Duplicator stores packages in its own table.
+			$table = $wpdb->prefix . 'duplicator_packages';
+			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$last = $wpdb->get_var( "SELECT MAX(created) FROM `$table` WHERE status = 100" );
+				if ( $last ) {
+					return $last;
+				}
+			}
+			// Duplicator Lite stores in options.
+			$packages = get_option( 'duplicator_package_active', array() );
+			if ( ! empty( $packages ) && is_array( $packages ) && isset( $packages['Created'] ) ) {
+				return $packages['Created'];
+			}
+			break;
+
+		case 'jetpack/jetpack.php':
+			// VaultPress/Jetpack Backup stores timestamp in option.
+			$option = get_option( 'vaultpress_backup_last' );
+			if ( is_numeric( $option ) ) {
+				return gmdate( 'Y-m-d H:i:s', (int) $option );
+			}
+			break;
+
+		case 'blogvault-real-time-backup/developer_developer.php':
+			// BlogVault stores last backup info in option.
+			$option = get_option( 'bv_last_backup_time' );
+			if ( is_numeric( $option ) ) {
+				return gmdate( 'Y-m-d H:i:s', (int) $option );
+			}
+			break;
+
+		case 'all-in-one-wp-migration/all-in-one-wp-migration.php':
+			// All-in-One WP Migration stores exports in its backups dir.
+			$backups_dir = WP_CONTENT_DIR . '/ai1wm-backups/';
+			if ( is_dir( $backups_dir ) ) {
+				$files = glob( $backups_dir . '*.wpress' );
+				if ( ! empty( $files ) ) {
+					$latest = 0;
+					foreach ( $files as $file ) {
+						$mtime = filemtime( $file );
+						if ( $mtime > $latest ) {
+							$latest = $mtime;
+						}
+					}
+					if ( $latest > 0 ) {
+						return gmdate( 'Y-m-d H:i:s', $latest );
+					}
+				}
+			}
+			break;
+	}
+
+	return 'Unknown';
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -183,6 +183,10 @@ class Abilities {
 			wp_agentic_admin_register_comment_stats();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_backup_check' ) ) {
+			wp_agentic_admin_register_backup_check();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/backup-check.js
+++ b/src/extensions/abilities/backup-check.js
@@ -1,0 +1,61 @@
+/**
+ * Backup Check Ability
+ *
+ * Checks backup plugin status and last backup time.
+ *
+ * @see includes/abilities/backup-check.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the backup-check ability with the chat system.
+ */
+export function registerBackupCheck() {
+	registerAbility( 'wp-agentic-admin/backup-check', {
+		label: 'Check backup plugin status',
+		description:
+			'Check if a backup plugin is installed and when the last backup ran. Use when users ask about backups or data safety.',
+
+		keywords: [ 'backup', 'backups', 'restore', 'recovery' ],
+
+		initialMessage: "I'll check your backup status...",
+
+		summarize: ( result ) => {
+			if ( ! result.has_backup_plugin ) {
+				return result.message || 'No backup plugin detected.';
+			}
+
+			const { detected } = result;
+			let summary = `**Backup plugin detected:** ${ result.plugin }\n`;
+			summary += `**Last backup:** ${ result.last_backup }\n`;
+
+			if ( detected && detected.length > 1 ) {
+				summary += `\n_${ detected.length } backup plugins found:_\n`;
+				detected.forEach( ( d ) => {
+					summary += `- ${ d.name } (last: ${ d.last_backup })\n`;
+				} );
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( ! result.has_backup_plugin ) {
+				return 'No backup plugin detected. The site has no automated backup solution.';
+			}
+			return `Backup plugin: ${ result.plugin }. Last backup: ${ result.last_backup }.`;
+		},
+
+		execute: async () => {
+			return executeAbility( 'wp-agentic-admin/backup-check', {} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerBackupCheck;

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -27,6 +27,7 @@ import { registerUserList } from './user-list';
 import { registerUpdateCheck } from './update-check';
 import { registerDiskUsage } from './disk-usage';
 import { registerCommentStats } from './comment-stats';
+import { registerBackupCheck } from './backup-check';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -48,6 +49,7 @@ export { registerUserList } from './user-list';
 export { registerUpdateCheck } from './update-check';
 export { registerDiskUsage } from './disk-usage';
 export { registerCommentStats } from './comment-stats';
+export { registerBackupCheck } from './backup-check';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 
@@ -78,6 +80,7 @@ export function registerAllAbilities() {
 	registerUpdateCheck();
 	registerDiskUsage();
 	registerCommentStats();
+	registerBackupCheck();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -86,6 +86,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/comment-stats',
 		},
 
+		// ── Backup check ──────────────────────────────────────────
+		{
+			input: 'do I have a backup plugin installed?',
+			expectTool: 'wp-agentic-admin/backup-check',
+		},
+		{
+			input: 'check my backup status',
+			expectTool: 'wp-agentic-admin/backup-check',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Add backup-check ability to detect installed backup plugins and report last backup time (#15)
- Supports 6 plugins: UpdraftPlus, BackWPup, Jetpack/VaultPress, BlogVault, Duplicator, All-in-One WP Migration
- Each plugin has specific lookup logic for its backup history storage (options, DB tables, file timestamps)

## Changes
- `includes/abilities/backup-check.php` — PHP backend with per-plugin last backup detection
- `src/extensions/abilities/backup-check.js` — JS frontend with summarize, interpretResult, execute
- `includes/class-abilities.php` — Register backup-check in core abilities
- `src/extensions/abilities/index.js` — Import, re-export, and call registration
- `tests/abilities/core-abilities.test.js` — 2 test cases for backup-related queries

## Testing
- [x] Unit tests pass (`npm test`) — 43/43
- [ ] Ability tests pass (`npm run test:abilities`)
- [x] JS lint clean
- [ ] PHP lint clean — pre-existing PHPCS config issue
- [ ] Manually tested in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)