### PR TITLE
Add build-ability skill with interview workflow

### DIFF
--- a/.claude/skills/build-ability/SKILL.md
+++ b/.claude/skills/build-ability/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: build-ability
+description: Generate a complete ability through an interview-driven workflow
+argument-hint: "<ability-name>"
+allowed-tools: "Bash(npm *), Bash(npx *), Bash(composer *), Read, Write, Edit, Grep, Glob"
+---
+
+# Build Ability
+
+Generate a complete WP-Agentic-Admin ability (PHP backend + JS frontend + index + tests) through an interview-driven workflow. If the user provides an ability name with the command (e.g., `/build-ability theme-list`), use it directly.
+
+## Workflow
+
+### Phase 1: Gather Requirements
+
+If no ability name was provided, ask for it (kebab-case format).
+
+Then ask these questions (batch into 1-2 messages, skip any already answered):
+
+1. **What does this ability do?** (one sentence)
+2. **What would a user say to trigger it?** (3-5 natural language examples)
+3. **Operation type?**
+   - Read-only (just reads data, e.g. list plugins)
+   - Write (modifies something reversible, e.g. flush cache)
+   - Destructive (may lose data or break things, e.g. deactivate plugin)
+4. **Does it need input parameters?** If yes, what are they? Which are required vs optional?
+5. **Is this a WordPress core wrapper?** (JS-only, no PHP — for `core/*` abilities)
+6. **Does it belong to a family?** (e.g., another plugin-* or user-* ability with existing shared helpers)
+
+Derive from the answers:
+- `readonly`, `destructive`, `idempotent` annotations
+- Whether `requiresConfirmation` is needed
+- Whether `parseIntent` is needed (if input comes from natural language)
+- Whether shared helpers should be created or reused
+- The `permission_callback` capability (default: `manage_options`)
+
+### Phase 2: Read Existing Patterns
+
+Before generating code, read these files to match project conventions:
+
+1. An existing ability closest to the new one's type:
+   - Read-only: `src/extensions/abilities/plugin-list.js` + `includes/abilities/plugin-list.php`
+   - Write: `src/extensions/abilities/cache-flush.js` + `includes/abilities/cache-flush.php`
+   - Destructive: `src/extensions/abilities/revision-cleanup.js` + `includes/abilities/revision-cleanup.php`
+   - With parseIntent: `src/extensions/abilities/revision-cleanup.js`
+   - With shared helpers: `src/extensions/abilities/plugin-activate.js` + `src/extensions/abilities/shared/plugin-helpers.js`
+2. `src/extensions/abilities/index.js` — to see current registration pattern
+3. `tests/abilities/core-abilities.test.js` — to see test case format
+
+Also read the full patterns reference: [references/ability-patterns.md](references/ability-patterns.md)
+
+### Phase 3: Generate Files
+
+Create files in this order:
+
+#### 1. PHP Backend (skip for core wrappers)
+
+File: `includes/abilities/{name}.php`
+
+Rules:
+- Function names: `wp_agentic_admin_register_{snake}` and `wp_agentic_admin_execute_{snake}`
+- Always include `permission_callback`
+- Always include `input_schema` with top-level `default` for optional/no-input abilities
+- Always include `output_schema`
+- Set `annotations` matching the operation type
+- Return `array( 'success' => bool, 'message' => string, ... )`
+- Use WordPress spacing: `array( 'key' => 'value' )` not `array('key'=>'value')`
+- Use tabs for indentation
+
+#### 2. JS Frontend
+
+File: `src/extensions/abilities/{name}.js`
+
+Rules:
+- Export function: `register{PascalCase}`
+- `label` and `description` must be **string literals** (test loader uses regex)
+- `label`: action-oriented, for LLM system prompt (e.g., "List installed plugins with status")
+- `description`: one sentence under 30 words, explains when to use this tool
+- `keywords`: array of lowercase trigger words
+- `summarize()`: human-readable summary, handle error case (`!result.success`)
+- `interpretResult()`: plain-English for LLM, concise single-line format preferred
+- `execute()`: call `executeAbility()` with the ability ID and params
+- `requiresConfirmation`: true for destructive, false otherwise
+- Use WordPress spacing: `registerAbility( 'id', { ... } )` not `registerAbility('id', {...})`
+- Use tabs for indentation, single quotes
+
+#### 3. Index Registration
+
+File: `src/extensions/abilities/index.js`
+
+Add:
+- Import statement (grouped with other WP-Agentic-Admin or core abilities)
+- Re-export statement
+- Call inside `registerAllAbilities()`
+
+#### 4. Test Cases
+
+File: `tests/abilities/core-abilities.test.js`
+
+Add 2-3 test cases with different phrasings to the `tests` array.
+
+#### 5. Shared Helpers (if applicable)
+
+If the ability belongs to a family with existing helpers, import and use them.
+If creating a new family, create:
+- `includes/abilities/shared/{domain}-helpers.php`
+- `src/extensions/abilities/shared/{domain}-helpers.js`
+
+### Phase 4: Validate
+
+Run these commands:
+
+```bash
+npx wp-scripts lint-js src/extensions/abilities/{name}.js
+composer lint -- includes/abilities/{name}.php
+npm run build
+```
+
+Fix any lint errors before finishing.
+
+### Phase 5: Summary
+
+Print a summary:
+- Files created/modified
+- Ability ID
+- Operation type (readonly/write/destructive)
+- How to test: `npm run test:abilities -- --file tests/abilities/core-abilities.test.js`
+- Reminder: test in browser chat with natural language prompts from the user's examples

