### PR TITLE
Add web-search ability with DuckDuckGo HTML parsing

### DIFF
--- a/includes/abilities/web-search.php
+++ b/includes/abilities/web-search.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Web Search Ability
+ *
+ * Searches the web for documentation and troubleshooting.
+ *
+ * @license GPL-2.0-or-later
+ * @package WPAgenticAdmin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the web-search ability.
+ *
+ * @return void
+ */
+function wp_agentic_admin_register_web_search(): void {
+	register_agentic_ability(
+		'wp-agentic-admin/web-search',
+		// PHP configuration for WordPress Abilities API.
+		array(
+			'label'               => __( 'Web Search', 'wp-agentic-admin' ),
+			'description'         => __( 'Search the web for documentation and troubleshooting.', 'wp-agentic-admin' ),
+			'category'            => 'sre-tools',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array( 'query' => '' ),
+				'properties'           => array(
+					'query'       => array(
+						'type'        => 'string',
+						'description' => __( 'Search query.', 'wp-agentic-admin' ),
+					),
+					'num_results' => array(
+						'type'        => 'integer',
+						'default'     => 5,
+						'description' => __( 'Number of results to return.', 'wp-agentic-admin' ),
+					),
+				),
+				'required'             => array( 'query' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether the search succeeded.', 'wp-agentic-admin' ),
+					),
+					'results' => array(
+						'type'        => 'array',
+						'description' => __( 'Search results.', 'wp-agentic-admin' ),
+					),
+					'total'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of results.', 'wp-agentic-admin' ),
+					),
+				),
+			),
+			'execute_callback'    => 'wp_agentic_admin_execute_web_search',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		),
+		// JS configuration for chat interface.
+		array(
+			'keywords'       => array( 'search', 'google', 'look up', 'find', 'documentation', 'docs', 'how to' ),
+			'initialMessage' => __( "I'll search the web for that...", 'wp-agentic-admin' ),
+		)
+	);
+}
+
+/**
+ * Execute the web-search ability.
+ *
+ * Uses the DuckDuckGo Instant Answer API (no key required).
+ *
+ * @param array $input Input parameters.
+ * @return array
+ */
+function wp_agentic_admin_execute_web_search( array $input = array() ): array {
+	$query       = isset( $input['query'] ) ? sanitize_text_field( $input['query'] ) : '';
+	$num_results = isset( $input['num_results'] ) ? min( absint( $input['num_results'] ), 10 ) : 5;
+
+	if ( empty( $query ) ) {
+		return array(
+			'success' => false,
+			'message' => 'No search query provided.',
+			'results' => array(),
+			'total'   => 0,
+		);
+	}
+
+	// Use DuckDuckGo HTML search endpoint (returns real search results, no API key needed).
+	$url      = 'https://html.duckduckgo.com/html/?q=' . rawurlencode( $query );
+	$response = wp_remote_get(
+		$url,
+		array(
+			'timeout'    => 15,
+			'user-agent' => 'WP-Agentic-Admin/1.0 (WordPress Plugin)',
+			'headers'    => array(
+				'Accept' => 'text/html',
+			),
+		)
+	);
+
+	if ( is_wp_error( $response ) ) {
+		return array(
+			'success' => false,
+			'message' => 'Search request failed: ' . $response->get_error_message(),
+			'results' => array(),
+			'total'   => 0,
+		);
+	}
+
+	$html    = wp_remote_retrieve_body( $response );
+	$results = wp_agentic_admin_parse_ddg_html( $html, $num_results );
+
+	return array(
+		'success' => true,
+		'results' => $results,
+		'total'   => count( $results ),
+		'note'    => 'Search queries are sent to DuckDuckGo servers.',
+	);
+}
+
+/**
+ * Parse DuckDuckGo HTML search results.
+ *
+ * @param string $html        Raw HTML from DuckDuckGo.
+ * @param int    $num_results Max results to return.
+ * @return array Parsed results with title, url, snippet.
+ */
+function wp_agentic_admin_parse_ddg_html( string $html, int $num_results = 5 ): array {
+	$results = array();
+
+	if ( empty( $html ) ) {
+		return $results;
+	}
+
+	// DuckDuckGo HTML results are in <div class="result"> or <div class="web-result">.
+	// Each result has: <a class="result__a"> for title/URL, <a class="result__snippet"> for snippet.
+	$dom = new \DOMDocument();
+	// Suppress warnings from malformed HTML.
+	libxml_use_internal_errors( true );
+	$dom->loadHTML( '<?xml encoding="UTF-8">' . $html );
+	libxml_clear_errors();
+
+	$xpath = new \DOMXPath( $dom );
+
+	// Find result links (title + URL).
+	$links = $xpath->query( '//a[contains(@class, "result__a")]' );
+
+	if ( false === $links || 0 === $links->length ) {
+		return $results;
+	}
+
+	foreach ( $links as $index => $link ) {
+		if ( count( $results ) >= $num_results ) {
+			break;
+		}
+
+		$title = trim( $link->textContent );
+		$href  = $link->getAttribute( 'href' );
+
+		// DuckDuckGo wraps URLs in a redirect — extract the real URL.
+		if ( preg_match( '/uddg=([^&]+)/', $href, $matches ) ) {
+			$href = rawurldecode( $matches[1] );
+		}
+
+		// Skip ad results and empty URLs.
+		if ( empty( $href ) || empty( $title ) || str_contains( $href, 'duckduckgo.com/y.js' ) ) {
+			continue;
+		}
+
+		// Find the corresponding snippet.
+		$snippet = '';
+		$snippet_nodes = $xpath->query( '//a[contains(@class, "result__snippet")]' );
+		if ( $snippet_nodes && $snippet_nodes->length > $index ) {
+			$snippet = trim( $snippet_nodes->item( $index )->textContent );
+		}
+
+		$results[] = array(
+			'title'   => $title,
+			'url'     => $href,
+			'snippet' => $snippet,
+		);
+	}
+
+	return $results;
+}

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -203,6 +203,10 @@ class Abilities {
 			wp_agentic_admin_register_backup_check();
 		}
 
