### PR TITLE
feat: feedback-upload — collect fine-tuning data from opted-in users (#75)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # S3-compatible endpoint for anonymous feedback uploads.
-# Set to the full bucket URL (e.g. http://localhost:9000/wp-agentic-feedback).
-# Empty (default) = upload is disabled; ratings are stored locally only.
+# Overrides the production bucket (https://wp-agentic-feedback.ams3.digitaloceanspaces.com).
+# Use this for local MinIO dev: http://localhost:9000/wp-agentic-feedback
+# Set to empty string to disable uploads entirely.
 FEEDBACK_S3_ENDPOINT=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# S3-compatible endpoint for anonymous feedback uploads.
+# Set to the full bucket URL (e.g. http://localhost:9000/wp-agentic-feedback).
+# Empty (default) = upload is disabled; ratings are stored locally only.
+FEEDBACK_S3_ENDPOINT=

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ build-extensions/
 hackathon-teasers.md
 hackathon-todo.md
 .direnv
+minio-data/
+feedback-export/
+.env

--- a/docs/FEEDBACK-DEV.md
+++ b/docs/FEEDBACK-DEV.md
@@ -152,10 +152,11 @@ docker run --rm \
   minio/mc cors set local/wp-agentic-feedback /tmp/cors.xml
 ```
 
-## Building with feedback enabled
+## Building with a local MinIO endpoint
 
-Set `FEEDBACK_S3_ENDPOINT` before building. When this variable is empty (the
-default), the opt-in UI is hidden entirely — no banner, no thumbs buttons.
+By default, production builds upload to the shared DigitalOcean Spaces bucket.
+To redirect uploads to your local MinIO instance instead, set
+`FEEDBACK_S3_ENDPOINT` before building:
 
 ```bash
 # .env  (gitignored — never commit this file)
@@ -170,8 +171,8 @@ npm run build
 npm run watch
 ```
 
-The endpoint URL is inlined at build time by dotenv-webpack. Changing `.env`
-requires a rebuild.
+The endpoint URL is inlined at build time. Changing `.env` requires a rebuild.
+Set `FEEDBACK_S3_ENDPOINT=` (empty) to disable uploads entirely.
 
 ## Verifying uploads
 

--- a/docs/FEEDBACK-DEV.md
+++ b/docs/FEEDBACK-DEV.md
@@ -1,0 +1,214 @@
+# Feedback Upload — Local Development Guide
+
+Opted-in ratings are PUT to an S3-compatible bucket so they can be used for
+future fine-tuning runs. This guide explains how to run a local MinIO bucket
+and wire it up to the plugin.
+
+## Quick start
+
+```bash
+npm run playground:feedback-dev
+```
+
+This single command:
+
+1. Starts MinIO (native binary or Docker — auto-detected)
+2. Creates the `wp-agentic-feedback` bucket with an anonymous write policy and CORS
+3. Builds the plugin with `FEEDBACK_S3_ENDPOINT` baked in
+4. Starts the WordPress Playground
+
+Stop everything with **Ctrl-C**.
+
+## Prerequisites — pick one
+
+### Option A: Nix / direnv (recommended)
+
+`minio` and `mc` are provided by the project's Nix flake.
+After `direnv allow` they are on your `PATH` automatically — no extra steps.
+
+```bash
+direnv allow   # first time only
+npm run playground:feedback-dev
+```
+
+### Option B: Docker
+
+Any system with Docker installed works. The script pulls `minio/minio` and
+`minio/mc` automatically.
+
+```bash
+npm run playground:feedback-dev
+```
+
+No other tools required. The script detects Docker when the native binaries
+are absent.
+
+## Manual setup (without the npm script)
+
+If you want to run MinIO independently — e.g. during active development with
+`npm run watch` — follow the steps below.
+
+### With Nix / native binaries
+
+```bash
+# Start MinIO — data stored in ./minio-data (gitignored)
+minio server ./minio-data --console-address ":9001"
+```
+
+In a second terminal, create and configure the bucket (run once):
+
+```bash
+MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+  mc mb --ignore-existing local/wp-agentic-feedback
+
+# anonymous policy (JSON file)
+cat > /tmp/policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::wp-agentic-feedback/*"
+    }
+  ]
+}
+EOF
+MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+  mc anonymous set-json /tmp/policy.json local/wp-agentic-feedback
+
+# CORS (XML file) — required for browser PUT requests
+cat > /tmp/cors.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>*</AllowedOrigin>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedHeader>Content-Type</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>
+EOF
+MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+  mc cors set local/wp-agentic-feedback /tmp/cors.xml
+```
+
+### With Docker
+
+```bash
+# Start MinIO
+docker run -d \
+  --name wp-agentic-minio \
+  -p 9000:9000 -p 9001:9001 \
+  -v "$(pwd)/minio-data:/data" \
+  -e MINIO_ROOT_USER=minioadmin \
+  -e MINIO_ROOT_PASSWORD=minioadmin \
+  minio/minio server /data --console-address ":9001"
+
+# Write config files to the host
+cat > /tmp/policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::wp-agentic-feedback/*"
+    }
+  ]
+}
+EOF
+
+cat > /tmp/cors.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>*</AllowedOrigin>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedHeader>Content-Type</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>
+EOF
+
+# Create bucket
+docker run --rm \
+  --network container:wp-agentic-minio \
+  -e MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+  minio/mc mb --ignore-existing local/wp-agentic-feedback
+
+# Apply anonymous policy
+docker run --rm \
+  --network container:wp-agentic-minio \
+  -e MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+  -v /tmp/policy.json:/tmp/policy.json:ro \
+  minio/mc anonymous set-json /tmp/policy.json local/wp-agentic-feedback
+
+# Apply CORS
+docker run --rm \
+  --network container:wp-agentic-minio \
+  -e MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+  -v /tmp/cors.xml:/tmp/cors.xml:ro \
+  minio/mc cors set local/wp-agentic-feedback /tmp/cors.xml
+```
+
+## Building with feedback enabled
+
+Set `FEEDBACK_S3_ENDPOINT` before building. When this variable is empty (the
+default), the opt-in UI is hidden entirely — no banner, no thumbs buttons.
+
+```bash
+# .env  (gitignored — never commit this file)
+FEEDBACK_S3_ENDPOINT=http://localhost:9000/wp-agentic-feedback
+```
+
+Then build:
+
+```bash
+npm run build
+# or during active development:
+npm run watch
+```
+
+The endpoint URL is inlined at build time by dotenv-webpack. Changing `.env`
+requires a rebuild.
+
+## Verifying uploads
+
+Rate a response in the chat, then export all feedback files to `feedback-export/`
+(gitignored):
+
+```bash
+npm run export:feedback
+```
+
+Pass a custom destination as needed:
+
+```bash
+npm run export:feedback -- ./my-export
+```
+
+Each file is a single labelled turn:
+
+```json
+{
+  "messageId": "...",
+  "sessionId": "...",
+  "abilityIds": ["wp-agentic-admin/list-plugins"],
+  "rating": "up",
+  "comment": "",
+  "timestamp": "2026-03-20T12:00:00.000Z",
+  "model": "Qwen3-1.7B-q4f16_1-MLC",
+  "conversation": [
+    { "role": "user",      "content": "Check the error log first." },
+    { "role": "assistant", "content": "The log shows a PHP warning in ..." },
+    { "role": "user",      "content": "How do I deactivate the Yoast plugin?" },
+    { "role": "assistant", "content": "I'll deactivate it for you. ..." }
+  ]
+}
+```
+
+## MinIO web console
+
+Available at <http://localhost:9001> (credentials: `minioadmin` / `minioadmin`).
+MinIO is **never** started automatically — start it manually when you need it.

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             php83
             php83Packages.composer
             minio
+            minio-client
           ];
         };
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "lint:php:fix": "composer lint:fix",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:php",
     "lint:fix": "npm run lint:js:fix && npm run lint:css:fix && npm run lint:php:fix",
-    "playground": "npm run build && npx @wp-now/wp-now start --php=8.3 --blueprint=.playground/blueprint.json"
+    "playground": "npm run build && npx @wp-now/wp-now start --php=8.3 --blueprint=.playground/blueprint.json",
+    "playground:feedback-dev": "bash scripts/feedback-dev.sh",
+    "export:feedback": "bash scripts/export-feedback.sh"
   },
   "devDependencies": {
     "@wordpress/scripts": "^31.0.0",

--- a/scripts/export-feedback.sh
+++ b/scripts/export-feedback.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Export all feedback JSONs from MinIO to a local folder.
+#
+# Usage:
+#   npm run export:feedback              # → feedback-export/
+#   npm run export:feedback -- ./out     # → ./out/
+set -euo pipefail
+
+DEST="${1:-feedback-export}"
+BUCKET="wp-agentic-feedback"
+
+mkdir -p "$DEST"
+
+MC_HOST_local=http://minioadmin:minioadmin@localhost:9000 \
+	mc mirror --overwrite "local/${BUCKET}/feedback/" "${DEST}/"
+
+echo "Exported to ${DEST}/"
+find "$DEST" -name "*.json" | wc -l | xargs -I{} echo "{} file(s) exported."

--- a/scripts/feedback-dev.sh
+++ b/scripts/feedback-dev.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# feedback-dev.sh — starts MinIO + playground for feedback-upload development
+#
+# Supports two modes:
+#   Nix/native  — uses `minio` + `mc` binaries (provided by the Nix flake)
+#   Docker      — uses the minio/minio and minio/mc Docker images
+#
+# Usage: npm run playground:feedback-dev
+set -euo pipefail
+
+BUCKET="wp-agentic-feedback"
+MINIO_PORT=9000
+CONSOLE_PORT=9001
+ENDPOINT="http://localhost:${MINIO_PORT}/${BUCKET}"
+CONTAINER_NAME="wp-agentic-minio"
+
+# ── Detect runtime ────────────────────────────────────────────────────────────
+if command -v minio >/dev/null 2>&1 && command -v mc >/dev/null 2>&1; then
+	USE_DOCKER=false
+	echo "Using native minio + mc"
+elif command -v docker >/dev/null 2>&1; then
+	USE_DOCKER=true
+	echo "Using Docker (minio/minio + minio/mc images)"
+else
+	echo "Error: neither 'minio'+'mc' (Nix) nor 'docker' found."
+	echo "See docs/FEEDBACK-DEV.md for setup instructions."
+	exit 1
+fi
+
+# ── Cleanup on exit ───────────────────────────────────────────────────────────
+MINIO_PID=""
+MINIO_LOG="minio-data/minio.log"
+cleanup() {
+	echo ""
+	echo "Shutting down MinIO..."
+	if [ "$USE_DOCKER" = true ]; then
+		docker stop "$CONTAINER_NAME" 2>/dev/null || true
+		docker rm   "$CONTAINER_NAME" 2>/dev/null || true
+	elif [ -n "$MINIO_PID" ]; then
+		kill "$MINIO_PID" 2>/dev/null || true
+		wait "$MINIO_PID" 2>/dev/null || true  # wait for it to actually exit
+	fi
+}
+trap cleanup EXIT INT TERM
+
+# ── Start MinIO ───────────────────────────────────────────────────────────────
+mkdir -p minio-data
+
+if [ "$USE_DOCKER" = true ]; then
+	# Remove stale container if present
+	docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+	docker run -d \
+		--name "$CONTAINER_NAME" \
+		-p "${MINIO_PORT}:9000" \
+		-p "${CONSOLE_PORT}:9001" \
+		-v "$(pwd)/minio-data:/data" \
+		-e MINIO_ROOT_USER=minioadmin \
+		-e MINIO_ROOT_PASSWORD=minioadmin \
+		minio/minio server /data --console-address ":9001"
+else
+	# Redirect output to log file so it doesn't interleave with script output
+	minio server ./minio-data --console-address ":${CONSOLE_PORT}" \
+		>"${MINIO_LOG}" 2>&1 &
+	MINIO_PID=$!
+fi
+
+# ── Wait for MinIO to be ready ────────────────────────────────────────────────
+echo "Waiting for MinIO on :${MINIO_PORT}..."
+for i in $(seq 1 30); do
+	if curl -sf "http://localhost:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1; then
+		echo "MinIO is ready."
+		break
+	fi
+	if [ "$i" -eq 30 ]; then
+		echo "Error: MinIO did not start in time."
+		exit 1
+	fi
+	sleep 1
+done
+
+# ── mc wrapper ────────────────────────────────────────────────────────────────
+# Native mode  : runs mc directly with MC_HOST_local env var.
+# Docker mode  : runs minio/mc container sharing the minio container's network
+#                namespace (so localhost:9000 reaches minio). Any argument that
+#                is an existing local file is auto-mounted into the container.
+run_mc() {
+	if [ "$USE_DOCKER" = true ]; then
+		local args=() mounts=()
+		for arg in "$@"; do
+			if [ -f "$arg" ]; then
+				local cpath="/tmp/mc-$(basename "$arg")"
+				mounts+=( -v "${arg}:${cpath}:ro" )
+				args+=( "$cpath" )
+			else
+				args+=( "$arg" )
+			fi
+		done
+		docker run --rm -i \
+			--network "container:${CONTAINER_NAME}" \
+			-e "MC_HOST_local=http://minioadmin:minioadmin@localhost:9000" \
+			"${mounts[@]+"${mounts[@]}"}" \
+			minio/mc "${args[@]}"
+	else
+		MC_HOST_local="http://minioadmin:minioadmin@localhost:${MINIO_PORT}" \
+			mc "$@"
+	fi
+}
+
+# ── Configure bucket (idempotent) ─────────────────────────────────────────────
+echo "Configuring bucket '${BUCKET}'..."
+
+# Write config to temp files — mc doesn't support /dev/stdin as a path argument
+POLICY_FILE=$(mktemp /tmp/minio-policy-XXXXXX.json)
+CORS_FILE=$(mktemp /tmp/minio-cors-XXXXXX.xml)
+trap 'rm -f "$POLICY_FILE" "$CORS_FILE"; cleanup' EXIT INT TERM
+
+cat > "$POLICY_FILE" <<'POLICY'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::wp-agentic-feedback/*"
+    }
+  ]
+}
+POLICY
+
+cat > "$CORS_FILE" <<'CORS'
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>*</AllowedOrigin>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedHeader>Content-Type</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>
+CORS
+
+run_mc mb --ignore-existing "local/${BUCKET}"
+run_mc anonymous set-json "$POLICY_FILE" "local/${BUCKET}"
+
+# CORS: mc cors set takes a file path (XML). Silently skipped if unavailable.
+if run_mc cors set "local/${BUCKET}" "$CORS_FILE" 2>/dev/null; then
+	echo "CORS configured."
+else
+	echo "Note: CORS not configured automatically — set it via the MinIO console at http://localhost:${CONSOLE_PORT} if the browser blocks PUT requests."
+fi
+
+echo "Bucket ready: ${ENDPOINT}"
+echo "Console:      http://localhost:${CONSOLE_PORT}  (minioadmin / minioadmin)"
+
+# ── Start playground (build + wp-now) with endpoint baked in ─────────────────
+echo ""
+echo "FEEDBACK_S3_ENDPOINT=${ENDPOINT}"
+echo "Starting playground. Ctrl-C to stop everything."
+echo "(MinIO log: ${MINIO_LOG})"
+FEEDBACK_S3_ENDPOINT="${ENDPOINT}" npm run playground

--- a/src/extensions/App.jsx
+++ b/src/extensions/App.jsx
@@ -8,6 +8,7 @@ import { TabPanel, Notice } from '@wordpress/components';
 import ChatContainer from './components/ChatContainer';
 import AbilityBrowser from './components/AbilityBrowser';
 import FeedbackTab from './components/FeedbackTab';
+import { FEEDBACK_UPLOAD_ENABLED } from './services/feedback';
 import ModelStatus from './components/ModelStatus';
 import WebGPUFallback from './components/WebGPUFallback';
 import modelLoader from './services/model-loader';
@@ -174,11 +175,15 @@ const App = () => {
 			title: 'Abilities',
 			className: 'wp-agentic-admin-tab',
 		},
-		{
-			name: 'feedback',
-			title: 'Feedback',
-			className: 'wp-agentic-admin-tab',
-		},
+		...( FEEDBACK_UPLOAD_ENABLED
+			? [
+					{
+						name: 'feedback',
+						title: 'Feedback',
+						className: 'wp-agentic-admin-tab',
+					},
+			  ]
+			: [] ),
 	];
 
 	/**

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -44,6 +44,7 @@ import {
 	getFeedbackOptIn,
 	setFeedbackOptIn,
 	saveFeedback,
+	FEEDBACK_UPLOAD_ENABLED,
 } from '../services/feedback';
 import { createLogger } from '../utils/logger';
 
@@ -444,11 +445,43 @@ const ChatContainer = ( {
 				.map( ( m ) => m.abilityName )
 				.filter( Boolean );
 
+			// Full conversation up to and including the rated message
+			const msgIdx = messages.findIndex( ( m ) => m.id === messageId );
+			const conversation =
+				msgIdx !== -1
+					? messages
+							.slice( 0, msgIdx + 1 )
+							.filter(
+								( m ) =>
+									m.type === 'user' || m.type === 'assistant'
+							)
+							.map( ( m ) => ( {
+								role: m.type,
+								content: m.content,
+							} ) )
+					: [];
+
+			const model =
+				modelLoader.getModelId() ||
+				window.wpAgenticAdmin?.settings?.modelId ||
+				'';
+
+			const systemPrompt = chatOrchestrator.getSystemPrompt?.() || '';
+			const { temperature, maxTokens } =
+				chatOrchestrator.llmOptions || {};
+
 			saveFeedback( {
 				messageId,
 				sessionId: sessionRef.current?.id || '',
 				abilityIds,
 				rating,
+				systemPrompt,
+				conversation,
+				model,
+				generationConfig: {
+					temperature: temperature ?? null,
+					maxTokens: maxTokens ?? null,
+				},
 			} );
 		},
 		[ messages ]
@@ -616,17 +649,21 @@ const ChatContainer = ( {
 
 			<MessageList
 				messages={ displayMessages }
-				feedbackOptIn={ feedbackOptIn === true }
+				feedbackOptIn={
+					FEEDBACK_UPLOAD_ENABLED && feedbackOptIn === true
+				}
 				onFeedback={ handleFeedback }
 			/>
 
 			{ /* Feedback opt-in banner — shown once, only after the first real exchange */ }
