### PR TITLE
feat: thumbs-up/down feedback on assistant responses (opt-in)

### DIFF
--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -144,8 +144,12 @@ class Admin_Page {
 			$abilities_js_config = get_agentic_abilities_js_config();
 		}
 
+		$feedback_optin_raw = $settings->get_field( 'feedback_optin', null );
+		$feedback_optin     = null === $feedback_optin_raw ? null : (bool) $feedback_optin_raw;
+
 		return array(
 			'restUrl'             => esc_url_raw( rest_url( 'wp-abilities/v1' ) ),
+			'settingsUrl'         => esc_url_raw( rest_url( 'wp-agentic-admin/v1/settings' ) ),
 			'nonce'               => wp_create_nonce( 'wp_rest' ),
 			'userId'              => get_current_user_id(),
 			'pluginUrl'           => esc_url( WP_AGENTIC_ADMIN_PLUGIN_URL ),
@@ -157,6 +161,7 @@ class Admin_Page {
 				'modelId'            => $settings->get_field( 'wp_agentic_admin_model_id', 'Qwen2.5-7B-Instruct-q4f16_1-MLC' ),
 				'confirmDestructive' => (bool) $settings->get_field( 'wp_agentic_admin_confirm_destructive', 1 ),
 				'maxLogLines'        => (int) $settings->get_field( 'wp_agentic_admin_max_log_lines', 100 ),
+				'feedbackOptIn'      => $feedback_optin,
 			),
 			'browserRequirements' => Utils::get_browser_requirements(),
 			'abilities'           => $abilities_js_config,

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -60,6 +60,8 @@ class Settings {
 			'plugin_action_links_' . plugin_basename( WP_AGENTIC_ADMIN_FILE ),
 			array( $this, 'add_settings_link' )
 		);
+
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 	}
 
 	/**
@@ -125,6 +127,57 @@ class Settings {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Register REST API routes for settings updates from the JS app.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes(): void {
+		register_rest_route(
+			'wp-agentic-admin/v1',
+			'/settings',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_settings_rest' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'feedback_optin' => array(
+						'type'              => 'boolean',
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle REST settings update request.
+	 *
+	 * Only whitelisted fields are accepted.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 * @return \WP_REST_Response
+	 */
+	public function update_settings_rest( \WP_REST_Request $request ): \WP_REST_Response {
+		$allowed = array( 'feedback_optin' );
+		$updated = false;
+
+		foreach ( $allowed as $key ) {
+			if ( $request->has_param( $key ) ) {
+				$this->settings[ $key ] = rest_sanitize_boolean( $request->get_param( $key ) );
+				$updated                = true;
+			}
+		}
+
+		if ( $updated ) {
+			$this->save();
+		}
+
+		return new \WP_REST_Response( array( 'success' => true ), 200 );
 	}
 
 	/**

--- a/src/extensions/App.jsx
+++ b/src/extensions/App.jsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { TabPanel, Notice } from '@wordpress/components';
 import ChatContainer from './components/ChatContainer';
 import AbilityBrowser from './components/AbilityBrowser';
+import FeedbackTab from './components/FeedbackTab';
 import ModelStatus from './components/ModelStatus';
 import WebGPUFallback from './components/WebGPUFallback';
 import modelLoader from './services/model-loader';
@@ -173,6 +174,11 @@ const App = () => {
 			title: 'Abilities',
 			className: 'wp-agentic-admin-tab',
 		},
+		{
+			name: 'feedback',
+			title: 'Feedback',
+			className: 'wp-agentic-admin-tab',
+		},
 	];
 
 	/**
@@ -197,6 +203,8 @@ const App = () => {
 				);
 			case 'abilities':
 				return <AbilityBrowser />;
+			case 'feedback':
+				return <FeedbackTab />;
 			default:
 				return null;
 		}

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -32,6 +32,7 @@ import {
 import { Button, Modal, Notice, Snackbar } from '@wordpress/components';
 import MessageList from './MessageList';
 import ChatInput from './ChatInput';
+import FeedbackOptInBanner from './FeedbackOptInBanner';
 import {
 	chatOrchestrator,
 	ChatSession,
@@ -39,6 +40,11 @@ import {
 	MessageType,
 	modelLoader,
 } from '../services';
+import {
+	getFeedbackOptIn,
+	setFeedbackOptIn,
+	saveFeedback,
+} from '../services/feedback';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger( 'ChatContainer' );
@@ -75,6 +81,11 @@ const ChatContainer = ( {
 
 	// Copy feedback state
 	const [ showCopiedSnackbar, setShowCopiedSnackbar ] = useState( false );
+
+	// Feedback opt-in state: null = not decided, true = opted in, false = declined
+	const [ feedbackOptIn, setFeedbackOptInState ] = useState( () =>
+		getFeedbackOptIn()
+	);
 
 	// Session ref to persist across renders
 	const sessionRef = useRef( null );
@@ -401,6 +412,49 @@ const ChatContainer = ( {
 	}, [] );
 
 	/**
+	 * Handle feedback opt-in acceptance
+	 */
+	const handleFeedbackAccept = useCallback( () => {
+		setFeedbackOptInState( true );
+		setFeedbackOptIn( true );
+	}, [] );
+
+	/**
+	 * Handle feedback opt-in decline
+	 */
+	const handleFeedbackDecline = useCallback( () => {
+		setFeedbackOptInState( false );
+		setFeedbackOptIn( false );
+	}, [] );
+
+	/**
+	 * Handle thumbs feedback from a message
+	 *
+	 * @param {string}      messageId - ID of the rated message
+	 * @param {string|null} rating    - 'up', 'down', or null (removed)
+	 */
+	const handleFeedback = useCallback(
+		( messageId, rating ) => {
+			if ( ! rating ) {
+				return;
+			}
+			// Collect ability IDs from the messages preceding this assistant response
+			const abilityIds = messages
+				.filter( ( m ) => m.type === 'ability_result' )
+				.map( ( m ) => m.abilityName )
+				.filter( Boolean );
+
+			saveFeedback( {
+				messageId,
+				sessionId: sessionRef.current?.id || '',
+				abilityIds,
+				rating,
+			} );
+		},
+		[ messages ]
+	);
+
+	/**
 	 * Copy all conversation to clipboard
 	 */
 	const copyAllConversation = useCallback( async () => {
@@ -560,7 +614,19 @@ const ChatContainer = ( {
 				</div>
 			</div>
 
-			<MessageList messages={ displayMessages } />
+			<MessageList
+				messages={ displayMessages }
+				feedbackOptIn={ feedbackOptIn === true }
+				onFeedback={ handleFeedback }
+			/>
+
+			{ /* Feedback opt-in banner — shown once, only after the first real exchange */ }
+			{ feedbackOptIn === null && messages.length > 1 && (
+				<FeedbackOptInBanner
+					onAccept={ handleFeedbackAccept }
+					onDecline={ handleFeedbackDecline }
+				/>
+			) }
 
 			{ /* Context usage warning */ }
 			{ contextUsage?.isHigh && (

--- a/src/extensions/components/FeedbackOptInBanner.jsx
+++ b/src/extensions/components/FeedbackOptInBanner.jsx
@@ -1,0 +1,65 @@
+/**
+ * FeedbackOptInBanner Component
+ *
+ * Shown once when the user has not yet decided whether to enable response feedback.
+ * All collected feedback stays in localStorage — nothing leaves the browser.
+ *
+ */
+
+/**
+ * FeedbackOptInBanner component
+ *
+ * @param {Object}   props           - Component props
+ * @param {Function} props.onAccept  - Called when the user opts in
+ * @param {Function} props.onDecline - Called when the user declines
+ * @return {JSX.Element} Rendered banner
+ */
+const FeedbackOptInBanner = ( { onAccept, onDecline } ) => {
+	return (
+		<div className="agentic-feedback-banner">
+			<div className="agentic-feedback-banner__body">
+				<span
+					className="agentic-feedback-banner__icon"
+					aria-hidden="true"
+				>
+					<svg
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+					>
+						<path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z" />
+						<path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+					</svg>
+				</span>
+				<p className="agentic-feedback-banner__text">
+					Would you like to rate responses with a thumbs up or down?{ ' ' }
+					<span className="agentic-feedback-banner__note">
+						Feedback stays in your browser — nothing is sent
+						externally.
+					</span>
+				</p>
+			</div>
+			<div className="agentic-feedback-banner__actions">
+				<button
+					type="button"
+					className="agentic-feedback-banner__btn agentic-feedback-banner__btn--accept"
+					onClick={ onAccept }
+				>
+					Yes, enable
+				</button>
+				<button
+					type="button"
+					className="agentic-feedback-banner__btn agentic-feedback-banner__btn--decline"
+					onClick={ onDecline }
+				>
+					No thanks
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default FeedbackOptInBanner;

--- a/src/extensions/components/FeedbackTab.jsx
+++ b/src/extensions/components/FeedbackTab.jsx
@@ -1,0 +1,186 @@
+/**
+ * FeedbackTab Component
+ *
+ * Settings and status panel for the response-feedback feature.
+ * Lets users opt in or out of thumbs-up / thumbs-down rating, and shows
+ * a summary of ratings collected so far (stored locally in the browser).
+ *
+ */
+
+import { useState, useEffect } from '@wordpress/element';
+import {
+	getFeedbackOptIn,
+	setFeedbackOptIn,
+	getAllFeedback,
+} from '../services/feedback';
+
+/**
+ * A single stat card
+ *
+ * @param {Object} props       - Component props
+ * @param {string} props.value - Large number / value to display
+ * @param {string} props.label - Description below the value
+ * @param {string} props.mod   - BEM modifier for colour
+ * @return {JSX.Element} Rendered stat card
+ */
+const StatCard = ( { value, label, mod = '' } ) => (
+	<div
+		className={ `wp-agentic-feedback__stat ${
+			mod ? `wp-agentic-feedback__stat--${ mod }` : ''
+		}` }
+	>
+		<span className="wp-agentic-feedback__stat-value">{ value }</span>
+		<span className="wp-agentic-feedback__stat-label">{ label }</span>
+	</div>
+);
+
+/**
+ * FeedbackTab component
+ *
+ * @return {JSX.Element} Rendered feedback settings tab
+ */
+const FeedbackTab = () => {
+	const [ optIn, setOptInState ] = useState( () => getFeedbackOptIn() );
+	const [ saving, setSaving ] = useState( false );
+	const [ entries, setEntries ] = useState( [] );
+
+	useEffect( () => {
+		setEntries( getAllFeedback() );
+	}, [] );
+
+	const thumbsUp = entries.filter( ( e ) => e.rating === 'up' ).length;
+	const thumbsDown = entries.filter( ( e ) => e.rating === 'down' ).length;
+	const total = entries.length;
+
+	/**
+	 * Toggle the opt-in state and persist to server.
+	 *
+	 * @param {boolean} newValue - New opt-in value
+	 */
+	const handleToggle = async ( newValue ) => {
+		setSaving( true );
+		setOptInState( newValue );
+		await setFeedbackOptIn( newValue );
+		setSaving( false );
+	};
+
+	return (
+		<div className="wp-agentic-feedback">
+			{ /* ── Header ── */ }
+			<div className="wp-agentic-feedback__header">
+				<h3 className="wp-agentic-feedback__title">
+					Response Feedback
+				</h3>
+				<p className="wp-agentic-feedback__intro">
+					Rate AI responses with a thumbs up or down after each reply.
+					Feedback helps you track where the assistant performs well
+					and where it struggles — entirely within your browser.{ ' ' }
+					<strong>No data is ever sent to external servers.</strong>
+				</p>
+			</div>
+
+			{ /* ── Opt-in toggle card ── */ }
+			<div className="wp-agentic-feedback__card">
+				<div className="wp-agentic-feedback__card-body">
+					<div className="wp-agentic-feedback__toggle-row">
+						<div className="wp-agentic-feedback__toggle-info">
+							<span className="wp-agentic-feedback__toggle-title">
+								Enable response ratings
+							</span>
+							<span className="wp-agentic-feedback__toggle-desc">
+								Shows 👍 / 👎 buttons below each assistant
+								reply.
+							</span>
+						</div>
+						<button
+							type="button"
+							className={ `wp-agentic-feedback__toggle ${
+								optIn ? 'wp-agentic-feedback__toggle--on' : ''
+							}` }
+							onClick={ () => handleToggle( ! optIn ) }
+							disabled={ saving }
+							aria-pressed={ !! optIn }
+							aria-label="Enable response ratings"
+						>
+							<span className="wp-agentic-feedback__toggle-knob" />
+						</button>
+					</div>
+
+					<p
+						className={ `wp-agentic-feedback__status ${
+							optIn
+								? 'wp-agentic-feedback__status--on'
+								: 'wp-agentic-feedback__status--off'
+						}` }
+					>
+						{ /* eslint-disable-next-line no-nested-ternary -- clear three-state status message */ }
+						{ saving
+							? 'Saving…'
+							: optIn
+							? 'Ratings are enabled. Thumbs icons appear on each assistant response.'
+							: 'Ratings are disabled. Enable to start collecting response feedback.' }
+					</p>
+				</div>
+			</div>
+
+			{ /* ── Stats ── */ }
+			{ optIn && (
+				<div className="wp-agentic-feedback__card">
+					<h4 className="wp-agentic-feedback__card-title">
+						Collected ratings
+					</h4>
+					<div className="wp-agentic-feedback__stats">
+						<StatCard value={ total } label="Total rated" />
+						<StatCard
+							value={ thumbsUp }
+							label="Thumbs up"
+							mod="up"
+						/>
+						<StatCard
+							value={ thumbsDown }
+							label="Thumbs down"
+							mod="down"
+						/>
+						{ total > 0 && (
+							<StatCard
+								value={ `${ Math.round(
+									( thumbsUp / total ) * 100
+								) }%` }
+								label="Positive"
+								mod="pct"
+							/>
+						) }
+					</div>
+					{ total === 0 && (
+						<p className="wp-agentic-feedback__empty">
+							No ratings yet. Rate responses in the Chat tab to
+							see results here.
+						</p>
+					) }
+				</div>
+			) }
+
+			{ /* ── Privacy note ── */ }
+			<div className="wp-agentic-feedback__privacy">
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					aria-hidden="true"
+				>
+					<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+				</svg>
+				<span>
+					Ratings are stored only in your browser&apos;s local
+					storage. They are never transmitted to Pluginslab,
+					WordPress.org, or any third party.
+				</span>
+			</div>
+		</div>
+	);
+};
+
+export default FeedbackTab;

--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -8,6 +8,7 @@
 
 import { useState } from '@wordpress/element';
 import { createLogger } from '../utils/logger';
+import { getMessageRating } from '../services/feedback';
 
 const log = createLogger( 'MessageItem' );
 
@@ -128,14 +129,23 @@ const getAbilityLabel = ( abilityId ) => {
 /**
  * MessageItem component
  *
- * @param {Object} props         - Component props
- * @param {Object} props.message - Message object
+ * @param {Object}        props               - Component props
+ * @param {Object}        props.message       - Message object
+ * @param {boolean}       props.feedbackOptIn - Whether the user has opted in to feedback
+ * @param {Function|null} props.onFeedback    - Called with (messageId, rating) when a thumb is clicked
  * @return {JSX.Element} Rendered message
  */
-const MessageItem = ( { message } ) => {
+const MessageItem = ( {
+	message,
+	feedbackOptIn = false,
+	onFeedback = null,
+} ) => {
 	const { type, content, timestamp, prefillTps, decodeTps } = message;
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ copied, setCopied ] = useState( false );
+	const [ rating, setRating ] = useState( () =>
+		feedbackOptIn ? getMessageRating( message.id ) : null
+	);
 
 	/**
 	 * Copy message content to clipboard
@@ -152,6 +162,19 @@ const MessageItem = ( { message } ) => {
 			setTimeout( () => setCopied( false ), 2000 );
 		} catch ( err ) {
 			log.error( 'Failed to copy:', err );
+		}
+	};
+
+	/**
+	 * Handle thumbs-up / thumbs-down click
+	 *
+	 * @param {string} newRating - 'up' or 'down'
+	 */
+	const handleRating = ( newRating ) => {
+		const next = rating === newRating ? null : newRating;
+		setRating( next );
+		if ( onFeedback ) {
+			onFeedback( message.id, next );
 		}
 	};
 
@@ -371,46 +394,108 @@ const MessageItem = ( { message } ) => {
 								</span>
 							) }
 						</div>
-						<button
-							className={ `agentic-message__copy ${
-								copied ? 'agentic-message__copy--copied' : ''
-							}` }
-							onClick={ handleCopy }
-							type="button"
-							title={ copied ? 'Copied!' : 'Copy to clipboard' }
-						>
-							{ copied ? (
-								<svg
-									width="14"
-									height="14"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<polyline points="20 6 9 17 4 12" />
-								</svg>
-							) : (
-								<svg
-									width="14"
-									height="14"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<rect
-										x="9"
-										y="9"
-										width="13"
-										height="13"
-										rx="2"
-										ry="2"
-									/>
-									<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-								</svg>
+						<div className="agentic-message__actions">
+							{ feedbackOptIn && (
+								<div className="agentic-message__feedback">
+									<button
+										type="button"
+										className={ `agentic-message__thumb ${
+											rating === 'up'
+												? 'agentic-message__thumb--active'
+												: ''
+										}` }
+										onClick={ () => handleRating( 'up' ) }
+										title="Good response"
+									>
+										<svg
+											width="14"
+											height="14"
+											viewBox="0 0 24 24"
+											fill={
+												rating === 'up'
+													? 'currentColor'
+													: 'none'
+											}
+											stroke="currentColor"
+											strokeWidth="2"
+										>
+											<path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14z" />
+											<path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+										</svg>
+									</button>
+									<button
+										type="button"
+										className={ `agentic-message__thumb ${
+											rating === 'down'
+												? 'agentic-message__thumb--active agentic-message__thumb--down'
+												: ''
+										}` }
+										onClick={ () => handleRating( 'down' ) }
+										title="Poor response"
+									>
+										<svg
+											width="14"
+											height="14"
+											viewBox="0 0 24 24"
+											fill={
+												rating === 'down'
+													? 'currentColor'
+													: 'none'
+											}
+											stroke="currentColor"
+											strokeWidth="2"
+										>
+											<path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3H10z" />
+											<path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17" />
+										</svg>
+									</button>
+								</div>
 							) }
-						</button>
+							<button
+								className={ `agentic-message__copy ${
+									copied
+										? 'agentic-message__copy--copied'
+										: ''
+								}` }
+								onClick={ handleCopy }
+								type="button"
+								title={
+									copied ? 'Copied!' : 'Copy to clipboard'
+								}
+							>
+								{ copied ? (
+									<svg
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="2"
+									>
+										<polyline points="20 6 9 17 4 12" />
+									</svg>
+								) : (
+									<svg
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="2"
+									>
+										<rect
+											x="9"
+											y="9"
+											width="13"
+											height="13"
+											rx="2"
+											ry="2"
+										/>
+										<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+									</svg>
+								) }
+							</button>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/src/extensions/components/MessageList.jsx
+++ b/src/extensions/components/MessageList.jsx
@@ -11,11 +11,17 @@ import MessageItem from './MessageItem';
 /**
  * MessageList component
  *
- * @param {Object} props          - Component props
- * @param {Array}  props.messages - Array of message objects
+ * @param {Object}        props               - Component props
+ * @param {Array}         props.messages      - Array of message objects
+ * @param {boolean}       props.feedbackOptIn - Whether the user has opted in to feedback
+ * @param {Function|null} props.onFeedback    - Called with (messageId, rating) on thumb click
  * @return {JSX.Element} Rendered message list
  */
-const MessageList = ( { messages } ) => {
+const MessageList = ( {
+	messages,
+	feedbackOptIn = false,
+	onFeedback = null,
+} ) => {
 	const listRef = useRef( null );
 
 	// Auto-scroll to bottom when new messages arrive
@@ -28,7 +34,12 @@ const MessageList = ( { messages } ) => {
 	return (
 		<div className="wp-agentic-admin-messages" ref={ listRef }>
 			{ messages.map( ( message ) => (
-				<MessageItem key={ message.id } message={ message } />
+				<MessageItem
+					key={ message.id }
+					message={ message }
+					feedbackOptIn={ feedbackOptIn }
+					onFeedback={ onFeedback }
+				/>
 			) ) }
 		</div>
 	);

--- a/src/extensions/services/feedback.js
+++ b/src/extensions/services/feedback.js
@@ -1,0 +1,176 @@
+/**
+ * Feedback Service
+ *
+ * Manages opt-in state and thumbs-up/thumbs-down feedback data.
+ *
+ * Opt-in preference is persisted on the server (WordPress options) via the
+ * wp-agentic-admin/v1/settings REST endpoint, and cached in localStorage for
+ * synchronous reads. Feedback ratings are stored in localStorage only —
+ * nothing leaves the browser.
+ *
+ */
+
+import { createLogger } from '../utils/logger';
+
+const log = createLogger( 'Feedback' );
+
+const OPTIN_CACHE_KEY = 'wp-agentic-admin-feedback-optin';
+const FEEDBACK_KEY = 'wp-agentic-admin-feedback';
+
+// ─── Opt-in ──────────────────────────────────────────────────────────────────
+
+/**
+ * Get the current opt-in state.
+ *
+ * Reads from window.wpAgenticAdmin.settings (server value) first, falling back
+ * to the localStorage cache so the value is always available synchronously.
+ *
+ * @return {boolean|null} true = opted in, false = declined, null = not yet decided
+ */
+export const getFeedbackOptIn = () => {
+	// Prefer the server-side value passed via wp_localize_script
+	const serverVal = window.wpAgenticAdmin?.settings?.feedbackOptIn;
+	if ( serverVal !== undefined ) {
+		return serverVal; // null | true | false
+	}
+
+	// Fall back to localStorage cache (e.g. during dev without the full PHP stack)
+	try {
+		const cached = localStorage.getItem( OPTIN_CACHE_KEY );
+		if ( cached === null ) {
+			return null;
+		}
+		return cached === 'true';
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Persist the opt-in decision to the server and update the local cache.
+ *
+ * @param {boolean} optIn - Whether the user opted in
+ * @return {Promise<void>}
+ */
+export const setFeedbackOptIn = async ( optIn ) => {
+	// Update localStorage cache immediately so the UI stays reactive
+	try {
+		localStorage.setItem( OPTIN_CACHE_KEY, String( optIn ) );
+	} catch {
+		// Ignore storage errors
+	}
+
+	// Also update window.wpAgenticAdmin so getFeedbackOptIn() returns the new
+	// value synchronously for any subsequent reads in this page load
+	if ( window.wpAgenticAdmin?.settings ) {
+		window.wpAgenticAdmin.settings.feedbackOptIn = optIn;
+	}
+
+	// Persist to server
+	const settingsUrl = window.wpAgenticAdmin?.settingsUrl;
+	const nonce = window.wpAgenticAdmin?.nonce;
+
+	if ( ! settingsUrl ) {
+		log.warn( 'settingsUrl not available, skipping server persist' );
+		return;
+	}
+
+	try {
+		const response = await fetch( settingsUrl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': nonce || '',
+			},
+			body: JSON.stringify( { feedback_optin: optIn } ),
+		} );
+
+		if ( ! response.ok ) {
+			log.error(
+				'Failed to persist feedback opt-in to server:',
+				response.status
+			);
+		}
+	} catch ( err ) {
+		log.error( 'Error persisting feedback opt-in:', err );
+	}
+};
+
+// ─── Feedback data ───────────────────────────────────────────────────────────
+
+/**
+ * Save a feedback entry to localStorage.
+ *
+ * @param {Object} entry            - Feedback entry
+ * @param {string} entry.messageId  - ID of the rated assistant message
+ * @param {string} entry.sessionId  - Chat session ID
+ * @param {Array}  entry.abilityIds - Abilities used in the turn
+ * @param {string} entry.rating     - 'up' or 'down'
+ * @param {string} [entry.comment]  - Optional free-form comment
+ */
+export const saveFeedback = ( {
+	messageId,
+	sessionId,
+	abilityIds,
+	rating,
+	comment = '',
+} ) => {
+	try {
+		const existing = JSON.parse(
+			localStorage.getItem( FEEDBACK_KEY ) || '[]'
+		);
+
+		// Update existing entry for this message, or push a new one
+		const idx = existing.findIndex( ( e ) => e.messageId === messageId );
+		const entry = {
+			messageId,
+			sessionId,
+			abilityIds: abilityIds || [],
+			rating,
+			comment,
+			timestamp: new Date().toISOString(),
+		};
+
+		if ( idx !== -1 ) {
+			existing[ idx ] = entry;
+		} else {
+			existing.push( entry );
+		}
+
+		localStorage.setItem( FEEDBACK_KEY, JSON.stringify( existing ) );
+	} catch {
+		// Silently ignore storage errors
+	}
+};
+
+/**
+ * Get the stored rating for a specific message, if any.
+ *
+ * @param {string} messageId - Message ID to look up
+ * @return {string|null} 'up', 'down', or null
+ */
+export const getMessageRating = ( messageId ) => {
+	try {
+		const existing = JSON.parse(
+			localStorage.getItem( FEEDBACK_KEY ) || '[]'
+		);
+		const entry = existing.find( ( e ) => e.messageId === messageId );
+		return entry ? entry.rating : null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Get all stored feedback entries.
+ *
+ * @return {Array} All feedback entries
+ */
+export const getAllFeedback = () => {
+	try {
+		return JSON.parse( localStorage.getItem( FEEDBACK_KEY ) || '[]' );
+	} catch {
+		return [];
+	}
+};

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -74,6 +74,81 @@
 	}
 }
 
+// Feedback opt-in banner
+.agentic-feedback-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin: 0 12px 8px;
+	padding: 10px 14px;
+	background: #f0f6fc;
+	border: 1px solid #c2d4e8;
+	border-radius: 6px;
+	font-size: 13px;
+
+	&__body {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex: 1;
+	}
+
+	&__icon {
+		flex-shrink: 0;
+		color: #2271b1;
+	}
+
+	&__text {
+		margin: 0;
+		color: #1d2327;
+		line-height: 1.4;
+	}
+
+	&__note {
+		color: #646970;
+		font-size: 12px;
+	}
+
+	&__actions {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		flex-shrink: 0;
+	}
+
+	&__btn {
+		padding: 4px 10px;
+		border-radius: 4px;
+		border: 1px solid transparent;
+		font-size: 12px;
+		cursor: pointer;
+		transition: all 0.15s ease;
+
+		&--accept {
+			background: #2271b1;
+			color: #fff;
+			border-color: #2271b1;
+
+			&:hover {
+				background: #135e96;
+				border-color: #135e96;
+			}
+		}
+
+		&--decline {
+			background: transparent;
+			color: #646970;
+			border-color: #c3c4c7;
+
+			&:hover {
+				background: #f0f0f1;
+				color: #1d2327;
+			}
+		}
+	}
+}
+
 // Individual Message
 .wp-agentic-admin-message {
 	margin-bottom: 16px;
@@ -647,6 +722,214 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 		gap: 16px;
+	}
+}
+
+// Feedback Tab
+.wp-agentic-feedback {
+	padding: 20px;
+	max-width: 680px;
+
+	&__header {
+		margin-bottom: 24px;
+	}
+
+	&__title {
+		margin: 0 0 10px !important;
+		font-size: 18px !important;
+		font-weight: 600;
+		color: #1d2327;
+	}
+
+	&__intro {
+		margin: 0;
+		color: #50575e;
+		line-height: 1.6;
+	}
+
+	&__card {
+		background: #fff;
+		border: 1px solid #c3c4c7;
+		border-radius: 4px;
+		padding: 20px;
+		margin-bottom: 16px;
+	}
+
+	&__card-title {
+		margin: 0 0 16px !important;
+		font-size: 13px !important;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: #646970;
+	}
+
+	&__card-body {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	&__toggle-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+	}
+
+	&__toggle-info {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+
+	&__toggle-title {
+		font-weight: 600;
+		color: #1d2327;
+		font-size: 14px;
+	}
+
+	&__toggle-desc {
+		color: #646970;
+		font-size: 13px;
+	}
+
+	// Toggle switch
+	&__toggle {
+		position: relative;
+		flex-shrink: 0;
+		width: 44px;
+		height: 24px;
+		background: #c3c4c7;
+		border: none;
+		border-radius: 12px;
+		cursor: pointer;
+		transition: background 0.2s ease;
+		padding: 0;
+
+		&:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
+		}
+
+		&--on {
+			background: #2271b1;
+		}
+
+		&:focus-visible {
+			outline: 2px solid #2271b1;
+			outline-offset: 2px;
+		}
+	}
+
+	&__toggle-knob {
+		position: absolute;
+		top: 3px;
+		left: 3px;
+		width: 18px;
+		height: 18px;
+		background: #fff;
+		border-radius: 50%;
+		transition: transform 0.2s ease;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+
+		.wp-agentic-feedback__toggle--on & {
+			transform: translateX( 20px );
+		}
+	}
+
+	&__status {
+		margin: 0;
+		font-size: 13px;
+		border-radius: 3px;
+		padding: 8px 12px;
+
+		&--on {
+			background: #edfaef;
+			color: #00a32a;
+			border-left: 3px solid #00a32a;
+		}
+
+		&--off {
+			background: #f6f7f7;
+			color: #646970;
+			border-left: 3px solid #c3c4c7;
+		}
+	}
+
+	// Stats row
+	&__stats {
+		display: flex;
+		gap: 12px;
+		flex-wrap: wrap;
+	}
+
+	&__stat {
+		flex: 1;
+		min-width: 80px;
+		background: #f6f7f7;
+		border-radius: 4px;
+		padding: 14px 16px;
+		text-align: center;
+		border-top: 3px solid #c3c4c7;
+
+		&--up {
+			border-top-color: #00a32a;
+			background: #f0faf1;
+		}
+
+		&--down {
+			border-top-color: #d63638;
+			background: #fdf0f0;
+		}
+
+		&--pct {
+			border-top-color: #2271b1;
+			background: #f0f6fc;
+		}
+	}
+
+	&__stat-value {
+		display: block;
+		font-size: 28px;
+		font-weight: 700;
+		color: #1d2327;
+		line-height: 1;
+		margin-bottom: 4px;
+	}
+
+	&__stat-label {
+		display: block;
+		font-size: 12px;
+		color: #646970;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	&__empty {
+		margin: 12px 0 0;
+		color: #646970;
+		font-style: italic;
+		font-size: 13px;
+	}
+
+	// Privacy note at bottom
+	&__privacy {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		padding: 12px 16px;
+		background: #f0f6fc;
+		border: 1px solid #c2d4e8;
+		border-radius: 4px;
+		color: #2271b1;
+		font-size: 12px;
+		line-height: 1.5;
+
+		svg {
+			flex-shrink: 0;
+			margin-top: 1px;
+		}
 	}
 }
 
@@ -1766,6 +2049,55 @@
 				&::before {
 					content: "·";
 					margin-right: 8px;
+				}
+			}
+
+			.agentic-message__actions {
+				display: flex;
+				align-items: center;
+				gap: 2px;
+			}
+
+			.agentic-message__feedback {
+				display: flex;
+				align-items: center;
+				gap: 2px;
+				margin-right: 4px;
+			}
+
+			.agentic-message__thumb {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				width: 28px;
+				height: 28px;
+				padding: 0;
+				border: none;
+				background: transparent;
+				color: #8c8f94;
+				border-radius: 4px;
+				cursor: pointer;
+				transition: all 0.15s ease;
+
+				&:hover {
+					background: #f0f0f1;
+					color: #1d2327;
+				}
+
+				&--active {
+					color: #00a32a;
+
+					&:hover {
+						color: #00a32a;
+					}
+				}
+
+				&--down#{&}--active {
+					color: #d63638;
+
+					&:hover {
+						color: #d63638;
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Clean rebase of #70 by @janvogt — cherry-picked feedback commits onto current `dev`, removing the nix flake files (now in #81) and unrelated changes.

**What it does:**
- Thumbs up/down buttons on assistant messages (opt-in)
- FeedbackOptInBanner shown once for consent
- FeedbackTab in settings with rating stats
- Feedback stored in localStorage — nothing leaves the browser
- Opt-in preference persisted server-side via REST endpoint (`wp-agentic-admin/v1/settings`)

## Original author

All code by @janvogt — cherry-picked with attribution preserved.

Supersedes #70.

Co-Authored-By: Jan Vogt <jan@noreply.vogts.cloud>