### PR TITLE
feat: add high-performance notice

### DIFF
--- a/src/extensions/components/ModelStatus.jsx
+++ b/src/extensions/components/ModelStatus.jsx
@@ -654,6 +654,21 @@ const ModelStatus = ( {
 								reload needed! No data is sent to external
 								servers.
 							</p>
+							<div className="wp-agentic-admin-performance-tip">
+								<span className="wp-agentic-admin-performance-tip__icon">
+									💡
+								</span>
+								<div className="wp-agentic-admin-performance-tip__content">
+									<strong>Performance Tip</strong>
+									LLM thinking can be slow on integrated GPUs.
+									For better performance in Chrome, visit{ ' ' }
+									<code>
+										chrome://flags/#force-high-performance-gpu
+									</code>{ ' ' }
+									and enable &quot;Force high performance
+									GPU&quot;.
+								</div>
+							</div>
 						</div>
 					) }
 

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -1000,6 +1000,43 @@
 	}
 }
 
+.wp-agentic-admin-performance-tip {
+	margin: 12px 0 0;
+	padding: 12px;
+	background: #fff8e1;
+	border: 1px solid #ffe082;
+	border-left: 4px solid #ffb300;
+	border-radius: 4px;
+	font-size: 13px;
+	color: #5d4037;
+	display: flex;
+	gap: 10px;
+	align-items: flex-start;
+
+	&__icon {
+		font-size: 16px;
+		flex-shrink: 0;
+		line-height: 1.4;
+	}
+
+	&__content {
+		flex: 1;
+
+		strong {
+			display: block;
+			margin-bottom: 4px;
+			color: #1d2327;
+		}
+
+		code {
+			background: rgba(0, 0, 0, 0.05);
+			padding: 0 4px;
+			border-radius: 2px;
+			font-family: monospace;
+		}
+	}
+}
+
 // Provider selection (Local / Remote toggle)
 .wp-agentic-admin-provider {
 	margin-top: 12px;


### PR DESCRIPTION
closes #63


## What does this PR do?

Adds a small info about the high performance flag

<img width="1274" height="533" alt="image" src="https://github.com/user-attachments/assets/ca643367-ef07-4625-9be5-efa90c30b264" />
<!-- One or two sentences -->

## Type

- [ ] New ability
- [ ] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

Unload local model, try to set a new one


