### PR TITLE
feat: dynamic plugin ability bundles in chat dropdown

### DIFF
--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -50,6 +50,7 @@ import {
 	FEEDBACK_UPLOAD_ENABLED,
 } from '../services/feedback';
 import { executeAbility } from '../services/agentic-abilities-api';
+import pluginAbilitiesManager from '../services/plugin-abilities-manager';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger( 'ChatContainer' );
@@ -419,11 +420,20 @@ const ChatContainer = ( {
 				return;
 			}
 
+			// Scope plugin abilities when a plugin bundle is active
+			if ( options.pluginNamespace ) {
+				pluginAbilitiesManager.scopeToPlugin( options.pluginNamespace );
+			}
+
 			// Process message through orchestrator
 			try {
 				await chatOrchestrator.processMessage( text, options );
 			} catch ( error ) {
 				log.error( 'Error processing message:', error );
+			} finally {
+				if ( options.pluginNamespace ) {
+					pluginAbilitiesManager.clearPluginScope();
+				}
 			}
 		},
 		[ modelReady ]

--- a/src/extensions/components/ChatInput.jsx
+++ b/src/extensions/components/ChatInput.jsx
@@ -20,6 +20,7 @@ import {
 	info,
 } from '@wordpress/icons';
 import ABILITY_BUNDLES from '../data/ability-bundles';
+import pluginAbilitiesManager from '../services/plugin-abilities-manager';
 
 /**
  * Map of bundle icon names to @wordpress/icons components.
@@ -52,7 +53,17 @@ const ChatInput = ( {
 	const [ message, setMessage ] = useState( '' );
 	const [ selectedBundle, setSelectedBundle ] = useState( null );
 	const [ webSearchEnabled, setWebSearchEnabled ] = useState( false );
+	const [ pluginBundles, setPluginBundles ] = useState( [] );
 	const textareaRef = useRef( null );
+
+	// Subscribe to plugin abilities manager for dynamic bundles
+	useEffect( () => {
+		const refresh = () => {
+			setPluginBundles( pluginAbilitiesManager.getPluginBundles() );
+		};
+		refresh();
+		return pluginAbilitiesManager.subscribe( refresh );
+	}, [] );
 
 	// Focus textarea on mount if not disabled
 	useEffect( () => {
@@ -78,6 +89,7 @@ const ChatInput = ( {
 
 		onSend( trimmedMessage, {
 			bundleToolIds: selectedBundle?.abilities || null,
+			pluginNamespace: selectedBundle?.pluginNamespace || null,
 			webSearch: webSearchEnabled,
 		} );
 		setMessage( '' );
@@ -184,6 +196,55 @@ const ChatInput = ( {
 											</span>
 										</button>
 									) ) }
+									{ pluginBundles.length > 0 && (
+										<>
+											<div className="wp-agentic-admin-bundle-menu__separator">
+												<span>Plugin Abilities</span>
+											</div>
+											{ pluginBundles.map( ( bundle ) => (
+												<button
+													type="button"
+													key={ bundle.id }
+													className={ `wp-agentic-admin-bundle-menu__item${
+														selectedBundle?.id ===
+														bundle.id
+															? ' wp-agentic-admin-bundle-menu__item--selected'
+															: ''
+													}` }
+													onClick={ () => {
+														setSelectedBundle(
+															bundle
+														);
+														onClose();
+													} }
+												>
+													{ bundle.icon ? (
+														<img
+															src={ bundle.icon }
+															alt={ bundle.label }
+															className="wp-agentic-admin-bundle-menu__plugin-icon"
+														/>
+													) : (
+														<Icon
+															icon={ plugins }
+															size={ 18 }
+														/>
+													) }
+													<span className="wp-agentic-admin-bundle-menu__label">
+														{ bundle.label }
+													</span>
+													<span className="wp-agentic-admin-bundle-menu__count">
+														{
+															bundle
+																.pluginAbilityIds
+																.length
+														}{ ' ' }
+														tools
+													</span>
+												</button>
+											) ) }
+										</>
+									) }
 								</div>
 							) }
 						/>

--- a/src/extensions/services/plugin-abilities-manager.js
+++ b/src/extensions/services/plugin-abilities-manager.js
@@ -384,6 +384,102 @@ class PluginAbilitiesManager {
 		);
 		return ability ? estimateAbilityTokens( ability ) : 0;
 	}
+
+	/**
+	 * Get dynamic bundles grouped by plugin namespace.
+	 *
+	 * Groups all enabled plugin abilities by their namespace (e.g. "woocommerce")
+	 * and returns bundle objects compatible with ABILITY_BUNDLES.
+	 *
+	 * @return {Object[]} Array of bundle objects.
+	 */
+	getPluginBundles() {
+		const groups = {};
+
+		for ( const id of this.enabledIds ) {
+			const ability = this.discoveredAbilities.find(
+				( a ) => ( a.name || a.id ) === id
+			);
+			if ( ! ability ) {
+				continue;
+			}
+
+			const namespace = id.split( '/' )[ 0 ];
+			if ( ! groups[ namespace ] ) {
+				groups[ namespace ] = {
+					abilities: [],
+					icon: ability.icon || null,
+					label: namespace,
+				};
+			}
+			groups[ namespace ].abilities.push( ability );
+		}
+
+		return Object.entries( groups ).map( ( [ namespace, group ] ) => ( {
+			id: `plugin-${ namespace }`,
+			label: group.label,
+			icon: group.icon,
+			isPluginBundle: true,
+			pluginNamespace: namespace,
+			description: `${ group.abilities.length } abilities from ${ namespace }`,
+			abilities: [ 'wp-agentic-admin/run-plugin-ability' ],
+			pluginAbilityIds: group.abilities.map( ( a ) => a.name || a.id ),
+		} ) );
+	}
+
+	/**
+	 * Temporarily scope the run-plugin-ability description to a single plugin.
+	 *
+	 * Call this before sending a message with a plugin bundle active,
+	 * then call clearPluginScope() after the message completes.
+	 *
+	 * @param {string} namespace - Plugin namespace to scope to.
+	 */
+	scopeToPlugin( namespace ) {
+		const runTool = toolRegistry.get(
+			'wp-agentic-admin/run-plugin-ability'
+		);
+		if ( ! runTool ) {
+			return;
+		}
+
+		// Save original description for restoration.
+		if ( ! this._savedDescription ) {
+			this._savedDescription = runTool.description;
+		}
+
+		const lines = [];
+		for ( const id of this.enabledIds ) {
+			if ( ! id.startsWith( namespace + '/' ) ) {
+				continue;
+			}
+			const ability = this.discoveredAbilities.find(
+				( a ) => ( a.name || a.id ) === id
+			);
+			if ( ability ) {
+				lines.push(
+					`${ id }: ${ ability.description || ability.label }`
+				);
+			}
+		}
+
+		runTool.description =
+			'Run a plugin ability. Pass ability_id and args. Available: ' +
+			lines.join( '; ' );
+	}
+
+	/**
+	 * Restore the run-plugin-ability description after plugin-scoped request.
+	 */
+	clearPluginScope() {
+		const runTool = toolRegistry.get(
+			'wp-agentic-admin/run-plugin-ability'
+		);
+		if ( runTool && this._savedDescription ) {
+			runTool.description = this._savedDescription;
+			this._savedDescription = null;
+		}
+	}
 }
 
 // Singleton

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -594,6 +594,33 @@
 		font-size: 11px;
 		color: #6e6e6e;
 	}
