### PR TITLE
merge: sync main into dev (direnv/nix flake)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build-extensions/
 *.swo
 hackathon-teasers.md
 hackathon-todo.md
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773831496,
+        "narHash": "sha256-JW2/QPyCVzmouqEp1H9kNa8JXd7xEhlam9sy3TYfhDY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "826430a188181a750ffa5948daff334039c5d741",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-25.11-darwin",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixpkgs-25.11-darwin";
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      utils,
+    }:
+    utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nodejs_20
+            gh
+            php83
+            php83Packages.composer
+            minio
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Merges the 2 commits on `main` that are not yet on `dev`
- Both commits add the direnv dev environment using the Nix flake (#81 from janvogt/feature/direnv-nix-flake)
- `main` is currently 37 commits behind `dev` and 2 commits ahead — this PR resolves the ahead-by-2 gap

## Notes
After this merges, a follow-up PR merging `dev` → `main` would be needed to fully sync.