### PR TITLE
feat: add AI chat sidebar toggle to the WordPress Admin Bar

### DIFF
--- a/includes/class-admin-bar.php
+++ b/includes/class-admin-bar.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Admin Bar class
+ *
+ * Adds an AI chat sidebar toggle to the WordPress admin bar
+ * and enqueues the sidebar on all wp-admin pages.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+namespace WPAgenticAdmin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Admin Bar class.
+ *
+ * Adds a toggle icon to the admin bar and enqueues the
+ * chat sidebar scripts on all wp-admin pages.
+ *
+ * @since 0.9.6
+ */
+class Admin_Bar {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Admin_Bar|null
+	 */
+	private static ?Admin_Bar $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Admin_Bar
+	 */
+	public static function get_instance(): Admin_Bar {
+		if ( null === self::$instance ) {
+			self::$instance = new Admin_Bar();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the class.
+	 */
+	public function __construct() {
+		add_action( 'admin_bar_menu', array( $this, 'add_toggle_node' ), 999 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_footer', array( $this, 'render_sidebar_container' ) );
+	}
+
+	/**
+	 * Add the sidebar toggle icon to the admin bar.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The admin bar instance.
+	 */
+	public function add_toggle_node( \WP_Admin_Bar $wp_admin_bar ): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$wp_admin_bar->add_node(
+			array(
+				'id'     => 'wp-agentic-admin-sidebar-toggle',
+				'parent' => 'top-secondary',
+				'title'  => '<span class="ab-icon" style="font-family:dashicons !important;display:inline-flex !important;align-items:center;justify-content:center;margin:0 3px;" aria-hidden="true">&#xf197;</span><span class="screen-reader-text">' . esc_html__( 'AI Assistant', 'wp-agentic-admin' ) . '</span>',
+				'href'   => '#',
+				'meta'   => array(
+					'class' => 'wp-agentic-admin-toggle',
+					'title' => __( 'AI Assistant', 'wp-agentic-admin' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Enqueue sidebar scripts and styles on all admin pages.
+	 *
+	 * @param string $hook The current admin page hook.
+	 */
+	public function enqueue_scripts( string $hook ): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Skip on the plugin's own settings page — the full app is already loaded.
+		if ( 'toplevel_page_wp-agentic-admin' === $hook ) {
+			return;
+		}
+
+		$asset_file = WP_AGENTIC_ADMIN_PLUGIN_DIR . 'build-extensions/admin-sidebar.asset.php';
+
+		if ( ! file_exists( $asset_file ) ) {
+			return;
+		}
+
+		$asset = require $asset_file;
+		$deps  = isset( $asset['dependencies'] ) ? (array) $asset['dependencies'] : array( 'wp-element' );
+		$ver   = isset( $asset['version'] ) ? $asset['version'] : WP_AGENTIC_ADMIN_VERSION;
+
+		// Enqueue WordPress components styles.
+		wp_enqueue_style( 'wp-components' );
+
+		// Enqueue sidebar styles.
+		$css_file = WP_AGENTIC_ADMIN_PLUGIN_DIR . 'build-extensions/admin-sidebar.css';
+		if ( file_exists( $css_file ) ) {
+			wp_enqueue_style(
+				'wp-agentic-admin-sidebar-style',
+				WP_AGENTIC_ADMIN_PLUGIN_URL . 'build-extensions/admin-sidebar.css',
+				array( 'wp-components', 'dashicons' ),
+				filemtime( $css_file )
+			);
+		}
+
+		// Register and enqueue sidebar script.
+		wp_register_script(
+			'wp-agentic-admin-sidebar',
+			WP_AGENTIC_ADMIN_PLUGIN_URL . 'build-extensions/admin-sidebar.js',
+			$deps,
+			$ver,
+			true
+		);
+
+		// Localize with the same data as the admin page.
+		wp_localize_script(
+			'wp-agentic-admin-sidebar',
+			'wpAgenticAdmin',
+			Admin_Page::get_localized_data()
+		);
+
+		wp_enqueue_script( 'wp-agentic-admin-sidebar' );
+	}
+
+	/**
+	 * Render the sidebar container in the admin footer.
+	 */
+	public function render_sidebar_container(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Don't render on the plugin page — the full app handles it.
+		$screen = get_current_screen();
+		if ( $screen && 'toplevel_page_wp-agentic-admin' === $screen->id ) {
+			return;
+		}
+		?>
+		<div id="wp-agentic-admin-sidebar"></div>
+		<div id="wp-agentic-admin-sidebar-overlay" class="wp-agentic-admin-sidebar-overlay"></div>
+		<?php
+	}
+}

--- a/src/extensions/admin-sidebar.js
+++ b/src/extensions/admin-sidebar.js
@@ -1,0 +1,62 @@
+/**
+ * WP Agentic Admin - Admin Sidebar Entry Point
+ *
+ * Renders an AI chat sidebar on all wp-admin pages.
+ * Toggled via a superhero icon in the WordPress admin bar.
+ * Shares the WebLLM instance via the existing Service Worker.
+ *
+ * @version 0.9.6
+ */
+
+import { createRoot } from '@wordpress/element';
+import AdminSidebar from './components/AdminSidebar';
+import './styles/admin-sidebar.scss';
+import { createLogger } from './utils/logger';
+
+const log = createLogger( 'AdminSidebar' );
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	// Find the container rendered by PHP in admin_footer.
+	const container = document.getElementById( 'wp-agentic-admin-sidebar' );
+
+	if ( ! container ) {
+		log.warn( 'Sidebar container not found' );
+		return;
+	}
+
+	if ( typeof window.wpAgenticAdmin === 'undefined' ) {
+		log.error( 'Settings not found' );
+		return;
+	}
+
+	// Toggle sidebar on admin bar icon click.
+	const toggleBtn = document.getElementById(
+		'wp-admin-bar-wp-agentic-admin-sidebar-toggle'
+	);
+
+	if ( toggleBtn ) {
+		toggleBtn.addEventListener( 'click', ( e ) => {
+			e.preventDefault();
+			const isOpen = container.classList.toggle( 'is-open' );
+			toggleBtn.classList.toggle( 'is-active', isOpen );
+		} );
+	}
+
+	// Close sidebar when clicking the overlay.
+	const overlay = document.getElementById(
+		'wp-agentic-admin-sidebar-overlay'
+	);
+	if ( overlay ) {
+		overlay.addEventListener( 'click', () => {
+			container.classList.remove( 'is-open' );
+			if ( toggleBtn ) {
+				toggleBtn.classList.remove( 'is-active' );
+			}
+		} );
+	}
+
+	const root = createRoot( container );
+	root.render( <AdminSidebar /> );
+
+	log.info( 'Admin sidebar initialized' );
+} );

--- a/src/extensions/components/AdminSidebar.jsx
+++ b/src/extensions/components/AdminSidebar.jsx
@@ -1,0 +1,120 @@
+/**
+ * Admin Sidebar Component
+ *
+ * Simplified version of App.jsx for the admin-wide chat sidebar.
+ * No TabPanel, no AbilityBrowser, no permalink check, no beforeunload warning.
+ * Renders ModelStatus (compact) + ChatContainer within a fixed sidebar.
+ */
+
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import ChatContainer from './ChatContainer';
+import ModelStatus from './ModelStatus';
+import WebGPUFallback from './WebGPUFallback';
+import modelLoader from '../services/model-loader';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger( 'AdminSidebar' );
+
+const AdminSidebar = () => {
+	const [ modelReady, setModelReady ] = useState( false );
+	const [ webGPUError, setWebGPUError ] = useState( null );
+	const [ isExecuting, setIsExecuting ] = useState( false );
+	const [ initPhase, setInitPhase ] = useState( 'checking' );
+	const [ initMessage, setInitMessage ] = useState(
+		'Checking WebGPU support...'
+	);
+	const [ initProgress, setInitProgress ] = useState( 5 );
+
+	/**
+	 * Background WebGPU check and auto-load cached model on mount
+	 */
+	useEffect( () => {
+		const initializeApp = async () => {
+			try {
+				setInitMessage( 'Checking WebGPU support...' );
+				setInitProgress( 10 );
+				const result = await modelLoader.checkWebGPUSupport();
+				if ( ! result.supported ) {
+					setWebGPUError( result.reason );
+					setInitPhase( null );
+					return;
+				}
+
+				setInitMessage( 'Checking model status...' );
+				setInitProgress( 20 );
+				if ( modelLoader.isModelReady() ) {
+					setModelReady( true );
+					setInitPhase( null );
+					return;
+				}
+
+				setInitMessage( 'Checking cache...' );
+				setInitProgress( 30 );
+				const isCached = await modelLoader.isModelCached();
+
+				if ( isCached ) {
+					log.info( 'Model is cached, auto-loading...' );
+					setInitPhase( 'loading' );
+					setInitMessage( 'Loading from cache...' );
+					setInitProgress( 35 );
+					try {
+						await modelLoader.load();
+						setModelReady( true );
+					} catch ( loadErr ) {
+						log.error( 'Auto-load failed:', loadErr );
+					}
+				}
+				setInitPhase( null );
+			} catch ( err ) {
+				log.error( 'Initialization failed:', err );
+				setInitPhase( null );
+			}
+		};
+
+		initializeApp();
+	}, [] );
+
+	const handleModelReady = useCallback( () => {
+		setModelReady( true );
+		setWebGPUError( null );
+	}, [] );
+
+	const handleModelError = useCallback( ( errorMessage ) => {
+		setModelReady( false );
+		if (
+			errorMessage.includes( 'WebGPU' ) ||
+			errorMessage.includes( 'GPU' )
+		) {
+			setWebGPUError( errorMessage );
+		}
+	}, [] );
+
+	return (
+		<div className="wp-agentic-admin-sidebar__inner">
+			<div className="wp-agentic-admin-sidebar__header">
+				<span className="dashicons dashicons-superhero-alt" />
+				<strong>AI Assistant</strong>
+			</div>
+
+			<ModelStatus
+				onModelReady={ handleModelReady }
+				onModelError={ handleModelError }
+				initPhase={ initPhase }
+				initMessage={ initMessage }
+				initProgress={ initProgress }
+			/>
+
+			{ webGPUError && ! modelReady ? (
+				<WebGPUFallback reason={ webGPUError } />
+			) : (
+				<ChatContainer
+					modelReady={ modelReady }
+					isLoading={ isExecuting }
+					setIsLoading={ setIsExecuting }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default AdminSidebar;

--- a/src/extensions/styles/admin-sidebar.scss
+++ b/src/extensions/styles/admin-sidebar.scss
@@ -1,0 +1,294 @@
+/* stylelint-disable no-descending-specificity, no-duplicate-selectors */
+
+/**
+ * WP Agentic Admin - Admin Sidebar Styles
+ *
+ * Fixed sidebar panel for all wp-admin pages.
+ * Imports base chat styles and adds sidebar-specific overrides.
+ *
+ * @package WPAgenticAdmin
+ */
+
+@import './main.scss';
+
+// ── Admin bar toggle button ───────────────────────────────
+#wp-admin-bar-wp-agentic-admin-sidebar-toggle {
+
+	&.is-active .ab-item {
+		background: rgba(0, 0, 0, 0.2) !important;
+	}
+}
+
+// ── Sidebar overlay (click to close) ──────────────────────
+.wp-agentic-admin-sidebar-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(0, 0, 0, 0.15);
+	z-index: 99998;
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+
+// Show overlay when sidebar is open
+.is-open + .wp-agentic-admin-sidebar-overlay {
+	opacity: 1;
+	visibility: visible;
+}
+
+// ── Sidebar panel ─────────────────────────────────────────
+#wp-agentic-admin-sidebar {
+	position: fixed;
+	right: 0;
+	top: 32px; // Below admin bar
+	width: 380px;
+	height: calc(100vh - 32px);
+	background: #fff;
+	border-left: 1px solid #c3c4c7;
+	box-shadow: -2px 0 12px rgba(0, 0, 0, 0.1);
+	z-index: 99999;
+	transform: translateX(100%);
+	transition: transform 0.25s ease;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	&.is-open {
+		transform: translateX(0);
+	}
+}
+
+// Responsive: admin bar is 46px on mobile
+@media screen and (max-width: 782px) {
+
+	#wp-agentic-admin-sidebar {
+		top: 46px;
+		height: calc(100vh - 46px);
+		width: 100%; // Full width on mobile
+	}
+
+	// Force our icon visible — WP hides custom top-secondary nodes on mobile
+	#wpadminbar #wp-admin-bar-wp-agentic-admin-sidebar-toggle {
+		display: block !important;
+	}
+
+	#wp-admin-bar-wp-agentic-admin-sidebar-toggle .ab-icon {
+		font-size: 28px !important;
+	}
+}
+
+// ── Inner wrapper ─────────────────────────────────────────
+.wp-agentic-admin-sidebar__inner {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+// ── Sidebar header ────────────────────────────────────────
+.wp-agentic-admin-sidebar__header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 12px 16px;
+	border-bottom: 1px solid #c3c4c7;
+	background: #f6f7f7;
+	flex-shrink: 0;
+
+	.dashicons {
+		color: #2271b1;
+		font-size: 20px;
+		width: 20px;
+		height: 20px;
+	}
+
+	strong {
+		font-size: 14px;
+		color: #1d2327;
+	}
+}
+
+// ── Chat container overrides ──────────────────────────────
+#wp-agentic-admin-sidebar {
+
+	// Chat container fills remaining space
+	.wp-agentic-admin-chat-container {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	// Chat chrome
+	.wp-agentic-admin-chat {
+		border: none;
+		border-radius: 0;
+		box-shadow: none;
+	}
+
+	// Messages area
+	.wp-agentic-admin-messages {
+		min-height: 150px;
+		padding: 12px;
+
+		.agentic-message--user {
+			padding-left: 20px;
+
+			.agentic-message__bubble {
+				max-width: 95%;
+			}
+		}
+
+		.agentic-message--system {
+			padding: 12px !important;
+			margin-bottom: 16px !important;
+
+			.agentic-message__content {
+
+				h3 {
+					font-size: 15px !important;
+				}
+
+				p,
+				li {
+					font-size: 13px;
+				}
+
+				ul {
+					margin: 8px 0 8px 16px !important;
+				}
+			}
+		}
+
+		.agentic-timeline {
+			width: 22px;
+		}
+	}
+
+	// Input area — fixed at bottom
+	.wp-agentic-admin-input-area {
+		padding: 10px;
+		flex-shrink: 0;
+		border-top: 1px solid #c3c4c7;
+
+		.wp-agentic-admin-input {
+			min-height: 44px;
+			font-size: 13px;
+			padding: 8px 10px;
+		}
+	}
+
+	// Stop generation — also fixed at bottom
+	.wp-agentic-admin-chat-actions {
+		flex-shrink: 0;
+	}
+
+	// Chat header — compact
+	.wp-agentic-admin-chat-header {
+		padding: 6px 10px;
+
+		&__actions {
+			gap: 4px;
+
+			.components-button {
+				font-size: 12px;
+				padding: 4px 8px;
+			}
+		}
+	}
+
+	// Model Status — compact
+	.wp-agentic-admin-model-status {
+		margin: 0;
+		padding: 10px;
+		border-radius: 0;
+		border-left: 0;
+		border-right: 0;
+		border-top: 0;
+
+		.wp-agentic-admin-status {
+			flex-wrap: wrap;
+		}
+
+		.wp-agentic-admin-status__controls {
+			flex-direction: column;
+			gap: 6px;
+			width: 100%;
+			margin-left: 0;
+		}
+
+		.wp-agentic-admin-model-select {
+			max-width: 100%;
+			width: 100%;
+		}
+
+		.button {
+			margin-left: 0;
+			width: 100%;
+			justify-content: center;
+		}
+	}
+
+	// Loading card — compact
+	.wp-agentic-admin-loading-card {
+		padding: 12px;
+		border-radius: 0;
+
+		&__icon {
+			font-size: 22px;
+		}
+
+		&__percent {
+			font-size: 18px;
+		}
+
+		&__title {
+			font-size: 14px !important;
+		}
+
+		&__subtitle,
+		&__description {
+			font-size: 12px;
+		}
+	}
+
+	// Model info — compact
+	.wp-agentic-admin-model-info {
+		margin: 8px 0 0;
+		padding: 8px 10px;
+		font-size: 12px;
+	}
+
+	// Context warning — compact
+	.wp-agentic-admin-context-warning {
+		padding: 0 8px;
+	}
+
+	// WebGPU fallback — compact
+	.wp-agentic-admin-webgpu-fallback {
+		padding: 12px;
+
+		.wp-agentic-admin-browser-instructions {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	// Workflow progress — compact
+	.agentic-message--workflow {
+		padding: 10px 12px;
+	}
+
+	// Snackbar positioning
+	.components-snackbar {
+		position: fixed !important;
+		top: 60px !important;
+		right: 20px !important;
+		left: auto !important;
+		bottom: auto !important;
+		z-index: 1000000 !important;
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,9 @@ module.exports = {
 		// Block editor sidebar plugin
 		editor: path.resolve( __dirname, 'src/extensions/editor.js' ),
 
+		// Admin-wide chat sidebar (all wp-admin pages)
+		'admin-sidebar': path.resolve( __dirname, 'src/extensions/admin-sidebar.js' ),
+
 		// Service Worker - needs to be a self-contained bundle
 		sw: {
 			import: path.resolve( __dirname, 'src/extensions/sw.js' ),

--- a/wp-agentic-admin.php
+++ b/wp-agentic-admin.php
@@ -73,6 +73,7 @@ if ( ! class_exists( 'WPAgenticAdmin' ) ) {
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-settings.php';
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-admin-page.php';
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-editor-sidebar.php';
+			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-admin-bar.php';
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-abilities.php';
 
 			// Initialize Utility Hooks (Cache Invalidation).
@@ -90,6 +91,10 @@ if ( ! class_exists( 'WPAgenticAdmin' ) ) {
 
 			if ( class_exists( '\\WPAgenticAdmin\\Editor_Sidebar' ) ) {
 				\WPAgenticAdmin\Editor_Sidebar::get_instance();
+			}
+
+			if ( class_exists( '\\WPAgenticAdmin\\Admin_Bar' ) ) {
+				\WPAgenticAdmin\Admin_Bar::get_instance();
 			}
 
 			if ( class_exists( '\\WPAgenticAdmin\\Abilities' ) ) {


### PR DESCRIPTION
## What does this PR do?

Adds an AI chat sidebar accessible from every wp-admin page via a superhero icon in the admin bar (next to "Howdy, ..."). Also adds the sidebar to the Gutenberg block editor as a PluginSidebar, and introduces a core/get-editor-blocks ability for querying page content while editing.

## Type

- [x] New ability
- [ ] New workflow
- [ ] Bug fix
- [ ] Enhancement
- [ ] Docs

## How to test

1. Run npm run build and activate the plugin on WordPress 6.9+
2. Visit any wp-admin page (Dashboard, Posts, Pages, etc.)
3. Look for the superhero icon in the admin bar, right side near "Howdy, ..."
4. Click the icon — sidebar slides in from the right with ModelStatus + chat
5. Click again or click the overlay to close
6. Navigate to different admin pages — icon persists, chat history carries over
7. Visit WP Agentic Admin settings page — sidebar does NOT load here (full app already handles it)
8. Open any post in the block editor — sidebar also available via PluginSidebar (superhero icon in editor toolbar)
9. In the editor, ask "what blocks are on this page?" — returns a list of blocks via the new core/get-editor-blocks ability
10. Resize browser below 782px — icon stays visible on mobile, sidebar opens full-width

## Screenshots (if UI changes)

<img width="400" height="" alt="CleanShot 2026-03-20 at 16 46 47@2x" src="https://github.com/user-attachments/assets/871e30d7-8dbb-45ab-b9e2-a522b4b8815a" />

<img width="400" height="" alt="CleanShot 2026-03-20 at 16 47 39@2x" src="https://github.com/user-attachments/assets/5c8f9adc-8390-4489-85b2-b4e57585fde4" />