+
+	&__separator {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 12px 4px;
+		font-size: 11px;
+		font-weight: 600;
+		color: #6e6e6e;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+
+		&::after {
+			content: "";
+			flex: 1;
+			height: 1px;
+			background: #c3c4c7;
+		}
+	}
+
+	&__plugin-icon {
+		width: 18px;
+		height: 18px;
+		border-radius: 3px;
+		flex-shrink: 0;
+		object-fit: contain;
+	}
 }
 
 // Status Bar


### PR DESCRIPTION
## Summary

- **Plugin abilities manager** now generates dynamic bundles grouped by plugin namespace (e.g. all WooCommerce abilities become a "WooCommerce" bundle). Adds `scopeToPlugin()`/`clearPluginScope()` to temporarily restrict the run-plugin-ability tool description during scoped requests.
- **ChatInput dropdown** dynamically shows plugin bundles below a "Plugin Abilities" separator, with plugin icons and ability counts, alongside existing core bundles.
- **ChatContainer** scopes/restores plugin abilities around orchestrator calls when a plugin bundle is active, so the LLM only sees that plugin's abilities in context.

## Test plan

- [ ] Enable abilities from 2+ plugins in the Plugin Abilities tab
- [ ] Verify each plugin appears as a separate bundle in the `+` dropdown
- [ ] Select a plugin bundle and send a message — confirm only that plugin's abilities are in the system prompt
- [ ] Verify scoping is restored after the request completes (other plugin abilities reappear)
- [ ] Verify core bundles still work as before
- [ ] Run `npm test` — all 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)