### PR TITLE
Feature/120 prefix global functions

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -186,7 +186,7 @@ Find your role below. Each section tells you what you'll build, where the code l
 
 **What you'll do:**
 1. Pick an ability from the [must-have list](CLOUDFEST_HACKATHON.md#goal-2-expanded-abilities-must-have) or grab an issue labeled `ability` + `php`
-2. Create a PHP file in `includes/abilities/` using `register_agentic_ability()`
+2. Create a PHP file in `includes/abilities/` using `wp_agentic_admin_register_ability()`
 3. Coordinate with a JS developer who builds the chat-side counterpart
 
 **Your workspace:**

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ wp-agentic-admin/
 ├── wp-agentic-admin.php              # Main plugin file
 ├── uninstall.php                     # Clean uninstall (multisite-aware)
 ├── includes/
-│   ├── functions-abilities.php      # Public API: register_agentic_ability()
+│   ├── functions-abilities.php      # Public API: wp_agentic_admin_register_ability()
 │   ├── class-abilities.php          # Ability registration orchestrator
 │   ├── class-admin-page.php         # Admin page & assets
 │   ├── class-settings.php           # Plugin settings (model selection, etc.)

--- a/docs/ABILITIES-GUIDE.md
+++ b/docs/ABILITIES-GUIDE.md
@@ -126,7 +126,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_my_new_ability(): void {
-    register_agentic_ability(
+    wp_agentic_admin_register_ability(
         'wp-agentic-admin/my-new-ability',
         // PHP configuration for WordPress Abilities API
         array(
@@ -197,7 +197,7 @@ if ( function_exists( 'wp_agentic_admin_register_my_new_ability' ) ) {
 
 ```php
 add_action( 'wp_agentic_admin_register_abilities', function() {
-    if ( function_exists( 'register_agentic_ability' ) ) {
+    if ( function_exists( 'wp_agentic_admin_register_ability' ) ) {
         wp_agentic_admin_register_my_new_ability();
     }
 } );
@@ -429,7 +429,7 @@ const merged = {
 };
 ```
 
-The original PHP label is still available as `phpLabel` (set by `get_agentic_abilities_js_config()` in `functions-abilities.php`). This means:
+The original PHP label is still available as `phpLabel` (set by `wp_agentic_admin_get_abilities_js_config()` in `functions-abilities.php`). This means:
 - `tool.label` -- the JS label (or PHP label if JS didn't provide one)
 - `tool.phpLabel` -- always the PHP-defined label, if one was registered
 
@@ -958,40 +958,40 @@ Key differences from regular abilities:
 
 All public PHP functions are defined in `functions-abilities.php`.
 
-### `register_agentic_ability( string $id, array $php_args, array $js_args = array() ): bool`
+### `wp_agentic_admin_register_ability( string $id, array $php_args, array $js_args = array() ): bool`
 
 Registers an ability with both the WordPress Abilities API (backend) and stores JS configuration for the frontend. See the [Creating a New Ability](#creating-a-new-ability) section for full usage.
 
-### `unregister_agentic_ability( string $id ): bool`
+### `wp_agentic_admin_unregister_ability( string $id ): bool`
 
 Removes a previously registered ability. Returns `true` if the ability was unregistered, `false` if it did not exist. Also calls `wp_unregister_ability()` if the WordPress Abilities API is available.
 
 ```php
 // Example: conditionally remove an ability
-if ( agentic_ability_exists( 'wp-agentic-admin/cache-flush' ) ) {
-    unregister_agentic_ability( 'wp-agentic-admin/cache-flush' );
+if ( wp_agentic_admin_ability_exists( 'wp-agentic-admin/cache-flush' ) ) {
+    wp_agentic_admin_unregister_ability( 'wp-agentic-admin/cache-flush' );
 }
 ```
 
-### `agentic_ability_exists( string $id ): bool`
+### `wp_agentic_admin_ability_exists( string $id ): bool`
 
 Checks whether an ability with the given ID is currently registered. Useful for guard checks before registering or unregistering.
 
 ```php
-if ( ! agentic_ability_exists( 'my-plugin/my-ability' ) ) {
-    register_agentic_ability( 'my-plugin/my-ability', $php_args, $js_args );
+if ( ! wp_agentic_admin_ability_exists( 'my-plugin/my-ability' ) ) {
+    wp_agentic_admin_register_ability( 'my-plugin/my-ability', $php_args, $js_args );
 }
 ```
 
-### `get_agentic_abilities(): array`
+### `wp_agentic_admin_get_abilities(): array`
 
 Returns all registered abilities as an associative array keyed by ability ID.
 
-### `get_agentic_ability( string $id ): ?array`
+### `wp_agentic_admin_get_ability( string $id ): ?array`
 
 Returns the configuration for a single ability, or `null` if not found.
 
-### `get_agentic_abilities_js_config(): array`
+### `wp_agentic_admin_get_abilities_js_config(): array`
 
 Returns JS-facing configurations for all abilities. Used internally by `wp_localize_script()` to pass ability metadata to the frontend. Includes `phpLabel`, `description`, and `annotations` from the PHP config.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ Our design decisions are optimized for these user personas:
 - **Require:** Clear APIs, WordPress coding standards compliance, extensibility
 
 **What they need:**
-- Simple `register_agentic_ability()` API
+- Simple `wp_agentic_admin_register_ability()` API
 - PHP/JavaScript dual registration pattern
 - WordPress Abilities API integration
 - Shared helper functions to avoid duplication
@@ -285,7 +285,7 @@ skills:
 ### WordPress Abilities (Chosen)
 
 ```php
-register_agentic_ability('wp-agentic-admin/db-optimize', [
+wp_agentic_admin_register_ability('wp-agentic-admin/db-optimize', [
     'label' => 'Optimize Database',
     'description' => 'Optimize database tables',
     'category' => 'sre-tools',

--- a/docs/THIRD-PARTY-INTEGRATION.md
+++ b/docs/THIRD-PARTY-INTEGRATION.md
@@ -14,7 +14,7 @@ Hook into `wp_agentic_admin_register_abilities` to register your ability:
 
 ```php
 add_action( 'wp_agentic_admin_register_abilities', function() {
-    register_agentic_ability(
+    wp_agentic_admin_register_ability(
         'my-plugin/my-ability',
         array(
             'label'            => __( 'My Ability', 'my-plugin' ),
@@ -119,7 +119,7 @@ Then register your ability in JavaScript:
 
 ### PHP API
 
-#### `register_agentic_ability( $id, $php_config, $js_config )`
+#### `wp_agentic_admin_register_ability( $id, $php_config, $js_config )`
 
 Registers an ability with both the WordPress Abilities API and the Agentic Admin chat system.
 
@@ -164,44 +164,44 @@ array(
 )
 ```
 
-> **Auto-forwarded PHP values:** The `get_agentic_abilities_js_config()` function automatically forwards the PHP config's `label` and `description` values to the JavaScript frontend as `phpLabel` and `description` keys respectively. This means you do not need to duplicate label/description information in your JS config -- simply set them in the PHP config and they will be available on the JS side automatically.
+> **Auto-forwarded PHP values:** The `wp_agentic_admin_get_abilities_js_config()` function automatically forwards the PHP config's `label` and `description` values to the JavaScript frontend as `phpLabel` and `description` keys respectively. This means you do not need to duplicate label/description information in your JS config -- simply set them in the PHP config and they will be available on the JS side automatically.
 
-#### `unregister_agentic_ability( string $id ): bool`
+#### `wp_agentic_admin_unregister_ability( string $id ): bool`
 
 Removes a previously registered ability. Returns `true` if the ability was found and removed, `false` if it did not exist.
 
 ```php
-$removed = unregister_agentic_ability( 'my-plugin/my-ability' );
+$removed = wp_agentic_admin_unregister_ability( 'my-plugin/my-ability' );
 ```
 
-#### `get_agentic_abilities(): array`
+#### `wp_agentic_admin_get_abilities(): array`
 
 Returns all registered abilities as an associative array keyed by ability ID. Each entry contains `id`, `php` (PHP config), and `js` (JS config) keys.
 
 ```php
-$all_abilities = get_agentic_abilities();
+$all_abilities = wp_agentic_admin_get_abilities();
 foreach ( $all_abilities as $id => $ability ) {
     echo $ability['php']['label'];
 }
 ```
 
-#### `get_agentic_ability( string $id ): ?array`
+#### `wp_agentic_admin_get_ability( string $id ): ?array`
 
 Returns the configuration for a specific ability, or `null` if not found.
 
 ```php
-$ability = get_agentic_ability( 'my-plugin/my-ability' );
+$ability = wp_agentic_admin_get_ability( 'my-plugin/my-ability' );
 if ( $ability ) {
     echo $ability['php']['label'];
 }
 ```
 
-#### `agentic_ability_exists( string $id ): bool`
+#### `wp_agentic_admin_ability_exists( string $id ): bool`
 
 Checks if an ability with the given ID is registered.
 
 ```php
-if ( agentic_ability_exists( 'my-plugin/my-ability' ) ) {
+if ( wp_agentic_admin_ability_exists( 'my-plugin/my-ability' ) ) {
     // Ability is registered
 }
 ```
@@ -701,11 +701,11 @@ Here's a complete example of a third-party plugin adding an ability:
 
 // Register the ability
 add_action( 'wp_agentic_admin_register_abilities', function() {
-    if ( ! function_exists( 'register_agentic_ability' ) ) {
+    if ( ! function_exists( 'wp_agentic_admin_register_ability' ) ) {
         return;
     }
     
-    register_agentic_ability(
+    wp_agentic_admin_register_ability(
         'my-plugin/count-posts',
         array(
             'label'            => __( 'Count Posts', 'my-plugin' ),

--- a/docs/ai-fundamentals/09-tools-and-abilities.md
+++ b/docs/ai-fundamentals/09-tools-and-abilities.md
@@ -55,7 +55,7 @@ Both refer to the same underlying operations.
 Abilities are registered with WordPress using the Abilities API:
 
 ```php
-register_agentic_ability(
+wp_agentic_admin_register_ability(
     'wp-agentic-admin/plugin-list',  // Unique ID
     array(
         'label'               => 'List installed plugins',
@@ -495,7 +495,7 @@ Other plugins can register custom abilities:
 
 ```php
 add_action( 'wp_agentic_admin_register_abilities', function() {
-    register_agentic_ability(
+    wp_agentic_admin_register_ability(
         'my-plugin/custom-ability',
         array(
             'label'            => 'My Custom Action',

--- a/docs/ai-fundamentals/11-tool-selection-at-scale.md
+++ b/docs/ai-fundamentals/11-tool-selection-at-scale.md
@@ -339,7 +339,7 @@ Third-party abilities automatically work:
 
 ```php
 // Third-party plugin
-register_agentic_ability(
+wp_agentic_admin_register_ability(
     'my-plugin/backup-restore',
     array(
         'description' => 'Restore site from backup file',

--- a/docs/ai-fundamentals/glossary.md
+++ b/docs/ai-fundamentals/glossary.md
@@ -10,7 +10,7 @@ Quick reference for the terms used across the AI Fundamentals chapters. Entries 
 A discrete operation the AI can execute on WordPress — for example, reading error logs or listing plugins. Each ability has an ID, description, input/output schema, execute callback, and permission check. See [Ch. 9](09-tools-and-abilities.md).
 
 **Abilities API**
-The WordPress registration system for tools. PHP abilities are registered with `register_agentic_ability()`, JS abilities with `registerAbility()`. See [Ch. 9](09-tools-and-abilities.md).
+The WordPress registration system for tools. PHP abilities are registered with `wp_agentic_admin_register_ability()`, JS abilities with `registerAbility()`. See [Ch. 9](09-tools-and-abilities.md).
 
 **Activation (Service Worker)**
 The lifecycle phase where a newly installed Service Worker takes control and can start intercepting requests. See [Ch. 7](07-service-worker-persistence.md).

--- a/includes/abilities/backup-check.php
+++ b/includes/abilities/backup-check.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_backup_check(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/backup-check',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/cache-flush.php
+++ b/includes/abilities/cache-flush.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_cache_flush(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/cache-flush',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/comment-stats.php
+++ b/includes/abilities/comment-stats.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_comment_stats(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/comment-stats',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/cron-list.php
+++ b/includes/abilities/cron-list.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_cron_list(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/cron-list',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/current-user-role.php
+++ b/includes/abilities/current-user-role.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_current_user_role(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/current-user-role',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/db-optimize.php
+++ b/includes/abilities/db-optimize.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_db_optimize(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/db-optimize',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/discover-plugin-abilities.php
+++ b/includes/abilities/discover-plugin-abilities.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_discover_plugin_abilities(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/discover-plugin-abilities',
 		array(
 			'label'               => __( 'Discover Plugin Abilities', 'wp-agentic-admin' ),

--- a/includes/abilities/disk-usage.php
+++ b/includes/abilities/disk-usage.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_disk_usage(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/disk-usage',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/error-log-read.php
+++ b/includes/abilities/error-log-read.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_error_log_read(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/error-log-read',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/error-log-search.php
+++ b/includes/abilities/error-log-search.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_error_log_search(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/error-log-search',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/opcode-cache-status.php
+++ b/includes/abilities/opcode-cache-status.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_opcode_cache_status(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/opcode-cache-status',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/plugin-activate.php
+++ b/includes/abilities/plugin-activate.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_plugin_activate(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/plugin-activate',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/plugin-deactivate.php
+++ b/includes/abilities/plugin-deactivate.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_plugin_deactivate(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/plugin-deactivate',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/plugin-list.php
+++ b/includes/abilities/plugin-list.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_plugin_list(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/plugin-list',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/post-list.php
+++ b/includes/abilities/post-list.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_post_list(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/post-list',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/query-database.php
+++ b/includes/abilities/query-database.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_query_database(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/query-database',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/read-file.php
+++ b/includes/abilities/read-file.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_read_file(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/read-file',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/revision-cleanup.php
+++ b/includes/abilities/revision-cleanup.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_revision_cleanup(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/revision-cleanup',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/rewrite-flush.php
+++ b/includes/abilities/rewrite-flush.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_rewrite_flush(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/rewrite-flush',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/rewrite-list.php
+++ b/includes/abilities/rewrite-list.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_rewrite_list(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/rewrite-list',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/run-plugin-ability.php
+++ b/includes/abilities/run-plugin-ability.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_run_plugin_ability(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/run-plugin-ability',
 		array(
 			'label'               => __( 'Run Plugin Ability', 'wp-agentic-admin' ),

--- a/includes/abilities/security-scan.php
+++ b/includes/abilities/security-scan.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_security_scan(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/security-scan',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/security/database-check.php
+++ b/includes/abilities/security/database-check.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_database_check(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/database-check',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/security/verify-core-checksums.php
+++ b/includes/abilities/security/verify-core-checksums.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_verify_core_checksums(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/verify-core-checksums',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/security/verify-plugin-checksums.php
+++ b/includes/abilities/security/verify-plugin-checksums.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_verify_plugin_checksums(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/verify-plugin-checksums',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/site-health.php
+++ b/includes/abilities/site-health.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_site_health(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/site-health',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/theme-list.php
+++ b/includes/abilities/theme-list.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_theme_list(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/theme-list',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/transient-flush.php
+++ b/includes/abilities/transient-flush.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_transient_flush(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/transient-flush',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/update-check.php
+++ b/includes/abilities/update-check.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_update_check(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/update-check',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/user-list.php
+++ b/includes/abilities/user-list.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_user_list(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/user-list',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/web-search.php
+++ b/includes/abilities/web-search.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_web_search(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/web-search',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/abilities/write-file.php
+++ b/includes/abilities/write-file.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wp_agentic_admin_register_write_file(): void {
-	register_agentic_ability(
+	wp_agentic_admin_register_ability(
 		'wp-agentic-admin/write-file',
 		// PHP configuration for WordPress Abilities API.
 		array(

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -260,13 +260,13 @@ class Abilities {
 		 * Fires after core abilities are registered.
 		 *
 		 * Third-party plugins can use this action to register their own abilities
-		 * using the register_agentic_ability() function.
+		 * using the wp_agentic_admin_register_ability() function.
 		 *
 		 * @since 0.1.0
 		 *
 		 * @example
 		 * add_action( 'wp_agentic_admin_register_abilities', function() {
-		 *     register_agentic_ability(
+		 *     wp_agentic_admin_register_ability(
 		 *         'my-plugin/my-ability',
 		 *         array(
 		 *             'label'            => 'My Ability',

--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -140,8 +140,8 @@ class Admin_Page {
 
 		// Get JS configurations for registered abilities.
 		$abilities_js_config = array();
-		if ( function_exists( 'get_agentic_abilities_js_config' ) ) {
-			$abilities_js_config = get_agentic_abilities_js_config();
+		if ( function_exists( 'wp_agentic_admin_get_abilities_js_config' ) ) {
+			$abilities_js_config = wp_agentic_admin_get_abilities_js_config();
 		}
 
 		$feedback_optin_raw = $settings->get_field( 'feedback_optin', null );

--- a/includes/functions-abilities.php
+++ b/includes/functions-abilities.php
@@ -40,7 +40,7 @@ $wp_agentic_abilities = array();
  *                           - confirmationMessage: (string) Custom confirmation message.
  * @return bool True on success, false on failure.
  */
-function register_agentic_ability( string $id, array $php_args, array $js_args = array() ): bool {
+function wp_agentic_admin_register_ability( string $id, array $php_args, array $js_args = array() ): bool {
 	global $wp_agentic_abilities;
 
 	// Validate ID format.
@@ -89,7 +89,7 @@ function register_agentic_ability( string $id, array $php_args, array $js_args =
  * @param string $id Ability identifier.
  * @return bool True if ability was unregistered, false if it didn't exist.
  */
-function unregister_agentic_ability( string $id ): bool {
+function wp_agentic_admin_unregister_ability( string $id ): bool {
 	global $wp_agentic_abilities;
 
 	if ( ! isset( $wp_agentic_abilities[ $id ] ) ) {
@@ -113,7 +113,7 @@ function unregister_agentic_ability( string $id ): bool {
  *
  * @return array Array of registered abilities.
  */
-function get_agentic_abilities(): array {
+function wp_agentic_admin_get_abilities(): array {
 	global $wp_agentic_abilities;
 	return $wp_agentic_abilities ?? array();
 }
@@ -126,7 +126,7 @@ function get_agentic_abilities(): array {
  * @param string $id Ability identifier.
  * @return array|null Ability configuration or null if not found.
  */
-function get_agentic_ability( string $id ): ?array {
+function wp_agentic_admin_get_ability( string $id ): ?array {
 	global $wp_agentic_abilities;
 	return $wp_agentic_abilities[ $id ] ?? null;
 }
@@ -141,7 +141,7 @@ function get_agentic_ability( string $id ): ?array {
  *
  * @return array Array of JS configurations keyed by ability ID.
  */
-function get_agentic_abilities_js_config(): array {
+function wp_agentic_admin_get_abilities_js_config(): array {
 	global $wp_agentic_abilities;
 
 	$js_configs = array();
@@ -176,7 +176,7 @@ function get_agentic_abilities_js_config(): array {
  * @param string $id Ability identifier.
  * @return bool True if ability exists.
  */
-function agentic_ability_exists( string $id ): bool {
+function wp_agentic_admin_ability_exists( string $id ): bool {
 	global $wp_agentic_abilities;
 	return isset( $wp_agentic_abilities[ $id ] );
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,18 +26,9 @@
 				<element value="WPAgenticAdmin"/>
 			</property>
 		</properties>
-		<!-- Exclude public API functions - intentionally unprefixed for clean developer experience -->
-		<exclude-pattern>includes/functions-abilities\.php</exclude-pattern>
 	</rule>
 
-	<!-- Allow unprefixed public API functions in abilities API -->
-	<!-- These are intentionally unprefixed for third-party developer experience -->
-	<!-- Example: register_agentic_ability() is cleaner than wp_agentic_admin_register_agentic_ability() -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound">
-		<exclude-pattern>includes/functions-abilities\.php</exclude-pattern>
-	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound">
-		<exclude-pattern>includes/functions-abilities\.php</exclude-pattern>
 		<!-- Allow WordPress core variables in uninstall.php (e.g., $sites, $site from get_sites()) -->
 		<exclude-pattern>uninstall\.php</exclude-pattern>
 	</rule>

--- a/src/extensions/services/agentic-abilities-api.js
+++ b/src/extensions/services/agentic-abilities-api.js
@@ -33,7 +33,7 @@ const log = createLogger( 'AgenticAbilitiesAPI' );
  * It can be called after the wp-agentic-admin scripts are loaded.
  *
  * @param {string}   id                                  - Unique ability identifier (e.g., 'my-plugin/my-ability').
- *                                                       Must match the ID used in register_agentic_ability() in PHP.
+ *                                                       Must match the ID used in wp_agentic_admin_register_ability() in PHP.
  * @param {Object}   config                              - Ability configuration.
  * @param {string}   [config.description]                - One-sentence description of what this ability does and what data
  *                                                       it returns. Shown to the LLM to help it decide when to use this tool.

--- a/src/extensions/services/wp-tools.js
+++ b/src/extensions/services/wp-tools.js
@@ -5,7 +5,7 @@
  * with the chat system. Uses the new extensible registration API.
  *
  * HOW TO ADD A NEW ABILITY:
- * 1. Create a new PHP file in includes/abilities/ with register_agentic_ability()
+ * 1. Create a new PHP file in includes/abilities/ with wp_agentic_admin_register_ability()
  * 2. Create a new JS file in src/extensions/abilities/ using registerAbility()
  * 3. Export it from src/extensions/abilities/index.js
  * 4. The ability will be automatically registered on init

--- a/wp-agentic-admin.php
+++ b/wp-agentic-admin.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WPAgenticAdmin' ) ) {
 			$this->define_constants();
 			$this->load_textdomain();
 
-			// Load functions first (provides register_agentic_ability API).
+			// Load functions first (provides wp_agentic_admin_register_ability API).
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/functions-abilities.php';
 
 			require_once WP_AGENTIC_ADMIN_PLUGIN_DIR . 'includes/class-utils.php';


### PR DESCRIPTION
## What does this PR do?

resolves #120 

The main change is renaming all ability-related functions to use the `wp_agentic_admin_` prefix



**API function renaming and namespacing:**

* All public PHP functions for ability registration and management have been renamed to use the `wp_agentic_admin_` prefix:
  - `register_agentic_ability()` → `wp_agentic_admin_register_ability()`
  - `unregister_agentic_ability()` → `wp_agentic_admin_unregister_ability()`
  - `agentic_ability_exists()` → `wp_agentic_admin_ability_exists()`
  - `get_agentic_abilities()` → `wp_agentic_admin_get_abilities()`
  - `get_agentic_ability()` → `wp_agentic_admin_get_ability()`
  - `get_agentic_abilities_js_config()` → `wp_agentic_admin_get_abilities_js_config()` 

* All ability registration calls in `includes/abilities/*.php` have been updated to use the new `wp_agentic_admin_register_ability()` function

**Documentation and onboarding updates:**

* All references in documentation files (`README.md`, `ONBOARDING.md`, `ARCHITECTURE.md`, `ABILITIES-GUIDE.md`, `THIRD-PARTY-INTEGRATION.md`, and AI Fundamentals docs) have been updated to use the new function names and to clarify the new API.

This update ensures a consistent, namespaced API surface for all ability-related functionality, making the codebase easier to maintain and integrate with third-party plugins.

<!-- One or two sentences -->

## Type

- [ ] New ability
- [ ] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

<!-- Steps to verify this works -->

1. look at the code
2.

## Screenshots (if UI changes)

<!-- Drop a screenshot or GIF here -->
