### PR TITLE
Add write-file ability with backup and append default

### DIFF
--- a/includes/abilities/write-file.php
+++ b/includes/abilities/write-file.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Write File Ability
+ *
+ * Edits WordPress files with backup and confirmation.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the write-file ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_write_file(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/write-file',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Write File', 'wp-agentic-admin' ),
+			'description'         => __( 'Edit WordPress files with automatic backup.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(
+					'file_path' => '',
+					'content'   => '',
+					'mode'      => 'replace',
+				),
+				'properties'           => array(
+					'file_path' => array(
+						'type'        => 'string',
+						'description' => __( 'File path relative to WordPress root.', 'wp-agentic-admin' ),
+					),
+					'content'   => array(
+						'type'        => 'string',
+						'description' => __( 'Content to write.', 'wp-agentic-admin' ),
+					),
+					'mode'      => array(
+						'type'        => 'string',
+						'enum'        => array( 'replace', 'append', 'prepend' ),
+						'default'     => 'replace',
+						'description' => __( 'Write mode: replace, append, or prepend.', 'wp-agentic-admin' ),
+					),
+				),
+				'required'             => array( 'file_path', 'content' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether the write succeeded.', 'wp-agentic-admin' ),
+					),
+					'message' => array(
+						'type'        => 'string',
+						'description' => __( 'Status message.', 'wp-agentic-admin' ),
+					),
+					'backup'  => array(
+						'type'        => 'string',
+						'description' => __( 'Backup file path.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_write_file',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'write', 'edit', 'modify', 'change', 'fix', 'add line', 'add code', 'enable debug', 'update file', 'functions.php', 'wp-config', '.htaccess' ),
+			'initialMessage' => __( "I'll edit that file...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the write-file ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_write_file( array $input = array() ): array {
+	$file_path = isset( $input['file_path'] ) ? sanitize_text_field( $input['file_path'] ) : '';
+	$content   = isset( $input['content'] ) ? $input['content'] : '';
+	$mode      = isset( $input['mode'] ) ? sanitize_text_field( $input['mode'] ) : 'replace';
+
+	if ( empty( $file_path ) || '' === $content ) {
+		return array(
+			'success' => false,
+			'message' => 'File path and content are required.',
+		);
+	}
+
+	// Resolve to absolute path.
+	$abs_path = realpath( ABSPATH . ltrim( $file_path, '/' ) );
+
+	// For new files, check parent directory.
+	if ( false === $abs_path ) {
+		$parent = realpath( dirname( ABSPATH . ltrim( $file_path, '/' ) ) );
+		if ( false === $parent || 0 !== strpos( $parent, realpath( ABSPATH ) ) ) {
+			return array(
+				'success' => false,
+				'message' => 'File path is outside the WordPress directory.',
+			);
+		}
+		$abs_path = $parent . '/' . basename( $file_path );
+	} elseif ( 0 !== strpos( $abs_path, realpath( ABSPATH ) ) ) {
+		return array(
+			'success' => false,
+			'message' => 'File path is outside the WordPress directory.',
+		);
+	}
+
+	// Create backup if file exists.
+	$backup_path = '';
+	if ( file_exists( $abs_path ) ) {
+		$backup_path = $abs_path . '.bak.' . time();
+		if ( ! copy( $abs_path, $backup_path ) ) {
+			return array(
+				'success' => false,
+				'message' => 'Failed to create backup.',
+			);
+		}
+	}
+
+	// Apply content based on mode.
+	$existing = file_exists( $abs_path ) ? file_get_contents( $abs_path ) : '';
+
+	switch ( $mode ) {
+		case 'append':
+			$final = $existing . "\n" . $content;
+			break;
+		case 'prepend':
+			$final = $content . "\n" . $existing;
+			break;
+		default:
+			$final = $content;
+	}
+
+	// Write the file.
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	$result = file_put_contents( $abs_path, $final );
+
+	if ( false === $result ) {
+		return array(
+			'success' => false,
+			'message' => 'Failed to write file.',
+			'backup'  => $backup_path,
+		);
+	}
+
+	return array(
+		'success' => true,
+		'message' => sprintf( 'File %s successfully (%s mode).', $file_path, $mode ),
+		'backup'  => $backup_path ? str_replace( realpath( ABSPATH ), '', $backup_path ) : '',
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -203,6 +203,10 @@ class Abilities {
 			wp_agentic_admin_register_backup_check();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_write_file' ) ) {
+			wp_agentic_admin_register_write_file();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -32,6 +32,7 @@ import { registerPostList } from './post-list';
 import { registerErrorLogSearch } from './error-log-search';
 import { registerOpcodeCacheStatus } from './opcode-cache-status';
 import { registerBackupCheck } from './backup-check';
+import { registerWriteFile } from './write-file';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 import { registerCoreEditorBlocks } from './core-editor-blocks';
@@ -59,6 +60,7 @@ export { registerPostList } from './post-list';
 export { registerErrorLogSearch } from './error-log-search';
 export { registerOpcodeCacheStatus } from './opcode-cache-status';
 export { registerBackupCheck } from './backup-check';
+export { registerWriteFile } from './write-file';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 export { registerCoreEditorBlocks } from './core-editor-blocks';
@@ -95,6 +97,7 @@ export function registerAllAbilities() {
 	registerErrorLogSearch();
 	registerOpcodeCacheStatus();
 	registerBackupCheck();
+	registerWriteFile();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/write-file.js
+++ b/src/extensions/abilities/write-file.js
@@ -1,0 +1,120 @@
+/**
+ * Write File Ability
+ *
+ * Edits WordPress files with backup and confirmation.
+ *
+ * @see includes/abilities/write-file.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the write-file ability with the chat system.
+ */
+export function registerWriteFile() {
+	registerAbility( 'wp-agentic-admin/write-file', {
+		label: 'Write or edit a WordPress file with backup',
+		description:
+			'Write or edit WordPress files with automatic backup. Use when users ask to add code, edit a file, enable debug, or change config. Args: file_path, content, mode (append/prepend/replace). Default mode is append for adding code.',
+
+		keywords: [
+			'write',
+			'edit',
+			'modify',
+			'change',
+			'fix',
+			'add line',
+			'add code',
+			'enable debug',
+			'update file',
+			'functions.php',
+			'wp-config',
+			'.htaccess',
+		],
+
+		initialMessage: "I'll edit that file...",
+
+		summarize: ( result ) => {
+			if ( ! result.success ) {
+				return `Failed: ${ result.message }`;
+			}
+
+			let summary = `${ result.message }`;
+			if ( result.backup ) {
+				summary += `\n\nBackup saved to: \`${ result.backup }\``;
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( ! result.success ) {
+				return `File edit failed: ${ result.message }`;
+			}
+			return `File edited successfully. ${
+				result.backup ? 'Backup created at ' + result.backup + '.' : ''
+			}`;
+		},
+
+		execute: async ( params ) => {
+			if ( ! params.file_path || ! params.content ) {
+				return {
+					success: false,
+					message: 'File path and content are required.',
+				};
+			}
+
+			// Determine mode from userMessage — always check, even if LLM sent a mode,
+			// because small models default to "replace" which destroys file content.
+			let mode = 'append'; // Safe default: append preserves existing content.
+			if ( params.userMessage ) {
+				const lower = params.userMessage.toLowerCase();
+				if (
+					lower.includes( 'replace' ) ||
+					lower.includes( 'overwrite' ) ||
+					lower.includes( 'rewrite' )
+				) {
+					mode = 'replace';
+				} else if (
+					lower.includes( 'prepend' ) ||
+					lower.includes( 'add to the top' ) ||
+					lower.includes( 'insert at the beginning' ) ||
+					lower.includes( 'before' )
+				) {
+					mode = 'prepend';
+				}
+			} else if (
+				params.mode === 'replace' ||
+				params.mode === 'prepend'
+			) {
+				// Only trust explicit mode when there's no userMessage (e.g. Abilities tab).
+				mode = params.mode;
+			}
+
+			return executeAbility( 'wp-agentic-admin/write-file', {
+				file_path: params.file_path,
+				content: params.content,
+				mode,
+			} );
+		},
+
+		requiresConfirmation: true,
+
+		getConfirmationMessage: ( params ) => {
+			const file = params.file_path || 'unknown file';
+			const mode = params.mode || 'replace';
+			const isWpConfig = file.includes( 'wp-config' );
+			let msg = `This will **${ mode }** the file \`${ file }\`. A backup will be created.`;
+			if ( isWpConfig ) {
+				msg +=
+					'\n\n**Warning:** This is a critical configuration file. Proceed with caution.';
+			}
+			return msg + '\n\nProceed?';
+		},
+	} );
+}
+
+export default registerWriteFile;

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -562,11 +562,19 @@ class ReactAgent {
 			}
 
 			// Try to fix common JSON syntax issues from small models
-			// 1. Single quotes to double quotes (for models that use single-quoted JSON keys)
+			// 1. Smart single-to-double quote replacement (only JSON structural quotes,
+			//    not apostrophes inside string values like error_log('test'))
 			// 2. Remove trailing commas before } or ]
 			// 3. Fix property names missing closing quotes (e.g., "args:{} → "args": {})
 			const jsonText = text
-				.replace( /'/g, '"' ) // Single quotes to double quotes
+				.replace(
+					// Replace single quotes that act as JSON delimiters:
+					// - After { , [ : or start of string
+					// - Before } , ] : or end of string
+					// This avoids replacing apostrophes inside string values.
+					/(?<=[[{,:\s])'|'(?=[}\],:\s])/g,
+					'"'
+				)
 				.replace( /,(\s*[}\]])/g, '$1' ) // Remove trailing commas
 				.replace( /"(\w+):([^"])/g, '"$1": $2' ); // Fix missing quote+space: "args:{} → "args": {}
 

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -136,6 +136,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/backup-check',
 		},
 
+		// ── File writing ──────────────────────────────────────────
+		{
+			input: 'add a line to my functions.php',
+			expectTool: 'wp-agentic-admin/write-file',
+		},
+		{
+			input: 'edit the wp-config.php to enable debug mode',
+			expectTool: 'wp-agentic-admin/write-file',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- New ability `wp-agentic-admin/write-file` to edit WordPress files with automatic backup creation
- Supports replace, append, and prepend modes — **defaults to append** to prevent accidental content loss
- Requires confirmation before executing (destructive operation)
- Extra warning shown for wp-config.php edits
- Fix ReAct agent JSON parser: single-quote replacement no longer corrupts quotes inside string values (e.g. `error_log('test')`)

## Changes
- `includes/abilities/write-file.php` — PHP backend with backup, path validation, mode support
- `src/extensions/abilities/write-file.js` — JS frontend with mode inference from user message
- `src/extensions/services/react-agent.js` — Smarter single-quote replacement in JSON fixer
- `includes/class-abilities.php` — Register write-file
- `src/extensions/abilities/index.js` — Import/export/register
- `tests/abilities/core-abilities.test.js` — 2 test cases

## Testing
- [ ] Unit tests pass (`npm test`)
- [ ] JS lint clean (`npm run lint:js`)
- [ ] Manually tested in browser: "Add error_log('test'); to functions.php" appends correctly
- [ ] Manually tested: backup file created before edit
- [ ] Confirmation dialog shown before write

## Notes
- `annotations.destructive` set to `false` in PHP because WordPress Abilities API maps `destructive: true` + `idempotent: true` → DELETE method, which the server rejects for write ops. Confirmation is handled by `requiresConfirmation: true` in JS.
- Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)