### PR TITLE
feat: add core/get-site-url ability for focused URL queries

### DIFF
--- a/src/extensions/abilities/core-site-url.js
+++ b/src/extensions/abilities/core-site-url.js
@@ -1,0 +1,91 @@
+/**
+ * Core Site URL Ability
+ *
+ * Wraps WordPress core ability: core/get-site-info (fields: ['url'])
+ * Returns only the site URL for focused queries like "what is my site URL?"
+ *
+ * ABILITY OVERVIEW:
+ * =================
+ * This is a focused wrapper around core/get-site-info that returns only the
+ * site URL. Solves the problem where URL queries either route to conversational
+ * mode (returning generic explanations) or return all site info fields.
+ *
+ * No PHP registration needed - uses WordPress core's get-site-info ability.
+ *
+ * READ-ONLY: This ability only reads data, no confirmation needed.
+ *
+ * @since 0.9.0
+ * @see core-site-info.js for the full site info ability
+ */
+
+import {
+	registerAbility,
+	executeAbility,
+} from '../services/agentic-abilities-api';
+
+/**
+ * Register the core/get-site-url ability with the chat system.
+ */
+export function registerCoreSiteUrl() {
+	registerAbility( 'core/get-site-url', {
+		label: 'Get site URL',
+		description:
+			'Get the WordPress site URL (address). Returns the public-facing site URL.',
+
+		keywords: [
+			'site url',
+			'siteurl',
+			'address',
+			'web address',
+			'my url',
+			'home url',
+			'site address',
+		],
+
+		initialMessage: 'Fetching site URL...',
+
+		/**
+		 * Generate summary from the result.
+		 *
+		 * @param {Object} result - The result from WordPress core.
+		 * @return {string} Human-readable summary.
+		 */
+		summarize: ( result ) => {
+			if ( ! result || ! result.url ) {
+				return 'Unable to retrieve the site URL.';
+			}
+
+			return `**Site URL:** ${ result.url }`;
+		},
+
+		/**
+		 * Plain-English interpretation of the result for the LLM.
+		 *
+		 * @param {Object} result - The result from WordPress core.
+		 * @return {string} Plain-English interpretation.
+		 */
+		interpretResult: ( result ) => {
+			if ( ! result || ! result.url ) {
+				return 'Unable to retrieve the site URL.';
+			}
+
+			return `The site URL is ${ result.url }.`;
+		},
+
+		/**
+		 * Execute the ability.
+		 *
+		 * @return {Promise<Object>} The result from WordPress core.
+		 */
+		execute: async () => {
+			return executeAbility( 'core/get-site-info', {
+				fields: [ 'url' ],
+			} );
+		},
+
+		// Read-only operation - no confirmation needed.
+		requiresConfirmation: false,
+	} );
+}
+
+export default registerCoreSiteUrl;

--- a/src/extensions/abilities/index.js
+++ b/src/extensions/abilities/index.js
@@ -36,6 +36,7 @@ import { registerWriteFile } from './write-file';
 import { registerQueryDatabase } from './query-database';
 import { registerWebSearch } from './web-search';
 import { registerCoreSiteInfo } from './core-site-info';
+import { registerCoreSiteUrl } from './core-site-url';
 import { registerCoreEnvironmentInfo } from './core-environment-info';
 import { registerVerifyCoreChecksums } from './verify-core-checksums';
 import { registerVerifyPluginChecksums } from './verify-plugin-checksums';
@@ -69,6 +70,7 @@ export { registerWriteFile } from './write-file';
 export { registerQueryDatabase } from './query-database';
 export { registerWebSearch } from './web-search';
 export { registerCoreSiteInfo } from './core-site-info';
+export { registerCoreSiteUrl } from './core-site-url';
 export { registerCoreEnvironmentInfo } from './core-environment-info';
 export { registerVerifyCoreChecksums } from './verify-core-checksums';
 export { registerVerifyPluginChecksums } from './verify-plugin-checksums';
@@ -120,6 +122,7 @@ export function registerAllAbilities() {
 	// These provide chat-friendly interfaces for WordPress core abilities
 	// Note: core/get-user-info is not included as it has show_in_rest=false
 	registerCoreSiteInfo();
+	registerCoreSiteUrl();
 	registerCoreEnvironmentInfo();
 	registerCoreEditorBlocks();
 

--- a/tests/abilities/core-abilities.test.js
+++ b/tests/abilities/core-abilities.test.js
@@ -233,6 +233,14 @@ module.exports = {
 			expectTool: 'core/get-site-info',
 		},
 		{
+			input: 'what is my site URL?',
+			expectTool: [ 'core/get-site-url', 'core/get-site-info' ],
+		},
+		{
+			input: 'what is my address URL',
+			expectTool: [ 'core/get-site-url', 'core/get-site-info' ],
+		},
+		{
 			input: 'what environment is this site running on?',
 			expectTool: 'core/get-environment-info',
 		},


### PR DESCRIPTION
## Summary

Queries like "what is my site URL" were routing to conversational mode (returning generic explanations) because `core-site-info` lacked URL keywords. New dedicated ability wraps `core/get-site-info` with `fields: ['url']` and URL-specific keywords to ensure proper tool routing and focused responses.

## What does this PR do?

Adds a new `core/get-site-url` JS-only ability that returns only the site URL, with keywords (`site url`, `siteurl`, `address`, `web address`, `home url`, `site address`) that ensure URL queries route to the ReAct agent instead of falling through to conversational mode.

## Type

- [x] New ability
- [ ] New workflow
- [ ] Bug fix
- [ ] Enhancement
- [ ] Docs

## How to test

1. Open the chat panel and ask "what is my site URL?"
2. Verify it returns the actual site URL value (e.g. `https://example.com`), not a generic explanation
3. Ask "what is my address URL" and verify the same focused response
4. Ask "what is the name of my site?" and verify `core/get-site-info` still works normally with all fields

## Screenshots (if UI changes)

<!-- Drop a screenshot or GIF here -->

Closes #79
