### PR TITLE
fix: auto-reconnect remote provider on page load

### DIFF
--- a/src/extensions/App.jsx
+++ b/src/extensions/App.jsx
@@ -59,7 +59,43 @@ const App = () => {
 					return;
 				}
 
-				// Check if model is cached
+				// Check saved provider preference
+				const savedProvider = localStorage.getItem(
+					'wp_agentic_admin_provider'
+				);
+
+				if ( savedProvider === 'remote' ) {
+					const url = localStorage.getItem(
+						'wp_agentic_admin_remote_url'
+					);
+					const remoteModel = localStorage.getItem(
+						'wp_agentic_admin_remote_model'
+					);
+					const apiKey =
+						localStorage.getItem(
+							'wp_agentic_admin_remote_api_key'
+						) || '';
+					if ( url && remoteModel ) {
+						log.info( 'Remote provider saved, auto-connecting...' );
+						setInitPhase( 'loading' );
+						setInitMessage( 'Connecting to remote provider...' );
+						setInitProgress( 35 );
+						try {
+							await modelLoader.loadExternal(
+								url,
+								remoteModel,
+								apiKey
+							);
+							setModelReady( true );
+						} catch ( loadErr ) {
+							log.error( 'Auto-connect remote failed:', loadErr );
+						}
+					}
+					setInitPhase( null );
+					return;
+				}
+
+				// Check if local model is cached
 				setInitMessage( 'Checking cache...' );
 				setInitProgress( 30 );
 				const isCached = await modelLoader.isModelCached();

--- a/src/extensions/components/AdminSidebar.jsx
+++ b/src/extensions/components/AdminSidebar.jsx
@@ -48,6 +48,43 @@ const AdminSidebar = () => {
 					return;
 				}
 
+				// Check saved provider preference
+				const savedProvider = localStorage.getItem(
+					'wp_agentic_admin_provider'
+				);
+
+				if ( savedProvider === 'remote' ) {
+					const url = localStorage.getItem(
+						'wp_agentic_admin_remote_url'
+					);
+					const remoteModel = localStorage.getItem(
+						'wp_agentic_admin_remote_model'
+					);
+					const apiKey =
+						localStorage.getItem(
+							'wp_agentic_admin_remote_api_key'
+						) || '';
+					if ( url && remoteModel ) {
+						log.info( 'Remote provider saved, auto-connecting...' );
+						setInitPhase( 'loading' );
+						setInitMessage( 'Connecting to remote provider...' );
+						setInitProgress( 35 );
+						try {
+							await modelLoader.loadExternal(
+								url,
+								remoteModel,
+								apiKey
+							);
+							setModelReady( true );
+						} catch ( loadErr ) {
+							log.error( 'Auto-connect remote failed:', loadErr );
+						}
+					}
+					setInitPhase( null );
+					return;
+				}
+
+				// Check if local model is cached
 				setInitMessage( 'Checking cache...' );
 				setInitProgress( 30 );
 				const isCached = await modelLoader.isModelCached();


### PR DESCRIPTION
Previously, the init logic in App.jsx and AdminSidebar.jsx always auto-loaded the cached local WebLLM model, ignoring the saved provider preference. Now checks localStorage for the saved provider setting and auto-connects the remote provider when it was last used.

Fixes #101

## What does this PR do?

Checks the saved provider preference from localStorage before auto-loading a model on page load. If the user last used a remote provider, it auto-connects to that remote endpoint instead of initializing the local WebLLM model.

## Type

- [ ] New ability
- [ ] New workflow
- [x] Bug fix
- [ ] Enhancement
- [ ] Docs

## How to test

1. Connect to a remote provider (e.g., Ollama), verify it works
2. Refresh the page — should auto-connect to the remote provider instead of loading the local model
3. Switch back to a local model, load it, refresh — should auto-load the local model from cache as before
4. Set remote provider with an invalid URL, refresh — should fail gracefully without crashing, user can manually reconnect

## Screenshots (if UI changes)

N/A — no UI changes, only initialization behavior.