+		if ( function_exists( 'wp_agentic_admin_register_web_search' ) ) {
+			wp_agentic_admin_register_web_search();
+		}
+
 		/**
 		 * Fires after core abilities are registered.
 		 *

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -32,6 +32,7 @@ import { registerPostList } from './post-list';
 import { registerErrorLogSearch } from './error-log-search';
 import { registerOpcodeCacheStatus } from './opcode-cache-status';
 import { registerBackupCheck } from './backup-check';
+import { registerWebSearch } from './web-search';
 import { registerCoreSiteInfo } from './core-site-info';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 import { registerCoreEditorBlocks } from './core-editor-blocks';
@@ -59,6 +60,7 @@ export { registerPostList } from './post-list';
 export { registerErrorLogSearch } from './error-log-search';
 export { registerOpcodeCacheStatus } from './opcode-cache-status';
 export { registerBackupCheck } from './backup-check';
+export { registerWebSearch } from './web-search';
 export { registerCoreSiteInfo } from './core-site-info';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 export { registerCoreEditorBlocks } from './core-editor-blocks';
@@ -95,6 +97,7 @@ export function registerAllAbilities() {
 	registerErrorLogSearch();
 	registerOpcodeCacheStatus();
 	registerBackupCheck();
+	registerWebSearch();
 
 	// WordPress 6.9+ core ability wrappers
 	// These provide chat-friendly interfaces for WordPress core abilities

--- a/src/extensions/abilities/web-search.js
+++ b/src/extensions/abilities/web-search.js
@@ -1,0 +1,83 @@
+/**
+ * Web Search Ability
+ *
+ * Searches the web for documentation and troubleshooting.
+ *
+ * @see includes/abilities/web-search.php for the PHP implementation
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the web-search ability with the chat system.
+ */
+export function registerWebSearch() {
+	registerAbility( 'wp-agentic-admin/web-search', {
+		label: 'Search the web for documentation',
+		description:
+			'Search the web via DuckDuckGo for WordPress docs, error solutions, and troubleshooting. Use when users ask how to fix an error, need documentation, or want external help. Args: query (search string).',
+
+		keywords: [
+			'search',
+			'google',
+			'look up',
+			'find',
+			'documentation',
+			'docs',
+			'how to',
+		],
+
+		initialMessage: "I'll search the web for that...",
+
+		summarize: ( result ) => {
+			if ( ! result.success ) {
+				return `Search failed: ${ result.message }`;
+			}
+
+			if ( result.total === 0 ) {
+				return 'No results found for your search.';
+			}
+
+			let summary = `Found **${ result.total }** result${
+				result.total !== 1 ? 's' : ''
+			}:\n\n`;
+
+			result.results.forEach( ( r, i ) => {
+				summary += `${ i + 1 }. **[${ r.title }](${ r.url })**\n`;
+				summary += `   ${ r.snippet.substring( 0, 150 ) }\n\n`;
+			} );
+
+			return summary;
+		},
+
+		interpretResult: ( result ) => {
+			if ( ! result.success ) {
+				return `Search failed: ${ result.message }`;
+			}
+			if ( result.total === 0 ) {
+				return 'No search results found.';
+			}
+			const items = result.results
+				.map( ( r, i ) => `${ i + 1 }. ${ r.title } (${ r.url })` )
+				.join( '; ' );
+			return `Found ${ result.total } web results: ${ items }`;
+		},
+
+		execute: async ( params ) => {
+			if ( ! params.query ) {
+				return { success: false, message: 'No search query provided.' };
+			}
+			return executeAbility( 'wp-agentic-admin/web-search', {
+				query: params.query,
+				num_results: params.num_results || 3,
+			} );
+		},
+
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerWebSearch;

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -766,7 +766,7 @@ class ReactAgent {
 	buildToolResultMessage( toolResult, truncatedResult ) {
 		let message;
 		if ( toolResult.result_for_llm ) {
-			message = `Tool interpretation: ${ toolResult.result_for_llm }\n\nRaw data: ${ truncatedResult }`;
+			message = `Tool interpretation: ${ toolResult.result_for_llm }`;
 		} else {
 			message = `Tool result: ${ truncatedResult }`;
 		}

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -136,6 +136,16 @@ module.exports = {
 			expectTool: 'wp-agentic-admin/backup-check',
 		},
 
+		// ── Web search ───────────────────────────────────────────
+		{
+			input: 'search for how to fix WordPress white screen of death',
+			expectTool: 'wp-agentic-admin/web-search',
+		},
+		{
+			input: 'look up WooCommerce REST API documentation',
+			expectTool: 'wp-agentic-admin/web-search',
+		},
+
 		// ── Diagnostics ────────────────────────────────────────────
 		{
 			input: 'show me the error log',


### PR DESCRIPTION
## Summary
- Adds web-search ability (PHP + JS) using DuckDuckGo HTML search endpoint
- Parses real search results via DOMDocument/XPath (titles, URLs, snippets)
- Optimizes ReAct agent: drops raw JSON from tool result when `interpretResult()` exists, freeing context for the 1.7B model

## Changes
- `includes/abilities/web-search.php` — PHP backend with HTML parsing
- `src/extensions/abilities/web-search.js` — JS frontend with concise interpretResult
- `src/extensions/services/react-agent.js` — Skip raw data when interpretResult available
- `includes/class-abilities.php` — Register ability
- `src/extensions/abilities/index.js` — Register ability
- `tests/abilities/core-abilities.test.js` — Add test cases

## Testing
- [ ] Unit tests pass (`npm test`)
- [ ] Ability tests pass (`npm run test:abilities -- --file tests/abilities/core-abilities.test.js`)
- [ ] JS lint clean (`npm run lint:js`)
- [ ] Manually tested in browser chat with "search for WooCommerce REST API docs"

## Notes
- The `react-agent.js` change (dropping raw JSON when interpretResult exists) benefits all abilities — the LLM gets only the concise interpretation instead of duplicated data
- Default results reduced to 3 to fit 4096-token context window

🤖 Generated with [Claude Code](https://claude.com/claude-code)