### PR TITLE
fix: action buttons not displaying in chat messages

### DIFF
--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -272,7 +272,7 @@ const ChatContainer = ( {
 	 * @return {Array} Display-formatted messages
 	 */
 	const convertMessagesToDisplay = ( sessionMessages ) => {
-		return sessionMessages.map( ( msg ) => {
+		const display = sessionMessages.map( ( msg ) => {
 			// Map session message types to display format
 			switch ( msg.type ) {
 				case MessageType.USER:
@@ -336,13 +336,12 @@ const ChatContainer = ( {
 			}
 		} );
 
-		// Attach actions from successful tool results to the next assistant message
+		// Attach actions from tool results to the next assistant message
 		for ( let i = 0; i < display.length - 1; i++ ) {
 			const curr = display[ i ];
 			const next = display[ i + 1 ];
 			if (
 				curr.type === 'ability_result' &&
-				curr.success &&
 				next.type === 'assistant' &&
 				curr.result?.actions?.length
 			) {
@@ -755,7 +754,7 @@ const ChatContainer = ( {
 				}
 				onFeedback={ handleFeedback }
 			/>
-			
+
 			{ /* Feedback opt-in banner — shown once, only after the first real exchange */ }
 			{ FEEDBACK_UPLOAD_ENABLED &&
 				feedbackOptIn === null &&

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -2521,6 +2521,7 @@
 				margin-top: 12px;
 				padding-top: 12px;
 				border-top: 1px solid #f0f0f1;
+				width: 100%;
 			}
 
 			.agentic-message__footer {
@@ -3149,6 +3150,7 @@
 	margin: 0;
 	padding: 0;
 	list-style: none;
+	width: 100%;
 
 	&__item {
 		display: flex;


### PR DESCRIPTION
## Summary
- **Fix dead code in ChatContainer**: `convertMessagesToDisplay()` returned early from `.map()`, making the action-attachment loop unreachable. Stored map result in `display` variable so actions from tool results are properly attached to assistant messages.
- **Show actions regardless of success**: Removed `curr.success &&` guard so action buttons render for both successful results and low-certainty plugin matches (candidate selection).
- **Full-width action list**: Added `width: 100%` to `.agentic-message__actions` and `.agentic-action-list` so action buttons stretch across the message area.

## Test plan
- [ ] Trigger a plugin-list ability and verify action buttons (Activate/Deactivate) appear on the assistant response
- [ ] Verify action buttons span full width of the message container
- [ ] Confirm clicking an action button executes the corresponding ability

🤖 Generated with [Claude Code](https://claude.com/claude-code)