### PR TITLE
ci(actions): add initial GitHub Actions quality workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: ${{ matrix.check_name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check_name: PHP lint
+            command: composer lint
+          - check_name: JS lint
+            command: npm run lint:js
+          - check_name: Unit tests
+            command: npm test
+          - check_name: Build check
+            command: npm run build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Cache Composer files
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache/files
+            ~/.cache/composer
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run ${{ matrix.check_name }}
+        run: ${{ matrix.command }}


### PR DESCRIPTION
## What does this PR do?

Adds an initial GitHub Actions CI workflow for the project.

The workflow runs PHP lint, JS lint, unit tests, and a build check as separate matrix jobs so all checks can report independently. It runs automatically on pull requests to `dev` and `main`, and it can also be triggered manually via `workflow_dispatch`.

## Type

- [ ] New ability
- [x] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

1. Open a pull request targeting `dev` or `main` and confirm the CI workflow starts automatically.
2. Verify that the workflow creates four separate checks:
   - PHP lint
   - JS lint
   - Unit tests
   - Build check
3. Confirm that if one check fails, the others still run because the workflow uses a matrix with `fail-fast: false`.
4. Go to the GitHub Actions tab and manually trigger the workflow with `workflow_dispatch`.
5. Confirm that the same quality checks run successfully in the manual run.

## Screenshots (if UI changes)

No UI changes.

Refs #22