### PR TITLE
Add query-database ability for read-only SQL queries

### DIFF
--- a/includes/abilities/query-database.php
+++ b/includes/abilities/query-database.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Query Database Ability
+ *
+ * Executes read-only SQL queries for site inspection.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the query-database ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_query_database(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/query-database',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Query Database', 'wp-agentic-admin' ),
+			'description'         => __( 'Execute read-only SQL queries for site inspection.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array( 'query' => '' ),
+				'properties'           => array(
+					'query' => array(
+						'type'        => 'string',
+						'description' => __( 'SQL SELECT query to execute.', 'wp-agentic-admin' ),
+					),
+				),
+				'required'             => array( 'query' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether the query succeeded.', 'wp-agentic-admin' ),
+					),
+					'results' => array(
+						'type'        => 'array',
+						'description' => __( 'Query results.', 'wp-agentic-admin' ),
+					),
+					'rows'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of rows returned.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_query_database',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'query', 'database', 'sql', 'select', 'table', 'rows' ),
+			'initialMessage' => __( "I'll run that query...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Check if a SQL query is safe (SELECT only).
+ *
+ * @param string $query SQL query string.
+ * @return bool True if safe.
+ */
+function wp_agentic_admin_is_safe_query( string $query ): bool {
+	$forbidden = array( 'INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE', 'REPLACE', 'GRANT', 'REVOKE' );
+	$upper     = strtoupper( trim( $query ) );
+
+	// Must start with SELECT or SHOW or DESCRIBE.
+	if ( ! preg_match( '/^\s*(SELECT|SHOW|DESCRIBE|EXPLAIN)\b/i', $upper ) ) {
+		return false;
+	}
+
+	foreach ( $forbidden as $keyword ) {
+		// Check for forbidden keywords as separate words.
+		if ( preg_match( '/\b' . $keyword . '\b/', $upper ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Redact sensitive columns from query results.
+ *
+ * @param array $results Query results.
+ * @return array Redacted results.
+ */
+function wp_agentic_admin_redact_query_results( array $results ): array {
+	$sensitive_columns = array( 'user_pass', 'user_email' );
+
+	foreach ( $results as &$row ) {
+		$row = (array) $row;
+		foreach ( $sensitive_columns as $col ) {
+			if ( isset( $row[ $col ] ) ) {
+				$row[ $col ] = '[REDACTED]';
+			}
+		}
+	}
+
+	return $results;
+}
+
+/**
+ * Execute the query-database ability.
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_query_database( array $input = array() ): array {
+	global $wpdb;
+
+	$query = isset( $input['query'] ) ? trim( $input['query'] ) : '';
+
+	if ( empty( $query ) ) {
+		return array(
+			'success' => false,
+			'message' => 'No query provided.',
+			'results' => array(),
+			'rows'    => 0,
+		);
+	}
+
+	if ( ! wp_agentic_admin_is_safe_query( $query ) ) {
+		return array(
+			'success' => false,
+			'message' => 'Only SELECT, SHOW, DESCRIBE, and EXPLAIN queries are allowed.',
+			'results' => array(),
+			'rows'    => 0,
+		);
+	}
+
+	// Replace {prefix} placeholder with actual prefix.
+	$query = str_replace( '{prefix}', $wpdb->prefix, $query );
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is validated as SELECT-only above.
+	$results = $wpdb->get_results( $query, ARRAY_A );
+
+	if ( null === $results ) {
+		return array(
+			'success' => false,
+			'message' => $wpdb->last_error ?: 'Query failed.',
+			'results' => array(),
+			'rows'    => 0,
+		);
+	}
+
+	// Limit to 50 rows.
+	$results = array_slice( $results, 0, 50 );
+
+	// Redact sensitive data.
+	$results = wp_agentic_admin_redact_query_results( $results );
+
+	return array(
+		'success' => true,
+		'results' => $results,
+		'rows'    => count( $results ),
+	);
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -203,6 +203,10 @@ class Abilities {
 			wp_agentic_admin_register_backup_check();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_query_database' ) ) {
+			wp_agentic_admin_register_query_database();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -32,6 +32,7 @@ import { registerPostList } from './post-list';
 import { registerErrorLogSearch } from './error-log-search';
 import { registerOpcodeCacheStatus } from './opcode-cache-status';
 import { registerBackupCheck } from './backup-check';
+import { registerQueryDatabase } from './query-database';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 import { registerCoreEditorBlocks } from './core-editor-blocks';
@@ -59,6 +60,7 @@ export { registerPostList } from './post-list';
 export { registerErrorLogSearch } from './error-log-search';
 export { registerOpcodeCacheStatus } from './opcode-cache-status';
 export { registerBackupCheck } from './backup-check';
+export { registerQueryDatabase } from './query-database';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 export { registerCoreEditorBlocks } from './core-editor-blocks';
@@ -95,6 +97,7 @@ export function registerAllAbilities() {
 	registerErrorLogSearch();
 	registerOpcodeCacheStatus();
 	registerBackupCheck();
+	registerQueryDatabase();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/query-database.js
+++ b/src/extensions/abilities/query-database.js
@@ -1,0 +1,89 @@
+/**
+ * Query Database Ability
+ *
+ * Executes read-only SQL queries for site inspection.
+ *
+ * @see includes/abilities/query-database.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the query-database ability with the chat system.
+ */
+export function registerQueryDatabase() {
+	registerAbility( 'wp-agentic-admin/query-database', {
+		label: 'Run a read-only SQL query',
+		description:
+			'Run a read-only SQL query (SELECT/SHOW/DESCRIBE) on the WordPress database. Use {prefix} for the table prefix. Args: query (the SQL string). Use when users ask about database content, row counts, or table data.',
+
+		keywords: [ 'query', 'database', 'sql', 'select', 'table', 'rows' ],
+
+		initialMessage: "I'll run that query...",
+
+		summarize: ( result ) => {
+			if ( ! result.success ) {
+				return `Query failed: ${ result.message }`;
+			}
+
+			if ( result.rows === 0 ) {
+				return 'Query returned no results.';
+			}
+
+			let summary = `**${ result.rows } row${
+				result.rows !== 1 ? 's' : ''
+			} returned:**\n\n`;
+
+			// Format as simple table for first 10 rows.
+			const rows = result.results.slice( 0, 10 );
+			if ( rows.length > 0 ) {
+				const keys = Object.keys( rows[ 0 ] );
+				summary += '| ' + keys.join( ' | ' ) + ' |\n';
+				summary +=
+					'| ' + keys.map( () => '---' ).join( ' | ' ) + ' |\n';
+				rows.forEach( ( row ) => {
+					const vals = keys.map( ( k ) =>
+						String( row[ k ] ?? '' ).substring( 0, 50 )
+					);
+					summary += '| ' + vals.join( ' | ' ) + ' |\n';
+				} );
+			}
+
+			if ( result.rows > 10 ) {
+				summary += `\n_Showing 10 of ${ result.rows } rows._`;
+			}
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( ! result.success ) {
+				return `Query failed: ${ result.message }`;
+			}
+			if ( result.rows === 0 ) {
+				return 'Query returned no results.';
+			}
+			// Include results so the LLM can summarize them for the user.
+			const preview = result.results.slice( 0, 10 );
+			return `Query returned ${
+				result.rows
+			} rows. Results:\n${ JSON.stringify( preview, null, 2 ) }`;
+		},
+
+		execute: async ( params ) => {
+			if ( ! params.query ) {
+				return { success: false, message: 'No SQL query provided.' };
+			}
+			return executeAbility( 'wp-agentic-admin/query-database', {
+				query: params.query,
+			} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerQueryDatabase;

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -136,6 +136,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/backup-check',
 		},
 
+		// ── Database queries ──────────────────────────────────────
+		{
+			input: 'how many posts have more than 10 comments?',
+			expectTool: 'wp-agentic-admin/query-database',
+		},
+		{
+			input: 'show me the last 5 options changed in the database',
+			expectTool: 'wp-agentic-admin/query-database',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- New ability `wp-agentic-admin/query-database` for read-only SQL queries against the WordPress database
- SELECT, SHOW, DESCRIBE, and EXPLAIN queries only — all write operations blocked
- Supports `{prefix}` placeholder for table prefix, redacts `user_pass`/`user_email`, limits to 50 rows
- `interpretResult` includes actual query data so the LLM can summarize results for users

## Changes
- `includes/abilities/query-database.php` — PHP backend with SQL validation, redaction, prefix support
- `src/extensions/abilities/query-database.js` — JS frontend with markdown table summary
- `includes/class-abilities.php` — Register query-database
- `src/extensions/abilities/index.js` — Import/export/register
- `tests/abilities/core-abilities.test.js` — 2 test cases

## Testing
- [ ] Unit tests pass (`npm test`)
- [ ] JS lint clean (`npm run lint:js`)
- [ ] Manually tested: SELECT query returns results
- [ ] Manually tested: INSERT/DELETE/DROP queries rejected
- [ ] Sensitive columns redacted in output

## Notes
- Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)