-			{ feedbackOptIn === null && messages.length > 1 && (
-				<FeedbackOptInBanner
-					onAccept={ handleFeedbackAccept }
-					onDecline={ handleFeedbackDecline }
-				/>
-			) }
+			{ FEEDBACK_UPLOAD_ENABLED &&
+				feedbackOptIn === null &&
+				messages.length > 1 && (
+					<FeedbackOptInBanner
+						onAccept={ handleFeedbackAccept }
+						onDecline={ handleFeedbackDecline }
+					/>
+				) }
 
 			{ /* Context usage warning */ }
 			{ contextUsage?.isHigh && (

--- a/src/extensions/components/FeedbackOptInBanner.jsx
+++ b/src/extensions/components/FeedbackOptInBanner.jsx
@@ -2,7 +2,8 @@
  * FeedbackOptInBanner Component
  *
  * Shown once when the user has not yet decided whether to enable response feedback.
- * All collected feedback stays in localStorage — nothing leaves the browser.
+ * Opted-in ratings (including the conversation turn) are uploaded anonymously
+ * to help improve the model. No PII is included.
  *
  */
 
@@ -37,8 +38,9 @@ const FeedbackOptInBanner = ( { onAccept, onDecline } ) => {
 				<p className="agentic-feedback-banner__text">
 					Would you like to rate responses with a thumbs up or down?{ ' ' }
 					<span className="agentic-feedback-banner__note">
-						Feedback stays in your browser — nothing is sent
-						externally.
+						Opted-in ratings (including the conversation turn) are
+						uploaded anonymously to help improve the model. No
+						personal information is included.
 					</span>
 				</p>
 			</div>

--- a/src/extensions/components/FeedbackTab.jsx
+++ b/src/extensions/components/FeedbackTab.jsx
@@ -12,6 +12,7 @@ import {
 	getFeedbackOptIn,
 	setFeedbackOptIn,
 	getAllFeedback,
+	FEEDBACK_UPLOAD_ENABLED,
 } from '../services/feedback';
 
 /**
@@ -73,58 +74,74 @@ const FeedbackTab = () => {
 				</h3>
 				<p className="wp-agentic-feedback__intro">
 					Rate AI responses with a thumbs up or down after each reply.
-					Feedback helps you track where the assistant performs well
-					and where it struggles — entirely within your browser.{ ' ' }
-					<strong>No data is ever sent to external servers.</strong>
+					Opted-in ratings — including the conversation turn — are
+					uploaded anonymously to help improve the local model. No
+					personal information is included.
 				</p>
 			</div>
 
-			{ /* ── Opt-in toggle card ── */ }
-			<div className="wp-agentic-feedback__card">
-				<div className="wp-agentic-feedback__card-body">
-					<div className="wp-agentic-feedback__toggle-row">
-						<div className="wp-agentic-feedback__toggle-info">
-							<span className="wp-agentic-feedback__toggle-title">
-								Enable response ratings
-							</span>
-							<span className="wp-agentic-feedback__toggle-desc">
-								Shows 👍 / 👎 buttons below each assistant
-								reply.
-							</span>
+			{ /* ── Opt-in toggle card — only shown when upload endpoint is configured ── */ }
+			{ FEEDBACK_UPLOAD_ENABLED ? (
+				<div className="wp-agentic-feedback__card">
+					<div className="wp-agentic-feedback__card-body">
+						<div className="wp-agentic-feedback__toggle-row">
+							<div className="wp-agentic-feedback__toggle-info">
+								<span className="wp-agentic-feedback__toggle-title">
+									Enable response ratings
+								</span>
+								<span className="wp-agentic-feedback__toggle-desc">
+									Shows 👍 / 👎 buttons below each assistant
+									reply.
+								</span>
+							</div>
+							<button
+								type="button"
+								className={ `wp-agentic-feedback__toggle ${
+									optIn
+										? 'wp-agentic-feedback__toggle--on'
+										: ''
+								}` }
+								onClick={ () => handleToggle( ! optIn ) }
+								disabled={ saving }
+								aria-pressed={ !! optIn }
+								aria-label="Enable response ratings"
+							>
+								<span className="wp-agentic-feedback__toggle-knob" />
+							</button>
 						</div>
-						<button
-							type="button"
-							className={ `wp-agentic-feedback__toggle ${
-								optIn ? 'wp-agentic-feedback__toggle--on' : ''
-							}` }
-							onClick={ () => handleToggle( ! optIn ) }
-							disabled={ saving }
-							aria-pressed={ !! optIn }
-							aria-label="Enable response ratings"
-						>
-							<span className="wp-agentic-feedback__toggle-knob" />
-						</button>
-					</div>
 
-					<p
-						className={ `wp-agentic-feedback__status ${
-							optIn
-								? 'wp-agentic-feedback__status--on'
-								: 'wp-agentic-feedback__status--off'
-						}` }
-					>
-						{ /* eslint-disable-next-line no-nested-ternary -- clear three-state status message */ }
-						{ saving
-							? 'Saving…'
-							: optIn
-							? 'Ratings are enabled. Thumbs icons appear on each assistant response.'
-							: 'Ratings are disabled. Enable to start collecting response feedback.' }
-					</p>
+						<p
+							className={ `wp-agentic-feedback__status ${
+								optIn
+									? 'wp-agentic-feedback__status--on'
+									: 'wp-agentic-feedback__status--off'
+							}` }
+						>
+							{ /* eslint-disable-next-line no-nested-ternary -- clear three-state status message */ }
+							{ saving
+								? 'Saving…'
+								: optIn
+								? 'Ratings are enabled. Thumbs icons appear on each assistant response.'
+								: 'Ratings are disabled. Enable to start collecting response feedback.' }
+						</p>
+					</div>
 				</div>
-			</div>
+			) : (
+				<div className="wp-agentic-feedback__card">
+					<div className="wp-agentic-feedback__card-body">
+						<p className="wp-agentic-feedback__status wp-agentic-feedback__status--off">
+							Feedback collection is not configured in this build.
+							Set <code>FEEDBACK_S3_ENDPOINT</code> in{ ' ' }
+							<code>.env</code> and rebuild to enable ratings. See{ ' ' }
+							<code>docs/FEEDBACK-DEV.md</code> for setup
+							instructions.
+						</p>
+					</div>
+				</div>
+			) }
 
 			{ /* ── Stats ── */ }
-			{ optIn && (
+			{ FEEDBACK_UPLOAD_ENABLED && optIn && (
 				<div className="wp-agentic-feedback__card">
 					<h4 className="wp-agentic-feedback__card-title">
 						Collected ratings
@@ -174,9 +191,11 @@ const FeedbackTab = () => {
 					<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
 				</svg>
 				<span>
-					Ratings are stored only in your browser&apos;s local
-					storage. They are never transmitted to Pluginslab,
-					WordPress.org, or any third party.
+					Ratings are saved in your browser. When opted in, each
+					rating (including the conversation turn) is also uploaded
+					anonymously to help fine-tune the local model. No personal
+					information — names, emails, or site URLs — is ever
+					included.
 				</span>
 			</div>
 		</div>

--- a/src/extensions/services/feedback.js
+++ b/src/extensions/services/feedback.js
@@ -5,8 +5,10 @@
  *
  * Opt-in preference is persisted on the server (WordPress options) via the
  * wp-agentic-admin/v1/settings REST endpoint, and cached in localStorage for
- * synchronous reads. Feedback ratings are stored in localStorage only —
- * nothing leaves the browser.
+ * synchronous reads. Feedback ratings are stored in localStorage. When
+ * FEEDBACK_S3_ENDPOINT is configured at build time and the user has opted in,
+ * each rating (including the conversation turn) is also uploaded anonymously
+ * to an S3-compatible bucket for model fine-tuning.
  *
  */
 
@@ -16,6 +18,15 @@ const log = createLogger( 'Feedback' );
 
 const OPTIN_CACHE_KEY = 'wp-agentic-admin-feedback-optin';
 const FEEDBACK_KEY = 'wp-agentic-admin-feedback';
+
+// S3 endpoint inlined at build time via dotenv-webpack. Empty string = disabled.
+const FEEDBACK_S3_ENDPOINT = process.env.FEEDBACK_S3_ENDPOINT || '';
+
+/**
+ * Whether feedback collection is enabled at build time.
+ * False when FEEDBACK_S3_ENDPOINT was not set — the opt-in UI is hidden.
+ */
+export const FEEDBACK_UPLOAD_ENABLED = Boolean( FEEDBACK_S3_ENDPOINT );
 
 // ─── Opt-in ──────────────────────────────────────────────────────────────────
 
@@ -100,22 +111,59 @@ export const setFeedbackOptIn = async ( optIn ) => {
 // ─── Feedback data ───────────────────────────────────────────────────────────
 
 /**
- * Save a feedback entry to localStorage.
+ * Save a feedback entry to localStorage and optionally upload to S3.
  *
- * @param {Object} entry            - Feedback entry
- * @param {string} entry.messageId  - ID of the rated assistant message
- * @param {string} entry.sessionId  - Chat session ID
- * @param {Array}  entry.abilityIds - Abilities used in the turn
- * @param {string} entry.rating     - 'up' or 'down'
- * @param {string} [entry.comment]  - Optional free-form comment
+ * When FEEDBACK_S3_ENDPOINT is configured at build time, the entry is also
+ * PUT to `{endpoint}/feedback/{sessionId}/{messageId}.json` so it can be
+ * collected for model fine-tuning. Upload errors are silently ignored.
+ *
+ * @param {Object} entry                    - Feedback entry
+ * @param {string} entry.messageId          - ID of the rated assistant message
+ * @param {string} entry.sessionId          - Chat session ID
+ * @param {Array}  entry.abilityIds         - Abilities used in the turn
+ * @param {string} entry.rating             - 'up' or 'down'
+ * @param {string} [entry.comment]          - Optional free-form comment
+ * @param {string} [entry.systemPrompt]     - System prompt active at rating time
+ * @param {Array}  [entry.conversation]     - Full conversation up to the rated message,
+ *                                          each item `{ role: 'user'|'assistant', content: string }`
+ * @param {string} [entry.model]            - Model ID that produced the response
+ * @param {Object} [entry.generationConfig] - Generation parameters (temperature, maxTokens)
+ * @return {Promise<void>}
  */
-export const saveFeedback = ( {
+export const saveFeedback = async ( {
 	messageId,
 	sessionId,
 	abilityIds,
 	rating,
 	comment = '',
+	systemPrompt = '',
+	conversation = [],
+	model = '',
+	generationConfig = null,
 } ) => {
+	const entry = {
+		messageId,
+		sessionId,
+		abilityIds: abilityIds || [],
+		rating,
+		comment,
+		timestamp: new Date().toISOString(),
+	};
+
+	if ( systemPrompt ) {
+		entry.systemPrompt = systemPrompt;
+	}
+	if ( conversation.length > 0 ) {
+		entry.conversation = conversation;
+	}
+	if ( model ) {
+		entry.model = model;
+	}
+	if ( generationConfig ) {
+		entry.generationConfig = generationConfig;
+	}
+
+	// Persist to localStorage
 	try {
 		const existing = JSON.parse(
 			localStorage.getItem( FEEDBACK_KEY ) || '[]'
@@ -123,14 +171,6 @@ export const saveFeedback = ( {
 
 		// Update existing entry for this message, or push a new one
 		const idx = existing.findIndex( ( e ) => e.messageId === messageId );
-		const entry = {
-			messageId,
-			sessionId,
-			abilityIds: abilityIds || [],
-			rating,
-			comment,
-			timestamp: new Date().toISOString(),
-		};
 
 		if ( idx !== -1 ) {
 			existing[ idx ] = entry;
@@ -141,6 +181,22 @@ export const saveFeedback = ( {
 		localStorage.setItem( FEEDBACK_KEY, JSON.stringify( existing ) );
 	} catch {
 		// Silently ignore storage errors
+	}
+
+	// Upload to S3 if endpoint is configured (silently skip on error)
+	if ( FEEDBACK_S3_ENDPOINT ) {
+		try {
+			await fetch(
+				`${ FEEDBACK_S3_ENDPOINT }/feedback/${ sessionId }/${ messageId }.json`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify( entry ),
+				}
+			);
+		} catch {
+			// Silently ignore upload errors
+		}
 	}
 };
 

--- a/src/extensions/services/feedback.js
+++ b/src/extensions/services/feedback.js
@@ -5,10 +5,11 @@
  *
  * Opt-in preference is persisted on the server (WordPress options) via the
  * wp-agentic-admin/v1/settings REST endpoint, and cached in localStorage for
- * synchronous reads. Feedback ratings are stored in localStorage. When
- * FEEDBACK_S3_ENDPOINT is configured at build time and the user has opted in,
- * each rating (including the conversation turn) is also uploaded anonymously
- * to an S3-compatible bucket for model fine-tuning.
+ * synchronous reads. Feedback ratings are stored in localStorage. When the
+ * user has opted in, each rating (including the full conversation) is also
+ * uploaded anonymously to the production S3 bucket for model fine-tuning.
+ * Set FEEDBACK_S3_ENDPOINT at build time to override the endpoint (e.g. for
+ * local MinIO dev).
  *
  */
 
@@ -19,12 +20,15 @@ const log = createLogger( 'Feedback' );
 const OPTIN_CACHE_KEY = 'wp-agentic-admin-feedback-optin';
 const FEEDBACK_KEY = 'wp-agentic-admin-feedback';
 
-// S3 endpoint inlined at build time via dotenv-webpack. Empty string = disabled.
-const FEEDBACK_S3_ENDPOINT = process.env.FEEDBACK_S3_ENDPOINT || '';
+// Production S3 endpoint. Override at build time via FEEDBACK_S3_ENDPOINT
+// (e.g. for local MinIO dev: FEEDBACK_S3_ENDPOINT=http://localhost:9000/wp-agentic-feedback npm run build).
+const FEEDBACK_S3_ENDPOINT =
+	process.env.FEEDBACK_S3_ENDPOINT ||
+	'https://wp-agentic-feedback.ams3.digitaloceanspaces.com';
 
 /**
- * Whether feedback collection is enabled at build time.
- * False when FEEDBACK_S3_ENDPOINT was not set — the opt-in UI is hidden.
+ * Whether feedback upload is enabled. Always true in production builds;
+ * can be disabled by setting FEEDBACK_S3_ENDPOINT to an empty string at build time.
  */
 export const FEEDBACK_UPLOAD_ENABLED = Boolean( FEEDBACK_S3_ENDPOINT );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@
 
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const path = require( 'path' );
+const webpack = require( 'webpack' );
 
 module.exports = {
 	...defaultConfig,
@@ -21,7 +22,10 @@ module.exports = {
 		editor: path.resolve( __dirname, 'src/extensions/editor.js' ),
 
 		// Admin-wide chat sidebar (all wp-admin pages)
-		'admin-sidebar': path.resolve( __dirname, 'src/extensions/admin-sidebar.js' ),
+		'admin-sidebar': path.resolve(
+			__dirname,
+			'src/extensions/admin-sidebar.js'
+		),
 
 		// Service Worker - needs to be a self-contained bundle
 		sw: {
@@ -34,6 +38,17 @@ module.exports = {
 		...defaultConfig.output,
 		path: path.resolve( __dirname, 'build-extensions' ),
 	},
+
+	// Always inline FEEDBACK_S3_ENDPOINT at build time so `process.env.*` is
+	// never a runtime reference in the browser (process is not defined there).
+	plugins: [
+		...( defaultConfig.plugins || [] ),
+		new webpack.DefinePlugin( {
+			'process.env.FEEDBACK_S3_ENDPOINT': JSON.stringify(
+				process.env.FEEDBACK_S3_ENDPOINT || ''
+			),
+		} ),
+	],
 
 	// Service Worker specific optimizations
 	optimization: {


### PR DESCRIPTION
## Summary
- Adds opt-in feedback upload: thumbs-up/down ratings (with full conversation context) are PUT anonymously to the production S3 bucket for model fine-tuning
- Uploads to `https://wp-agentic-feedback.ams3.digitaloceanspaces.com` by default — no configuration required; `FEEDBACK_S3_ENDPOINT` at build time overrides (e.g. local MinIO dev)
- Feedback payload includes: system prompt, full conversation array, model ID, generation config (temperature, maxTokens), ability IDs, and rating
- Feedback tab and opt-in banner are hidden when `FEEDBACK_UPLOAD_ENABLED` is false (i.e. endpoint set to empty string at build time)

## Changes
- `src/extensions/services/feedback.js` — async `saveFeedback()` with S3 PUT; production bucket as default endpoint; `FEEDBACK_UPLOAD_ENABLED` export
- `src/extensions/components/ChatContainer.jsx` — builds full conversation array and captures system prompt + generation config before calling `saveFeedback()`
- `src/extensions/App.jsx` — feedback tab gated on `FEEDBACK_UPLOAD_ENABLED`
- `src/extensions/components/FeedbackTab.jsx` — updated copy; "not configured" notice when disabled
- `src/extensions/components/FeedbackOptInBanner.jsx` — updated privacy copy
- `webpack.config.js` — `DefinePlugin` to inline `FEEDBACK_S3_ENDPOINT` at build time
- `scripts/feedback-dev.sh` — starts MinIO + playground for local feedback dev (native or Docker)
- `scripts/export-feedback.sh` — mirrors bucket to local folder for inspection
- `docs/FEEDBACK-DEV.md` — local dev guide (MinIO setup, export, payload format)
- `.env.example`, `.gitignore` — document and ignore local dev files

## Testing
- [ ] Unit tests pass (`npm test`)
- [ ] JS lint clean (`npm run lint:js`)
- [ ] PHP lint clean (`composer lint`)
- [ ] Manually tested in browser — opt-in banner appears, thumbs rating triggers PUT to S3
- [ ] `npm run playground:feedback-dev` starts MinIO + playground correctly
- [ ] `npm run export:feedback` mirrors feedback files locally

## Notes
- Anonymous PUT is allowed on the `feedback/*` prefix only; GET/LIST/DELETE return 403
- CORS configured for PUT with `Content-Type` from any origin
- Random seed is not captured (WebLLM doesn't expose it) — payload is sufficient for SFT but not exact reproduction