### PR TITLE
Settings tab with GPU-based context window recommendations

### DIFF
--- a/src/extensions/App.jsx
+++ b/src/extensions/App.jsx
@@ -9,6 +9,7 @@ import ChatContainer from './components/ChatContainer';
 import AbilityBrowser from './components/AbilityBrowser';
 import PluginAbilitiesPanel from './components/PluginAbilitiesPanel';
 import FeedbackTab from './components/FeedbackTab';
+import SettingsTab from './components/SettingsTab';
 import { FEEDBACK_UPLOAD_ENABLED } from './services/feedback';
 import ModelStatus from './components/ModelStatus';
 import WebGPUFallback from './components/WebGPUFallback';
@@ -153,6 +154,13 @@ const App = () => {
 	}, [] );
 
 	/**
+	 * Handle model unload callback — resets ready state
+	 */
+	const handleModelUnload = useCallback( () => {
+		setModelReady( false );
+	}, [] );
+
+	/**
 	 * Handle model error callback
 	 */
 	const handleModelError = useCallback( ( errorMessage ) => {
@@ -217,6 +225,11 @@ const App = () => {
 			title: 'Plugin Abilities',
 			className: 'wp-agentic-admin-tab',
 		},
+		{
+			name: 'settings',
+			title: 'Settings',
+			className: 'wp-agentic-admin-tab',
+		},
 		...( FEEDBACK_UPLOAD_ENABLED
 			? [
 					{
@@ -252,6 +265,8 @@ const App = () => {
 				return <AbilityBrowser />;
 			case 'plugin-abilities':
 				return <PluginAbilitiesPanel />;
+			case 'settings':
+				return <SettingsTab />;
 			case 'feedback':
 				return <FeedbackTab />;
 			default:
@@ -278,6 +293,7 @@ const App = () => {
 			<ModelStatus
 				onModelReady={ handleModelReady }
 				onModelError={ handleModelError }
+				onModelUnload={ handleModelUnload }
 				initPhase={ initPhase }
 				initMessage={ initMessage }
 				initProgress={ initProgress }

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -95,6 +95,7 @@ const ChatContainer = ( {
 	// Session ref to persist across renders
 	const sessionRef = useRef( null );
 	const initializedRef = useRef( false );
+	const prevModelReadyRef = useRef( modelReady );
 
 	/**
 	 * Initialize the chat framework on mount
@@ -264,6 +265,19 @@ const ChatContainer = ( {
 			session.save();
 		};
 	}, [ setIsLoading ] );
+
+	/**
+	 * Clear chat when model is unloaded (modelReady transitions true → false)
+	 */
+	useEffect( () => {
+		if ( prevModelReadyRef.current && ! modelReady ) {
+			if ( sessionRef.current ) {
+				sessionRef.current.clear();
+				setMessages( [] );
+			}
+		}
+		prevModelReadyRef.current = modelReady;
+	}, [ modelReady ] );
 
 	/**
 	 * Convert session messages to display format for MessageList

--- a/src/extensions/components/ModelStatus.jsx
+++ b/src/extensions/components/ModelStatus.jsx
@@ -185,6 +185,7 @@ const getLoadingStage = ( message, progress ) => {
 const ModelStatus = ( {
 	onModelReady,
 	onModelError,
+	onModelUnload,
 	initPhase,
 	initMessage, // eslint-disable-line no-unused-vars -- Prop passed by parent for future use in status display.
 	initProgress,
@@ -303,10 +304,14 @@ const ModelStatus = ( {
 			const gpu = modelLoader.getGPUInfo();
 			setGpuInfo( gpu );
 
-			// Initial stats fetch
+			// Initial stats and context fetch
 			modelLoader.getMemoryStats().then( ( stats ) => {
 				setMemoryStats( stats );
 			} );
+			const initialContext = modelLoader.getContextUsage();
+			if ( initialContext ) {
+				setContextUsage( initialContext );
+			}
 
 			// Poll for stats updates every 2 seconds to capture post-inference performance
 			const statsInterval = setInterval( () => {
@@ -375,7 +380,10 @@ const ModelStatus = ( {
 		await modelLoader.unload();
 		setProgress( 0 );
 		setIsFromCache( false );
-	}, [] );
+		if ( onModelUnload ) {
+			onModelUnload();
+		}
+	}, [ onModelUnload ] );
 
 	/**
 	 * Fetch models from remote endpoint
@@ -532,8 +540,6 @@ const ModelStatus = ( {
 										{ ' · ' }
 									</span>
 								) }
-								{ loadedModelInfo.mode !== 'external' &&
-									`~${ loadedModelInfo.size } VRAM` }
 								{ memoryStats?.available &&
 									memoryStats?.formatted && (
 										<>

--- a/src/extensions/components/SettingsTab.jsx
+++ b/src/extensions/components/SettingsTab.jsx
@@ -1,0 +1,323 @@
+/**
+ * Settings Tab — Context Window Recommendations
+ */
+
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	SelectControl,
+	Notice,
+} from '@wordpress/components';
+import modelLoader, {
+	ModelLoader,
+	MODEL_CONTEXT_SIZES,
+} from '../services/model-loader';
+
+const CONTEXT_OPTIONS = [
+	{ label: '2,048 tokens (minimal)', value: '2048' },
+	{ label: '4,096 tokens (conservative)', value: '4096' },
+	{ label: '8,192 tokens (balanced)', value: '8192' },
+	{ label: '16,384 tokens (generous)', value: '16384' },
+	{ label: '32,768 tokens (maximum)', value: '32768' },
+];
+
+const STORAGE_KEY = 'wp_agentic_admin_context_size';
+
+const TIER_COLORS = {
+	minimal: '#d63638',
+	conservative: '#dba617',
+	balanced: '#00a32a',
+	generous: '#2271b1',
+	maximum: '#8c1aff',
+	unknown: '#757575',
+};
+
+function getSavedContextSizes() {
+	try {
+		const saved = localStorage.getItem( STORAGE_KEY );
+		return saved ? JSON.parse( saved ) : {};
+	} catch {
+		return {};
+	}
+}
+
+function saveContextSize( modelId, size ) {
+	const saved = getSavedContextSizes();
+	saved[ modelId ] = size;
+	localStorage.setItem( STORAGE_KEY, JSON.stringify( saved ) );
+}
+
+function clearContextSize( modelId ) {
+	const saved = getSavedContextSizes();
+	delete saved[ modelId ];
+	if ( Object.keys( saved ).length === 0 ) {
+		localStorage.removeItem( STORAGE_KEY );
+	} else {
+		localStorage.setItem( STORAGE_KEY, JSON.stringify( saved ) );
+	}
+}
+
+const SettingsTab = () => {
+	const [ gpuInfo, setGpuInfo ] = useState( null );
+	const [ recommendations, setRecommendations ] = useState( {} );
+	const [ savedSizes, setSavedSizes ] = useState( getSavedContextSizes() );
+	const [ selectedSizes, setSelectedSizes ] = useState( {} );
+	const [ savedNotice, setSavedNotice ] = useState( null );
+	const [ detecting, setDetecting ] = useState( true );
+
+	const models = ModelLoader.getAvailableModels();
+
+	const detectGPU = useCallback( async () => {
+		setDetecting( true );
+
+		// If GPU info already detected (model loaded), use cached
+		let info = modelLoader.getGPUInfo();
+		if ( ! info ) {
+			await modelLoader.checkWebGPUSupport();
+			info = modelLoader.getGPUInfo();
+		}
+		setGpuInfo( info );
+
+		// Build recommendations for each model
+		const recs = {};
+		for ( const model of models ) {
+			recs[ model.id ] = modelLoader.getRecommendedContextSize(
+				model.id
+			);
+		}
+		setRecommendations( recs );
+
+		// Initialize selected sizes from saved or defaults
+		const initial = {};
+		const saved = getSavedContextSizes();
+		for ( const model of models ) {
+			initial[ model.id ] = String(
+				saved[ model.id ] ||
+					MODEL_CONTEXT_SIZES[ model.id ] ||
+					MODEL_CONTEXT_SIZES.default
+			);
+		}
+		setSelectedSizes( initial );
+		setDetecting( false );
+	}, [ models ] );
+
+	useEffect( () => {
+		detectGPU();
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
+	}, [] );
+
+	const handleSave = ( modelId ) => {
+		const size = parseInt( selectedSizes[ modelId ], 10 );
+		saveContextSize( modelId, size );
+		setSavedSizes( getSavedContextSizes() );
+		setSavedNotice( modelId );
+		setTimeout( () => setSavedNotice( null ), 3000 );
+	};
+
+	const handleReset = ( modelId ) => {
+		clearContextSize( modelId );
+		const defaultSize =
+			MODEL_CONTEXT_SIZES[ modelId ] || MODEL_CONTEXT_SIZES.default;
+		setSelectedSizes( ( prev ) => ( {
+			...prev,
+			[ modelId ]: String( defaultSize ),
+		} ) );
+		setSavedSizes( getSavedContextSizes() );
+		setSavedNotice( null );
+	};
+
+	const handleApplyRecommendation = ( modelId ) => {
+		const rec = recommendations[ modelId ];
+		if ( ! rec ) {
+			return;
+		}
+		setSelectedSizes( ( prev ) => ( {
+			...prev,
+			[ modelId ]: String( rec.recommended ),
+		} ) );
+	};
+
+	const estimatedVRAM = modelLoader.getEstimatedVRAM();
+
+	return (
+		<div className="wp-agentic-admin-settings-tab">
+			<Card>
+				<CardHeader>
+					<h3 style={ { margin: 0 } }>GPU Information</h3>
+				</CardHeader>
+				<CardBody>
+					{ detecting ? (
+						<p>Detecting GPU capabilities...</p>
+					) : gpuInfo ? (
+						<table className="wp-agentic-admin-settings-tab__gpu-table">
+							<tbody>
+								<tr>
+									<td>
+										<strong>Device</strong>
+									</td>
+									<td>{ gpuInfo.device }</td>
+								</tr>
+								<tr>
+									<td>
+										<strong>Vendor</strong>
+									</td>
+									<td>{ gpuInfo.vendor }</td>
+								</tr>
+								{ gpuInfo.architecture !== 'Unknown' && (
+									<tr>
+										<td>
+											<strong>Architecture</strong>
+										</td>
+										<td>{ gpuInfo.architecture }</td>
+									</tr>
+								) }
+								<tr>
+									<td>
+										<strong>Max Buffer Size</strong>
+									</td>
+									<td>
+										{ gpuInfo.maxBufferSize
+											? `${ (
+													gpuInfo.maxBufferSize /
+													1024 ** 3
+											  ).toFixed( 2 ) } GB`
+											: 'Unknown' }
+									</td>
+								</tr>
+								<tr>
+									<td>
+										<strong>Estimated VRAM</strong>
+									</td>
+									<td>
+										{ estimatedVRAM > 0
+											? `~${ estimatedVRAM } GB`
+											: 'Unknown' }
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					) : (
+						<Notice status="warning" isDismissible={ false }>
+							Could not detect GPU. WebGPU may not be supported in
+							this browser.
+						</Notice>
+					) }
+				</CardBody>
+			</Card>
+
+			<h3>Context Window per Model</h3>
+			<p className="wp-agentic-admin-settings-tab__description">
+				The context window determines how much conversation history and
+				tool data the model can process. Larger windows use more GPU
+				memory for the KV cache. Choose based on your available VRAM.
+			</p>
+
+			{ models.map( ( model ) => {
+				const rec = recommendations[ model.id ];
+				const isCustom = savedSizes[ model.id ] !== undefined;
+				const currentDefault =
+					MODEL_CONTEXT_SIZES[ model.id ] ||
+					MODEL_CONTEXT_SIZES.default;
+				const selectedValue =
+					selectedSizes[ model.id ] || String( currentDefault );
+				const isChanged =
+					parseInt( selectedValue, 10 ) !==
+					( savedSizes[ model.id ] || currentDefault );
+
+				return (
+					<Card
+						key={ model.id }
+						className="wp-agentic-admin-settings-tab__model-card"
+					>
+						<CardHeader>
+							<h4 style={ { margin: 0 } }>
+								{ model.name }
+								<span className="wp-agentic-admin-settings-tab__model-size">
+									{ model.size } download / { model.vram }{ ' ' }
+									VRAM
+								</span>
+							</h4>
+						</CardHeader>
+						<CardBody>
+							{ rec && rec.tier !== 'unknown' && (
+								<div className="wp-agentic-admin-settings-tab__recommendation">
+									<span
+										className="wp-agentic-admin-settings-tab__tier-badge"
+										style={ {
+											background:
+												TIER_COLORS[ rec.tier ] ||
+												TIER_COLORS.unknown,
+										} }
+									>
+										{ rec.tier }
+									</span>
+									<span className="wp-agentic-admin-settings-tab__rec-text">
+										Recommended:{ ' ' }
+										<strong>
+											{ rec.recommended.toLocaleString() }{ ' ' }
+											tokens
+										</strong>
+									</span>
+									<Button
+										variant="link"
+										onClick={ () =>
+											handleApplyRecommendation(
+												model.id
+											)
+										}
+									>
+										Apply
+									</Button>
+								</div>
+							) }
+							{ rec && (
+								<p className="wp-agentic-admin-settings-tab__reasoning">
+									{ rec.reasoning }
+								</p>
+							) }
+
+							<div className="wp-agentic-admin-settings-tab__controls">
+								<SelectControl
+									label="Context window size"
+									value={ selectedValue }
+									options={ CONTEXT_OPTIONS }
+									onChange={ ( val ) =>
+										setSelectedSizes( ( prev ) => ( {
+											...prev,
+											[ model.id ]: val,
+										} ) )
+									}
+								/>
+								<div className="wp-agentic-admin-settings-tab__actions">
+									<Button
+										variant="primary"
+										onClick={ () => handleSave( model.id ) }
+										disabled={ ! isChanged }
+									>
+										Save
+									</Button>
+								</div>
+							</div>
+
+							{ savedNotice === model.id && (
+								<Notice
+									status="success"
+									isDismissible={ false }
+									style={ { marginTop: '12px' } }
+								>
+									Context window updated. Changes take effect
+									on next model load.
+								</Notice>
+							) }
+						</CardBody>
+					</Card>
+				);
+			} ) }
+		</div>
+	);
+};
+
+export default SettingsTab;

--- a/src/extensions/services/model-loader.js
+++ b/src/extensions/services/model-loader.js
@@ -360,6 +360,7 @@ class ModelLoader {
 				architecture: info.architecture || 'Unknown',
 				device: info.device || 'Unknown',
 				description: info.description || '',
+				maxBufferSize: adapter.limits?.maxBufferSize || 0,
 			};
 
 			return {
@@ -961,6 +962,117 @@ class ModelLoader {
 	}
 
 	/**
+	 * Get the effective context window size for a model.
+	 * Checks localStorage override first, then falls back to MODEL_CONTEXT_SIZES.
+	 *
+	 * @param {string} modelId - Model identifier
+	 * @return {number} Context window size in tokens
+	 */
+	static getEffectiveContextSize( modelId ) {
+		try {
+			const saved = localStorage.getItem(
+				'wp_agentic_admin_context_size'
+			);
+			if ( saved ) {
+				const parsed = JSON.parse( saved );
+				if ( parsed[ modelId ] ) {
+					return parsed[ modelId ];
+				}
+			}
+		} catch ( e ) {
+			// Ignore parse errors
+		}
+		return MODEL_CONTEXT_SIZES[ modelId ] || MODEL_CONTEXT_SIZES.default;
+	}
+
+	/**
+	 * Estimate available GPU VRAM from WebGPU adapter limits.
+	 * maxBufferSize is a rough proxy for total GPU memory.
+	 *
+	 * @return {number} Estimated VRAM in GB, or 0 if unknown
+	 */
+	getEstimatedVRAM() {
+		if ( ! this.gpuAdapterInfo?.maxBufferSize ) {
+			return 0;
+		}
+		// maxBufferSize is typically 25-50% of total VRAM.
+		// Use a 2x multiplier as a conservative estimate.
+		const estimatedBytes = this.gpuAdapterInfo.maxBufferSize * 2;
+		return Math.round( ( estimatedBytes / 1024 ** 3 ) * 10 ) / 10;
+	}
+
+	/**
+	 * Get recommended context window size based on estimated VRAM and model.
+	 *
+	 * @param {string} modelId - Model identifier
+	 * @return {Object} Recommendation with size, reasoning, and tier info
+	 */
+	getRecommendedContextSize( modelId ) {
+		const estimatedVRAM = this.getEstimatedVRAM();
+		const model = ModelLoader.getAvailableModels().find(
+			( m ) => m.id === modelId
+		);
+		const modelVRAM = model
+			? parseFloat( model.vram.replace( /[^0-9.]/g, '' ) )
+			: 1.5;
+
+		const remainingVRAM = estimatedVRAM - modelVRAM;
+		const maxBuffer = this.gpuAdapterInfo?.maxBufferSize || 0;
+		const maxBufferGB = Math.round( ( maxBuffer / 1024 ** 3 ) * 100 ) / 100;
+
+		let recommended, tier, reasoning;
+		if ( estimatedVRAM === 0 ) {
+			recommended =
+				MODEL_CONTEXT_SIZES[ modelId ] || MODEL_CONTEXT_SIZES.default;
+			tier = 'unknown';
+			reasoning =
+				'Could not detect GPU memory. Using default context size.';
+		} else if ( remainingVRAM < 1 ) {
+			recommended = 2048;
+			tier = 'minimal';
+			reasoning = `Only ~${ remainingVRAM.toFixed(
+				1
+			) }GB available after model weights (${ modelVRAM }GB). Minimal context recommended.`;
+		} else if ( remainingVRAM < 2 ) {
+			recommended = 4096;
+			tier = 'conservative';
+			reasoning = `~${ remainingVRAM.toFixed(
+				1
+			) }GB available after model weights. Conservative context for stable operation.`;
+		} else if ( remainingVRAM < 4 ) {
+			recommended = 8192;
+			tier = 'balanced';
+			reasoning = `~${ remainingVRAM.toFixed(
+				1
+			) }GB available after model weights. Good balance of context and performance.`;
+		} else if ( remainingVRAM < 8 ) {
+			recommended = 16384;
+			tier = 'generous';
+			reasoning = `~${ remainingVRAM.toFixed(
+				1
+			) }GB available after model weights. Large context window possible.`;
+		} else {
+			recommended = 32768;
+			tier = 'maximum';
+			reasoning = `~${ remainingVRAM.toFixed(
+				1
+			) }GB available after model weights. Maximum context window.`;
+		}
+
+		return {
+			recommended,
+			tier,
+			reasoning,
+			estimatedVRAM,
+			modelVRAM,
+			remainingVRAM: Math.max( 0, remainingVRAM ),
+			maxBufferGB,
+			currentDefault:
+				MODEL_CONTEXT_SIZES[ modelId ] || MODEL_CONTEXT_SIZES.default,
+		};
+	}
+
+	/**
 	 * Get GPU adapter info (vendor, architecture, device)
 	 *
 	 * @return {Object|null} GPU info or null if not available
@@ -975,15 +1087,14 @@ class ModelLoader {
 	 * @return {Object|null} Context usage info or null if not available
 	 */
 	getContextUsage() {
-		if ( ! this.lastUsageStats ) {
+		if ( ! this.isReady ) {
 			return null;
 		}
 
 		const maxContext = this.isExternalProvider()
 			? this.externalContextSize || 32768
-			: MODEL_CONTEXT_SIZES[ this.modelId ] ||
-			  MODEL_CONTEXT_SIZES.default;
-		const usedTokens = this.lastUsageStats.prompt_tokens || 0;
+			: ModelLoader.getEffectiveContextSize( this.modelId );
+		const usedTokens = this.lastUsageStats?.prompt_tokens || 0;
 		const percentage = Math.round( ( usedTokens / maxContext ) * 100 );
 
 		return {
@@ -1085,6 +1196,7 @@ export {
 	modelLoader,
 	DEFAULT_MODEL,
 	MODEL_CONFIG,
+	MODEL_CONTEXT_SIZES,
 	ExternalEngine,
 };
 export default modelLoader;

--- a/src/extensions/services/plugin-abilities-manager.js
+++ b/src/extensions/services/plugin-abilities-manager.js
@@ -60,18 +60,11 @@ function estimateAbilityTokens( ability ) {
  * @return {number} Max context tokens.
  */
 function getMaxContext() {
-	// Import dynamically to avoid circular deps
-	const MODEL_CONTEXT_SIZES = {
-		'Qwen3-1.7B-q4f16_1-MLC': 4096,
-		'Qwen2.5-7B-Instruct-q4f16_1-MLC': 32768,
-		default: 4096,
-	};
-
-	// Try to get current model from the global
+	// Use ModelLoader's effective context size which respects localStorage overrides
+	const { ModelLoader } = require( './model-loader' );
 	const settings = window.wpAgenticAdmin || {};
 	const modelId = settings.currentModel || '';
-
-	return MODEL_CONTEXT_SIZES[ modelId ] || MODEL_CONTEXT_SIZES.default;
+	return ModelLoader.getEffectiveContextSize( modelId );
 }
 
 /**

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -3356,3 +3356,89 @@
 	margin-left: 4px;
 	color: inherit;
 }
+
+/* Settings Tab */
+.wp-agentic-admin-settings-tab {
+	padding: 16px;
+
+	.components-card {
+		margin-bottom: 16px;
+	}
+
+	h3 {
+		margin: 24px 0 8px;
+	}
+
+	&__description {
+		color: #646970;
+		margin-bottom: 16px;
+	}
+
+	&__gpu-table {
+		width: 100%;
+		border-collapse: collapse;
+
+		td {
+			padding: 6px 12px 6px 0;
+			border-bottom: 1px solid #f0f0f0;
+		}
+
+		td:first-child {
+			width: 160px;
+			color: #646970;
+		}
+	}
+
+	&__model-card {
+		margin-bottom: 16px;
+	}
+
+	&__model-size {
+		font-weight: normal;
+		font-size: 13px;
+		color: #646970;
+		margin-left: 8px;
+	}
+
+	&__recommendation {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 8px;
+		padding: 8px 12px;
+		background: #f0f6fc;
+		border-radius: 4px;
+	}
+
+	&__tier-badge {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: 3px;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		color: #fff;
+		letter-spacing: 0.5px;
+	}
+
+	&__rec-text {
+		flex: 1;
+		font-size: 13px;
+	}
+
+	&__reasoning {
+		font-size: 13px;
+		color: #646970;
+		margin: 0 0 12px;
+	}
+
+	&__controls {
+		max-width: 400px;
+	}
+
+	&__actions {
+		display: flex;
+		gap: 8px;
+		margin-top: 8px;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new **Settings tab** to the plugin admin page with GPU information display and per-model context window configuration
- Detects GPU capabilities via WebGPU adapter limits and recommends context window sizes based on available VRAM after model weights
- Shows context usage bar (`0 / max`) immediately on model load instead of waiting for first inference
- Model unload now properly clears chat history and resets state

## Changes

- **New file**: `src/extensions/components/SettingsTab.jsx` — Settings tab with GPU info table, tier-based recommendations (minimal/conservative/balanced/generous/maximum), and per-model context size selector
- **`model-loader.js`**: Added `getEffectiveContextSize()`, `getEstimatedVRAM()`, `getRecommendedContextSize()` methods; exported `MODEL_CONTEXT_SIZES`; context usage now shows immediately on model ready
- **`App.jsx`**: Added Settings tab and `onModelUnload` callback
- **`ChatContainer.jsx`**: Clears chat when model is unloaded (modelReady true→false)
- **`ModelStatus.jsx`**: Wired `onModelUnload` prop, removed VRAM text from status bar, fetches context on ready
- **`plugin-abilities-manager.js`**: Uses `ModelLoader.getEffectiveContextSize()` instead of hardcoded duplicate
- **`main.scss`**: Styles for the settings tab

## Test plan

- [ ] Load model → verify context bar shows `0 / 4,096 (0%)` immediately
- [ ] Go to Settings tab → verify GPU info table populates
- [ ] Check per-model recommendations match available VRAM
- [ ] Change context size, save → verify reflected in status bar after model reload
- [ ] Unload model → verify chat clears
- [ ] Load different model → verify new context size applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)