### PR TITLE
feat: add raw json to context and think after tool calls (to improve e.g. cron event list)

### DIFF
--- a/src/extensions/abilities/cron-list.js
+++ b/src/extensions/abilities/cron-list.js
@@ -132,7 +132,24 @@ export function registerCronList() {
 			if ( total === 0 ) {
 				return 'No cron events are currently scheduled.';
 			}
-			let text = `Found ${ total } scheduled cron events.`;
+
+			const events = result.events || [];
+			const eventLines = events
+				.slice( 0, 15 )
+				.map( ( e ) => {
+					const time = e.is_overdue
+						? `${ e.next_run_diff } ago (OVERDUE)`
+						: `in ${ e.next_run_diff }`;
+					return `- ${ e.hook }: ${ e.schedule }, ${ time }`;
+				} )
+				.join( '\n' );
+
+			let text = `Found ${ total } scheduled cron events:\n${ eventLines }`;
+
+			if ( events.length > 15 ) {
+				text += `\n...and ${ events.length - 15 } more events.`;
+			}
+
 			if ( overdue > 0 ) {
 				text += ` WARNING: ${ overdue } events are overdue, which may indicate wp-cron is not running properly.`;
 			} else {

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -24,7 +24,7 @@ const REACT_CONFIG = {
 	confirmationTimeout: 30000, // 30s timeout for user confirmations
 	maxToolResultLength: 3000, // 7B models handle more context
 	disableThinking: false, // Disable Qwen 3 <think> blocks for faster inference
-	disableThinkingAfterTool: true, // Skip thinking on iterations after tool results
+	disableThinkingAfterTool: false, // Skip thinking on iterations after tool results
 };
 
 /**
@@ -774,7 +774,10 @@ class ReactAgent {
 	buildToolResultMessage( toolResult, truncatedResult ) {
 		let message;
 		if ( toolResult.result_for_llm ) {
-			message = `Tool interpretation: ${ toolResult.result_for_llm }\n\nRaw data: ${ truncatedResult }`;
+			message = `Tool interpretation: ${ toolResult.result_for_llm }`;
+			if ( ! this.config.disableThinkingAfterTool ) {
+				message += `\n\nRaw data: ${ truncatedResult }`;
+			}
 		} else {
 			message = `Tool result: ${ truncatedResult }`;
 		}

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -22,7 +22,7 @@ const REACT_CONFIG = {
 	temperature: 0.3, // 7B models are more reliable, lower temp for consistency
 	maxTokens: 1024, // 7B models produce richer reasoning
 	confirmationTimeout: 30000, // 30s timeout for user confirmations
-	maxToolResultLength: 2000, // 7B models handle more context
+	maxToolResultLength: 3000, // 7B models handle more context
 	disableThinking: false, // Disable Qwen 3 <think> blocks for faster inference
 	disableThinkingAfterTool: true, // Skip thinking on iterations after tool results
 };
@@ -328,9 +328,9 @@ class ReactAgent {
 					const truncatedResult =
 						resultStr.length > this.config.maxToolResultLength
 							? resultStr.substring(
-									0,
-									this.config.maxToolResultLength
-							  ) + '...[truncated]'
+								0,
+								this.config.maxToolResultLength
+							) + '...[truncated]'
 							: resultStr;
 
 					// Add observation to conversation with JSON format reminder
@@ -774,7 +774,7 @@ class ReactAgent {
 	buildToolResultMessage( toolResult, truncatedResult ) {
 		let message;
 		if ( toolResult.result_for_llm ) {
-			message = `Tool interpretation: ${ toolResult.result_for_llm }`;
+			message = `Tool interpretation: ${ toolResult.result_for_llm }\n\nRaw data: ${ truncatedResult }`;
 		} else {
 			message = `Tool result: ${ truncatedResult }`;
 		}


### PR DESCRIPTION
## What does this PR do?

<img width="1072" height="783" alt="image" src="https://github.com/user-attachments/assets/576981a5-e63f-4339-a909-d9aba66f307b" />

* The cron event summary can  now includes a detailed list of scheduled cron events


* Increased the `maxToolResultLength` from 2000 to 3000 to allow more context in tool results. (`src/extensions/services/react-agent.js`)
* Changed `disableThinkingAfterTool` from `true` to `false`, enabling the inclusion of raw tool data after tool results in subsequent iterations. (`src/extensions/services/react-agent.js`)
* Updated the message formatting in the `ReactAgent` class to append the raw data after the tool result when `disableThinkingAfterTool` is `false`. (`src/extensions/services/react-agent.js`)
<!-- One or two sentences -->

## Type

- [x] New ability
- [ ] New workflow
- [x] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

<!-- Steps to verify this works -->

1. Ask the model to list all cron jobs
2. profit

## Screenshots (if UI changes)

<!-- Drop a screenshot or GIF here -->