--- a/.claude/skills/build-ability/references/ability-patterns.md
+++ b/.claude/skills/build-ability/references/ability-patterns.md
@@ -1,0 +1,101 @@
+# Ability Patterns Reference
+
+Quick reference for common patterns when building abilities.
+
+## Annotations → HTTP Method Mapping
+
+PHP annotations control the HTTP method the server expects:
+
+| `readonly` | `destructive` | `idempotent` | HTTP Method |
+|------------|---------------|--------------|-------------|
+| `true`     | `false`       | `true`       | GET         |
+| `false`    | `false`       | `false`      | POST        |
+| `false`    | `true`        | `true`       | DELETE      |
+| `false`    | `false`       | `true`       | POST        |
+
+**Important**: `destructive: true` + `idempotent: true` → DELETE. If your ability writes data but isn't truly destructive, use `destructive: false`.
+
+## PHP input_schema Default
+
+Always include a top-level `default` in `input_schema`, even for abilities with no required input. Without it, GET requests fail with "input is not of type object".
+
+```php
+'input_schema' => array(
+    'type'       => 'object',
+    'default'    => array(), // Required for GET abilities
+    'properties' => array( ... ),
+),
+```
+
+## JS String Literals for label/description
+
+The test loader extracts `label` and `description` via regex. They must be string literals:
+
+```javascript
+// GOOD
+label: 'List installed plugins',
+description: 'Show all plugins with their status and version.',
+
+// BAD — test loader can't extract these
+label: __( 'List installed plugins' ),
+description: `Show all ${ type } plugins`,
+```
+
+## interpretResult vs summarize
+
+- `interpretResult()` — fed to the LLM as context. Keep concise, single-line preferred. No markdown, no URLs in complex formats. The LLM must fit this in its 4096-token context window.
+- `summarize()` — displayed to the user in the tool result UI. Can use markdown formatting.
+
+## parseIntent Pattern
+
+Use when input parameters come from natural language rather than structured args:
+
+```javascript
+parseIntent: ( message ) => {
+    const lower = message.toLowerCase();
+    let keepLast = 3;
+    const keepMatch = lower.match( /keep\s*(?:last\s*)?(\d+)/ );
+    if ( keepMatch ) {
+        keepLast = parseInt( keepMatch[ 1 ], 10 );
+    }
+    return { keep_last: keepLast };
+},
+```
+
+## Dynamic Confirmation
+
+Use a function instead of a boolean when confirmation depends on parameters:
+
+```javascript
+requiresConfirmation: ( params ) => {
+    return ! params.dry_run; // Only confirm actual operations
+},
+```
+
+## Shared Helpers
+
+For ability families (e.g., plugin-activate, plugin-deactivate):
+
+- PHP: `includes/abilities/shared/{domain}-helpers.php`
+- JS: `src/extensions/abilities/shared/{domain}-helpers.js`
+
+Example: `plugin-helpers.js` provides `findPluginByName()` used by both activate and deactivate.
+
+## PHP Return Format
+
+Always return this structure:
+
+```php
+return array(
+    'success' => true,
+    'message' => 'Human-readable result.',
+    // ... additional data fields
+);
+```
+
+## Context Window Constraints
+
+- 1.7B model: 4096 tokens, 7B model: 32768 tokens
+- Tool descriptions are sent every request — keep `label` and `description` concise
+- Tool results truncated to 2000 chars
+- `interpretResult()` output replaces raw JSON for the LLM — keep it short


### PR DESCRIPTION
## Summary
- Adds `/build-ability` skill — a comprehensive interview-driven workflow for generating complete abilities (PHP + JS + index + tests)
- Includes `references/ability-patterns.md` with annotations mapping, context window constraints, and common patterns (parseIntent, shared helpers, dynamic confirmation)
- Complements the existing `/new-ability` skill (basic scaffold) with a guided, opinionated workflow

## Changes
- `.claude/skills/build-ability/SKILL.md` — 5-phase workflow (gather requirements, read patterns, generate, validate, summarize)
- `.claude/skills/build-ability/references/ability-patterns.md` — quick reference for HTTP method mapping, input_schema defaults, interpretResult vs summarize, and more

## Testing
- [ ] Invoke `/build-ability test-ability` and verify the interview flow works
- [ ] Verify generated files match project conventions

## Notes
- This skill captures lessons learned from building 20+ abilities (e.g., `input_schema.default` requirement, `destructive: true` → DELETE mapping, context window constraints for interpretResult)

🤖 Generated with [Claude Code](https://claude.com/claude-code)