### PR TITLE
fix: PHP fatal error from unclosed brace in class-abilities.php

### DIFF
--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -189,8 +189,8 @@ class Abilities {
 
 		if ( function_exists( 'wp_agentic_admin_register_database_check' ) ) {
 			wp_agentic_admin_register_database_check();
-    }
-    
+		}
+
 		if ( function_exists( 'wp_agentic_admin_register_theme_list' ) ) {
 			wp_agentic_admin_register_theme_list();
 		}
@@ -221,6 +221,7 @@ class Abilities {
 
 		if ( function_exists( 'wp_agentic_admin_register_read_file' ) ) {
 			wp_agentic_admin_register_read_file();
+		}
 
 		if ( function_exists( 'wp_agentic_admin_register_error_log_search' ) ) {
 			wp_agentic_admin_register_error_log_search();


### PR DESCRIPTION
## Summary

- Adds missing closing `}` for the `read_file` registration block (line 224) — caused a PHP parse error that took down the entire plugin
- Fixes spaces-to-tabs indentation on the `database_check` block (lines 191-193)

**Root cause**: Merge commit `c1704ae` in PR #99 resolved conflicts incorrectly and dropped the closing brace, nesting all subsequent ability registrations inside the `read_file` if-block.

## Test plan

- [x] `php -l includes/class-abilities.php` passes
- [x] All PHP files pass syntax check
- [ ] Plugin loads without fatal error in WordPress

🤖 Generated with [Claude Code](https://claude.com/claude-code)