### PR TITLE
feat: add prompt UX with ability bundles, web search toggle, and send button

### DIFF
--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -324,10 +324,12 @@ const ChatContainer = ( {
 	/**
 	 * Handle sending a user message
 	 *
-	 * @param {string} text - User's message text
+	 * @param {string} text                  - User's message text
+	 * @param {Object} options               - Send options
+	 * @param {Array}  options.bundleToolIds - Tool IDs to constrain the LLM to
 	 */
 	const handleSendMessage = useCallback(
-		async ( text ) => {
+		async ( text, options = {} ) => {
 			if ( ! text.trim() ) {
 				return;
 			}
@@ -343,7 +345,7 @@ const ChatContainer = ( {
 
 			// Process message through orchestrator
 			try {
-				await chatOrchestrator.processMessage( text );
+				await chatOrchestrator.processMessage( text, options );
 			} catch ( error ) {
 				log.error( 'Error processing message:', error );
 			}

--- a/src/extensions/components/ChatInput.jsx
+++ b/src/extensions/components/ChatInput.jsx
@@ -1,11 +1,37 @@
 /**
  * ChatInput Component
  *
- * Text input area with send button for the chat interface.
+ * Text input area with bundle selection, plus icon, and send button.
  *
  */
 
 import { useState, useRef, useEffect } from '@wordpress/element';
+import { Dropdown, Icon } from '@wordpress/components';
+import {
+	plus,
+	send,
+	closeSmall,
+	shield,
+	globe,
+	plugins,
+	tool,
+	bug,
+	post,
+	info,
+} from '@wordpress/icons';
+import ABILITY_BUNDLES from '../data/ability-bundles';
+
+/**
+ * Map of bundle icon names to @wordpress/icons components.
+ */
+const BUNDLE_ICONS = {
+	shield,
+	plugins,
+	tool,
+	bug,
+	post,
+	info,
+};
 
 /**
  * ChatInput component
@@ -24,6 +50,8 @@ const ChatInput = ( {
 	isLoading = false,
 } ) => {
 	const [ message, setMessage ] = useState( '' );
+	const [ selectedBundle, setSelectedBundle ] = useState( null );
+	const [ webSearchEnabled, setWebSearchEnabled ] = useState( false );
 	const textareaRef = useRef( null );
 
 	// Focus textarea on mount if not disabled
@@ -39,14 +67,19 @@ const ChatInput = ( {
 	 * @param {Event} e - Submit event
 	 */
 	const handleSubmit = ( e ) => {
-		e.preventDefault();
+		if ( e ) {
+			e.preventDefault();
+		}
 
 		const trimmedMessage = message.trim();
 		if ( ! trimmedMessage || disabled || isLoading ) {
 			return;
 		}
 
-		onSend( trimmedMessage );
+		onSend( trimmedMessage, {
+			bundleToolIds: selectedBundle?.abilities || null,
+			webSearch: webSearchEnabled,
+		} );
 		setMessage( '' );
 	};
 
@@ -72,23 +105,135 @@ const ChatInput = ( {
 	};
 
 	const isDisabled = disabled || isLoading;
+	const canSend = message.trim().length > 0 && ! isDisabled;
 
 	return (
 		<div className="wp-agentic-admin-input-area">
-			<textarea
-				ref={ textareaRef }
-				className="wp-agentic-admin-input"
-				value={ message }
-				onChange={ handleChange }
-				onKeyDown={ handleKeyDown }
-				placeholder={
-					isDisabled ? 'Load the AI model first...' : placeholder
-				}
-				rows="3"
-				disabled={ isDisabled }
-			/>
-			<div className="wp-agentic-admin-input-hint">
-				Enter to send, Shift+Enter for new line
+			<div
+				className={ `wp-agentic-admin-input-wrapper${
+					isDisabled
+						? ' wp-agentic-admin-input-wrapper--disabled'
+						: ''
+				}` }
+			>
+				<textarea
+					ref={ textareaRef }
+					className="wp-agentic-admin-input"
+					value={ message }
+					onChange={ handleChange }
+					onKeyDown={ handleKeyDown }
+					placeholder={
+						isDisabled ? 'Load the AI model first...' : placeholder
+					}
+					rows="3"
+					disabled={ isDisabled }
+				/>
+				<div className="wp-agentic-admin-input-toolbar">
+					<div className="wp-agentic-admin-input-toolbar__left">
+						<Dropdown
+							popoverProps={ {
+								placement: 'top-start',
+								shift: true,
+							} }
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<button
+									type="button"
+									className={ `wp-agentic-admin-bundle-trigger${
+										isOpen
+											? ' wp-agentic-admin-bundle-trigger--active'
+											: ''
+									}` }
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									aria-label="Select ability bundle"
+									disabled={ isDisabled }
+								>
+									<Icon icon={ plus } size={ 24 } />
+								</button>
+							) }
+							renderContent={ ( { onClose } ) => (
+								<div className="wp-agentic-admin-bundle-menu">
+									{ ABILITY_BUNDLES.map( ( bundle ) => (
+										<button
+											type="button"
+											key={ bundle.id }
+											className={ `wp-agentic-admin-bundle-menu__item${
+												selectedBundle?.id === bundle.id
+													? ' wp-agentic-admin-bundle-menu__item--selected'
+													: ''
+											}` }
+											onClick={ () => {
+												setSelectedBundle( bundle );
+												onClose();
+											} }
+										>
+											<Icon
+												icon={
+													BUNDLE_ICONS[
+														bundle.icon
+													] || shield
+												}
+												size={ 18 }
+											/>
+											<span className="wp-agentic-admin-bundle-menu__label">
+												{ bundle.label }
+											</span>
+											<span className="wp-agentic-admin-bundle-menu__count">
+												{ bundle.abilities.length }{ ' ' }
+												tools
+											</span>
+										</button>
+									) ) }
+								</div>
+							) }
+						/>
+						<button
+							type="button"
+							className={ `wp-agentic-admin-websearch-toggle${
+								webSearchEnabled
+									? ' wp-agentic-admin-websearch-toggle--active'
+									: ''
+							}` }
+							onClick={ () =>
+								setWebSearchEnabled( ! webSearchEnabled )
+							}
+							aria-label="Toggle web search"
+							aria-pressed={ webSearchEnabled }
+							disabled={ isDisabled }
+							data-tooltip={ `Web Search: ${
+								webSearchEnabled ? 'active' : 'inactive'
+							}` }
+						>
+							<Icon icon={ globe } size={ 24 } />
+						</button>
+						{ selectedBundle && (
+							<span className="wp-agentic-admin-bundle-pill">
+								<span className="wp-agentic-admin-bundle-pill__label">
+									{ selectedBundle.label }
+								</span>
+								<button
+									type="button"
+									className="wp-agentic-admin-bundle-pill__remove"
+									onClick={ () => setSelectedBundle( null ) }
+									aria-label={ `Remove ${ selectedBundle.label }` }
+								>
+									<Icon icon={ closeSmall } size={ 18 } />
+								</button>
+							</span>
+						) }
+					</div>
+					<div className="wp-agentic-admin-input-toolbar__right">
+						<button
+							type="button"
+							className="wp-agentic-admin-send-button"
+							onClick={ handleSubmit }
+							disabled={ ! canSend }
+							aria-label="Send message"
+						>
+							<Icon icon={ send } size={ 20 } />
+						</button>
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/extensions/data/ability-bundles.js
+++ b/src/extensions/data/ability-bundles.js
@@ -1,0 +1,104 @@
+/**
+ * Ability Bundles
+ *
+ * Curated sets of abilities that constrain the LLM to a specific
+ * subset of tools. When a bundle is selected, the ReAct agent only
+ * sees the bundled tools in its system prompt.
+ *
+ * @since 0.5.0
+ */
+
+const ABILITY_BUNDLES = [
+	{
+		id: 'plugins-themes',
+		label: 'Plugins & Themes',
+		icon: 'plugins',
+		description: 'Manage extensions and themes',
+		abilities: [
+			'wp-agentic-admin/plugin-list',
+			'wp-agentic-admin/plugin-activate',
+			'wp-agentic-admin/plugin-deactivate',
+			'wp-agentic-admin/theme-list',
+			'wp-agentic-admin/update-check',
+		],
+	},
+	{
+		id: 'performance',
+		label: 'Performance',
+		icon: 'tool',
+		description: 'Optimize site speed and resources',
+		abilities: [
+			'wp-agentic-admin/cache-flush',
+			'wp-agentic-admin/transient-flush',
+			'wp-agentic-admin/opcode-cache-status',
+			'wp-agentic-admin/db-optimize',
+			'wp-agentic-admin/revision-cleanup',
+			'wp-agentic-admin/cron-list',
+			'wp-agentic-admin/rewrite-list',
+			'wp-agentic-admin/rewrite-flush',
+		],
+	},
+	{
+		id: 'security',
+		label: 'Security',
+		icon: 'shield',
+		description: 'Audit site security and integrity',
+		abilities: [
+			'wp-agentic-admin/security-scan',
+			'wp-agentic-admin/verify-core-checksums',
+			'wp-agentic-admin/verify-plugin-checksums',
+			'wp-agentic-admin/database-check',
+			'wp-agentic-admin/backup-check',
+		],
+	},
+	{
+		id: 'troubleshooting',
+		label: 'Troubleshooting',
+		icon: 'bug',
+		description: 'Diagnose errors and site health issues',
+		abilities: [
+			'wp-agentic-admin/error-log-read',
+			'wp-agentic-admin/error-log-search',
+			'wp-agentic-admin/site-health',
+		],
+	},
+	{
+		id: 'content-users',
+		label: 'Content & Users',
+		icon: 'post',
+		description: 'Manage posts, comments, and users',
+		abilities: [
+			'wp-agentic-admin/post-list',
+			'wp-agentic-admin/comment-stats',
+			'wp-agentic-admin/user-list',
+			'core/get-editor-blocks',
+			'wp-agentic-admin/write-file',
+		],
+	},
+	{
+		id: 'site-overview',
+		label: 'Site Overview',
+		icon: 'info',
+		description: 'Get a full picture of your site',
+		abilities: [
+			'core/get-site-info',
+			'core/get-environment-info',
+			'wp-agentic-admin/site-health',
+			'wp-agentic-admin/disk-usage',
+			'wp-agentic-admin/plugin-list',
+			'wp-agentic-admin/theme-list',
+		],
+	},
+];
+
+/**
+ * Get a bundle definition by ID.
+ *
+ * @param {string} id - Bundle identifier
+ * @return {Object|undefined} The bundle definition or undefined
+ */
+export function getBundleById( id ) {
+	return ABILITY_BUNDLES.find( ( bundle ) => bundle.id === id );
+}
+
+export default ABILITY_BUNDLES;

--- a/src/extensions/services/chat-orchestrator.js
+++ b/src/extensions/services/chat-orchestrator.js
@@ -18,6 +18,7 @@ import workflowRegistry from './workflow-registry';
 import workflowOrchestrator from './workflow-orchestrator';
 import ReactAgent from './react-agent';
 import messageRouter from './message-router';
+import { executeAbility } from './agentic-abilities-api';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger( 'ChatOrchestrator' );
@@ -209,13 +210,16 @@ class ChatOrchestrator {
 	 * This is the main entry point for handling user input
 	 *
 	 * Routing logic:
-	 * 1. Check for workflow keyword match → workflow mode
-	 * 2. Default to ReAct loop for everything else (actions AND questions)
+	 * 1. If bundle is active → force ReAct with filtered tools
+	 * 2. Check for workflow keyword match → workflow mode
+	 * 3. Default to ReAct loop for everything else (actions AND questions)
 	 *
-	 * @param {string} userMessage - The user's message
+	 * @param {string} userMessage           - The user's message
+	 * @param {Object} options               - Processing options
+	 * @param {Array}  options.bundleToolIds - Tool IDs to constrain the LLM to
 	 * @return {Promise<Object>} Result with success status and any errors
 	 */
-	async processMessage( userMessage ) {
+	async processMessage( userMessage, options = {} ) {
 		if ( ! this.session ) {
 			throw new Error(
 				'ChatOrchestrator not initialized. Call initialize() first.'
@@ -233,6 +237,24 @@ class ChatOrchestrator {
 		try {
 			// Add user message to session
 			this.session.addUserMessage( userMessage );
+
+			// Web search pre-step: run search first, inject results as context
+			if ( options.webSearch ) {
+				await this.performWebSearchPreStep( userMessage );
+			}
+
+			// If bundle is active, bypass router and force ReAct with filtered tools
+			if ( options.bundleToolIds && options.bundleToolIds.length > 0 ) {
+				log.info(
+					'Bundle active, forcing ReAct with filtered tools:',
+					options.bundleToolIds
+				);
+				return await this.processWithReact(
+					userMessage,
+					false,
+					options.bundleToolIds
+				);
+			}
 
 			// Route the message
 			const route = this.messageRouter.route( userMessage );
@@ -275,15 +297,58 @@ class ChatOrchestrator {
 	}
 
 	/**
+	 * Perform web search as a pre-step before normal routing.
+	 *
+	 * Executes a web search using the user's message as query,
+	 * then injects results into the session so subsequent processing
+	 * has web context available.
+	 *
+	 * @param {string} userMessage - The user's message to search for
+	 */
+	async performWebSearchPreStep( userMessage ) {
+		const toolId = 'wp-agentic-admin/web-search';
+		log.info( 'Web search pre-step for:', userMessage );
+
+		this.callbacks.onToolStart( toolId );
+
+		try {
+			const result = await executeAbility( toolId, {
+				query: userMessage,
+				num_results: 5,
+			} );
+
+			this.callbacks.onToolEnd( toolId, result, true );
+			this.session.addToolResult( toolId, result, true );
+
+			log.info(
+				`Web search pre-step complete: ${ result.total || 0 } results`
+			);
+		} catch ( error ) {
+			log.error( 'Web search pre-step failed:', error );
+			this.callbacks.onToolEnd( toolId, { error: error.message }, false );
+			this.session.addToolResult(
+				toolId,
+				{ error: error.message },
+				false
+			);
+		}
+	}
+
+	/**
 	 * Process message with ReAct loop
 	 *
 	 * Uses the ReAct agent to intelligently select and use tools.
 	 *
 	 * @param {string}  userMessage     - User's message
 	 * @param {boolean} disableThinking - Whether to disable model thinking
+	 * @param {Array}   toolFilter      - Optional array of tool IDs to constrain the agent
 	 * @return {Promise<Object>} Result with success status and ReAct execution details.
 	 */
-	async processWithReact( userMessage, disableThinking = false ) {
+	async processWithReact(
+		userMessage,
+		disableThinking = false,
+		toolFilter = null
+	) {
 		if ( ! this.isLLMReady() ) {
 			this.session.addAssistantMessage(
 				'The AI model is not loaded yet. Please load the model first.'
@@ -329,7 +394,8 @@ class ChatOrchestrator {
 		// Execute ReAct loop
 		const result = await this.reactAgent.execute(
 			userMessage,
-			this.session.getConversationHistory()
+			this.session.getConversationHistory(),
+			{ toolFilter }
 		);
 
 		// Stream the final answer

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -87,13 +87,19 @@ class ReactAgent {
 	 *
 	 * @param {string} userMessage         - The user's request
 	 * @param {Array}  conversationHistory - Previous messages (for context)
+	 * @param {Object} options             - Execution options
+	 * @param {Array}  options.toolFilter  - Optional array of tool IDs to constrain the agent
 	 * @return {Promise<ReactResult>} Result with success status, final answer, and execution details.
 	 */
-	async execute( userMessage, conversationHistory = [] ) {
+	async execute( userMessage, conversationHistory = [], options = {} ) {
 		log.info( 'Starting ReAct loop for:', userMessage );
+
+		// Store tool filter for this execution
+		this.currentToolFilter = options.toolFilter || null;
 
 		const engine = this.modelLoader.getEngine();
 		if ( ! engine ) {
+			this.currentToolFilter = null;
 			return {
 				success: false,
 				finalAnswer:
@@ -109,6 +115,9 @@ class ReactAgent {
 			userMessage,
 			conversationHistory
 		);
+
+		// Clean up tool filter
+		this.currentToolFilter = null;
 
 		// Store last result for test observability
 		this.lastResult = result;
@@ -675,6 +684,21 @@ class ReactAgent {
 	 * @return {Promise<Object>} Tool result
 	 */
 	async executeTool( toolId, args, userMessage ) {
+		// Enforce bundle filter — block tools outside the active bundle
+		if (
+			this.currentToolFilter &&
+			this.currentToolFilter.length > 0 &&
+			! this.currentToolFilter.includes( toolId )
+		) {
+			log.warn( `Tool ${ toolId } blocked by active bundle filter` );
+			return {
+				success: false,
+				error: `Tool "${ toolId }" is not available in the current bundle. Available tools: ${ this.currentToolFilter.join(
+					', '
+				) }`,
+			};
+		}
+
 		const tool = this.toolRegistry.get( toolId );
 
 		if ( ! tool ) {
@@ -792,7 +816,15 @@ class ReactAgent {
 	 * @return {string} System prompt with JSON instructions
 	 */
 	buildSystemPromptPromptBased() {
-		const tools = this.toolRegistry.getAll();
+		let tools = this.toolRegistry.getAll();
+
+		// Filter tools when a bundle is active
+		if ( this.currentToolFilter && this.currentToolFilter.length > 0 ) {
+			tools = tools.filter( ( t ) =>
+				this.currentToolFilter.includes( t.id )
+			);
+		}
+
 		const toolsList = tools
 			.map( ( t ) => `- ${ t.id }: ${ t.description || t.label || '' }` )
 			.join( '\n' );
@@ -824,8 +856,10 @@ User: "list plugins"
 
 User: "what is a transient?"
 {"action": "final_answer", "content": "A transient is temporary cached data in WordPress..."}${
-			this.config.disableThinking ? '\n\n/nothink' : ''
-		}`;
+			this.currentToolFilter && this.currentToolFilter.length > 0
+				? '\n\nIMPORTANT: The user has selected a specific tool bundle. You MUST use the available tools to answer. Do not use final_answer without calling a tool first.'
+				: ''
+		}${ this.config.disableThinking ? '\n\n/nothink' : '' }`;
 	}
 }
 

--- a/src/extensions/styles/admin-sidebar.scss
+++ b/src/extensions/styles/admin-sidebar.scss
@@ -174,12 +174,32 @@
 		padding: 10px;
 		flex-shrink: 0;
 		border-top: 1px solid #c3c4c7;
+	}
+
+	.wp-agentic-admin-input-wrapper {
+		border-radius: 6px;
 
 		.wp-agentic-admin-input {
 			min-height: 44px;
 			font-size: 13px;
 			padding: 8px 10px;
 		}
+	}
+
+	// Input toolbar — compact
+	.wp-agentic-admin-input-toolbar {
+		padding: 2px 6px 6px;
+	}
+
+	.wp-agentic-admin-bundle-trigger,
+	.wp-agentic-admin-websearch-toggle,
+	.wp-agentic-admin-send-button {
+		width: 28px;
+		height: 28px;
+	}
+
+	.wp-agentic-admin-bundle-pill {
+		font-size: 12px;
 	}
 
 	// Stop generation — also fixed at bottom

--- a/src/extensions/styles/editor-sidebar.scss
+++ b/src/extensions/styles/editor-sidebar.scss
@@ -94,12 +94,32 @@
 		padding: 10px;
 		flex-shrink: 0;
 		border-top: 1px solid #c3c4c7;
+	}
+
+	.wp-agentic-admin-input-wrapper {
+		border-radius: 6px;
 
 		.wp-agentic-admin-input {
 			min-height: 44px;
 			font-size: 13px;
 			padding: 8px 10px;
 		}
+	}
+
+	// Input toolbar — compact
+	.wp-agentic-admin-input-toolbar {
+		padding: 2px 6px 6px;
+	}
+
+	.wp-agentic-admin-bundle-trigger,
+	.wp-agentic-admin-websearch-toggle,
+	.wp-agentic-admin-send-button {
+		width: 28px;
+		height: 28px;
+	}
+
+	.wp-agentic-admin-bundle-pill {
+		font-size: 12px;
 	}
 
 	// Stop generation bar — also fixed at bottom

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -220,47 +220,304 @@
 .wp-agentic-admin-input-area {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
 	padding: 15px;
 	border-top: 1px solid #c3c4c7;
 	background: #fff;
+}
+
+// Unified wrapper — single border around textarea + toolbar
+.wp-agentic-admin-input-wrapper {
+	border: 1px solid #c3c4c7;
+	border-radius: 8px;
+	background: #fff;
+	overflow: hidden;
+	transition: border-color 0.2s ease;
+
+	&:focus-within {
+		border-color: #2271b1;
+		box-shadow: 0 0 0 1px #2271b1;
+	}
+
+	&--disabled {
+		background: #f6f7f7;
+		opacity: 0.6;
+	}
 
 	.wp-agentic-admin-input {
+		display: block;
 		width: 100%;
-		resize: vertical;
+		resize: none;
 		min-height: 60px;
 		max-height: 200px;
 		padding: 12px;
-		border: 1px solid #8c8f94;
-		border-radius: 4px;
+		border: none;
+		border-radius: 0;
+		background: transparent;
 		font-size: 14px;
 		line-height: 1.5;
-		transition:
-			border-color 0.2s ease,
-			box-shadow 0.2s ease;
+		outline: none;
+		box-shadow: none;
+		-webkit-appearance: none;
 
 		&:focus {
-			border-color: #2271b1;
-			box-shadow: 0 0 0 1px #2271b1;
 			outline: none;
+			box-shadow: none;
 		}
 
 		&:disabled {
-			background: #f6f7f7;
 			cursor: not-allowed;
-			opacity: 0.6;
 		}
 
 		&::placeholder {
 			color: #a0a0a0;
 		}
 	}
+}
 
-	.wp-agentic-admin-input-hint {
+.wp-agentic-admin-input-hint {
+	font-size: 12px;
+	color: #6e6e6e;
+	padding: 0 4px;
+	text-align: left;
+}
+
+// Input Toolbar (below textarea, inside unified wrapper)
+.wp-agentic-admin-input-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 4px 8px 8px;
+
+	&__left {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	&__right {
+		display: flex;
+		align-items: center;
+	}
+}
+
+// Web search toggle
+.wp-agentic-admin-websearch-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 34px;
+	height: 34px;
+	border: none;
+	background: none;
+	color: #50575e;
+	cursor: pointer;
+	border-radius: 6px;
+	padding: 0;
+	margin-right: 4px;
+	position: relative;
+	transition: color 0.15s ease;
+
+	// CSS tooltip — stays visible on hover regardless of clicks
+	&::before {
+		content: attr(data-tooltip);
+		position: absolute;
+		bottom: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		padding: 4px 8px;
+		background: #1d2327;
+		color: #fff;
 		font-size: 12px;
-		color: #6e6e6e;
-		padding: 0 4px;
+		font-weight: 400;
+		white-space: nowrap;
+		border-radius: 4px;
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 0.1s ease;
+		margin-bottom: 6px;
+	}
+
+	&:hover::before {
+		opacity: 1;
+	}
+
+	&:hover {
+		background: #f0f0f1;
+		color: #2271b1;
+	}
+
+	&--active {
+		color: #2271b1;
+
+		svg {
+			fill: #2271b1;
+		}
+	}
+
+	&:disabled {
+		color: #a0a0a0;
+		cursor: not-allowed;
+
+		&:hover {
+			background: none;
+			color: #a0a0a0;
+		}
+
+		&:hover::before {
+			opacity: 0;
+		}
+	}
+}
+
+// Bundle trigger button (plus icon)
+.wp-agentic-admin-bundle-trigger {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 34px;
+	height: 34px;
+	border: none;
+	background: none;
+	color: #50575e;
+	cursor: pointer;
+	border-radius: 6px;
+	padding: 0;
+	transition: color 0.15s ease, background 0.15s ease;
+
+	&:hover {
+		background: #f0f0f1;
+		color: #2271b1;
+	}
+
+	&--active {
+		background: #f0f0f1;
+		color: #2271b1;
+	}
+
+	&:disabled {
+		color: #a0a0a0;
+		cursor: not-allowed;
+
+		&:hover {
+			background: none;
+			color: #a0a0a0;
+		}
+	}
+}
+
+// Send button (arrow icon) — fades in when text is present
+.wp-agentic-admin-send-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 34px;
+	height: 34px;
+	border: none;
+	background: #2271b1;
+	color: #fff;
+	cursor: pointer;
+	border-radius: 6px;
+	padding: 0;
+	opacity: 1;
+	transform: scale(1);
+	transition:
+		background 0.15s ease,
+		opacity 0.2s ease,
+		transform 0.2s ease;
+
+	svg {
+		fill: #fff;
+	}
+
+	&:hover {
+		background: #135e96;
+	}
+
+	&:disabled {
+		opacity: 0;
+		transform: scale(0.8);
+		pointer-events: none;
+	}
+}
+
+// Bundle pill — label + dismiss
+.wp-agentic-admin-bundle-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	background: none;
+	border: none;
+	padding: 4px 0;
+	font-size: 13px;
+	color: #2271b1;
+	line-height: 1;
+
+	&__label {
+		white-space: nowrap;
+		font-weight: 600;
+	}
+
+	&__remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		border: none;
+		background: none;
+		color: #50575e;
+		cursor: pointer;
+		padding: 0;
+		border-radius: 50%;
+		transition: color 0.15s ease, background 0.15s ease;
+
+		&:hover {
+			background: #f0f0f1;
+			color: #d63638;
+		}
+	}
+}
+
+// Bundle dropdown menu
+.wp-agentic-admin-bundle-menu {
+	min-width: 200px;
+	padding: 4px 0;
+
+	&__item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 8px 12px;
+		border: none;
+		background: none;
+		cursor: pointer;
+		font-size: 13px;
+		color: #1d2327;
 		text-align: left;
+		transition: background 0.1s ease;
+
+		&:hover {
+			background: #f0f0f1;
+		}
+
+		&--selected {
+			background: #f0f6fc;
+		}
+
+		svg {
+			fill: #2271b1;
+			flex-shrink: 0;
+		}
+	}
+
+	&__label {
+		flex: 1;
+	}
+
+	&__count {
+		font-size: 11px;
+		color: #6e6e6e;
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a prompt UX system with ability bundle selection (plus icon), web search toggle (globe icon), and a send button to the chat input. Users can constrain the LLM to curated tool sets (Security, Performance, Troubleshooting, etc.) and optionally enable web search as a pre-step before any tool routing.

## Type

- [ ] New ability
- [ ] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

  1. Load the AI model and open the chat interface
  2. Click the + icon in the input toolbar — verify 6 bundles appear (Plugins & Themes, Performance, Security,
  Troubleshooting, Content & Users, Site Overview)
  3. Select "Security" — verify the pill appears with the label and an X to dismiss
  4. Type a message and send — verify in console logs that only the 5 security tools are sent to the ReAct agent
  5. Click X on the pill to remove the bundle — verify next message uses all tools
  6. Click the globe icon to enable web search — verify tooltip shows "Web Search: active"
  7. Send a message with web search on — verify a web search runs first, then normal routing continues with results as
  context
  8. Combine both: select a bundle + enable web search — verify search runs first, then bundle-constrained ReAct follows
  9. Verify the send arrow button only appears when text is typed (fades in), and clicking it sends the message
  10. Test in the admin sidebar — verify compact sizing works

## Screenshots (if UI changes)

<img width="600" height="" alt="CleanShot 2026-03-21 at 12 49 13@2x" src="https://github.com/user-attachments/assets/46c2eeda-fa55-432e-ae8f-66c396b83f07" />

Resolves #127 