### PR TITLE
fix: ability result status UI

### DIFF
--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -833,7 +833,7 @@ const MessageItem = ( {
 
 		const statusLabel = {
 			success: 'Task completed successfully',
-			info: 'Finished processing but failed to complete the task',
+			info: 'Finished processing but could not perform the task',
 			error: 'Failed',
 		};
 

--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -819,24 +819,34 @@ const MessageItem = ( {
 		);
 	}
 
-	// Ability result - collapsible with success/error state
+	// Ability result - collapsible with success/info state
 	if ( type === MessageType.ABILITY_RESULT ) {
-		const isSuccess = meta?.success;
+		// Two visual states:
+		//   'success' — tool ran and task succeeded (green, checkmark)
+		//   'info'    — tool ran but task goal not achieved (blue, eye)
+		const resultStatus =
+			meta?.success === false ||
+			( meta?.success === undefined &&
+				( meta?.result?.success === false || meta?.result?.error ) )
+				? 'info'
+				: 'success';
+
+		const statusLabel = {
+			success: 'Task completed successfully',
+			info: 'Finished processing but failed to complete the task',
+			error: 'Failed',
+		};
 
 		return (
 			<div className="agentic-message agentic-message--tool">
 				<div className="agentic-timeline">
 					<div className="agentic-timeline__line" />
 					<div
-						className={ `agentic-timeline__dot agentic-timeline__dot--${
-							isSuccess ? 'success' : 'error'
-						}` }
+						className={ `agentic-timeline__dot agentic-timeline__dot--${ resultStatus }` }
 					/>
 				</div>
 				<div
-					className={ `agentic-tool agentic-tool--${
-						isSuccess ? 'success' : 'error'
-					}` }
+					className={ `agentic-tool agentic-tool--${ resultStatus }` }
 				>
 					<button
 						className="agentic-tool__header agentic-tool__header--clickable"
@@ -844,7 +854,7 @@ const MessageItem = ( {
 						type="button"
 					>
 						<span className="agentic-tool__icon">
-							{ isSuccess ? (
+							{ resultStatus === 'success' && (
 								<svg
 									width="14"
 									height="14"
@@ -855,7 +865,21 @@ const MessageItem = ( {
 								>
 									<polyline points="20 6 9 17 4 12" />
 								</svg>
-							) : (
+							) }
+							{ resultStatus === 'info' && (
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+								>
+									<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+									<circle cx="12" cy="12" r="3" />
+								</svg>
+							) }
+							{ resultStatus === 'error' && (
 								<svg
 									width="14"
 									height="14"
@@ -871,23 +895,10 @@ const MessageItem = ( {
 							) }
 						</span>
 						<span className="agentic-tool__label">
-							{ isSuccess ? 'Completed' : 'Failed' }
+							{ statusLabel[ resultStatus ] }
 						</span>
-						<span
-							className={ `agentic-tool__expand ${
-								isExpanded ? 'agentic-tool__expand--open' : ''
-							}` }
-						>
-							<svg
-								width="12"
-								height="12"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-							>
-								<polyline points="6 9 12 15 18 9" />
-							</svg>
+						<span className="agentic-tool__expand">
+							{ isExpanded ? 'Hide details' : 'Show details' }
 						</span>
 						<span className="agentic-tool__id">
 							{ meta?.abilityId }

--- a/src/extensions/services/chat-orchestrator.js
+++ b/src/extensions/services/chat-orchestrator.js
@@ -24,6 +24,25 @@ import { createLogger } from '../utils/logger';
 const log = createLogger( 'ChatOrchestrator' );
 
 /**
+ * Check whether a tool result indicates business-level success.
+ *
+ * @param {*} result - The raw result from tool.execute().
+ * @return {boolean} True if the result does not indicate failure.
+ */
+function isToolResultSuccess( result ) {
+	if ( ! result || typeof result !== 'object' ) {
+		return true;
+	}
+	if ( result.success === false ) {
+		return false;
+	}
+	if ( result.error && ! result.success ) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Build system prompt for conversational queries
  *
  * Simple prompt used when the LLM is answering questions without tools.
@@ -317,8 +336,9 @@ class ChatOrchestrator {
 				num_results: 5,
 			} );
 
-			this.callbacks.onToolEnd( toolId, result, true );
-			this.session.addToolResult( toolId, result, true );
+			const webSuccess = isToolResultSuccess( result );
+			this.callbacks.onToolEnd( toolId, result, webSuccess );
+			this.session.addToolResult( toolId, result, webSuccess );
 
 			log.info(
 				`Web search pre-step complete: ${ result.total || 0 } results`
@@ -494,7 +514,8 @@ class ChatOrchestrator {
 		try {
 			// Pass userMessage to execute so tools can extract parameters
 			result = await tool.execute( { userMessage } );
-			this.session.addToolResult( tool.id, result, true );
+			success = isToolResultSuccess( result );
+			this.session.addToolResult( tool.id, result, success );
 		} catch ( error ) {
 			result = { error: error.message };
 			success = false;

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -15,6 +15,29 @@ import { createLogger } from '../utils/logger';
 const log = createLogger( 'ReactAgent' );
 
 /**
+ * Check whether a tool result indicates business-level success.
+ *
+ * PHP abilities return { success: false, message } on failure.
+ * JS-only abilities may return { error: '...' } instead.
+ * Abilities without a success field default to true (backward compatible).
+ *
+ * @param {*} result - The raw result from tool.execute().
+ * @return {boolean} True if the result does not indicate failure.
+ */
+function isToolResultSuccess( result ) {
+	if ( ! result || typeof result !== 'object' ) {
+		return true;
+	}
+	if ( result.success === false ) {
+		return false;
+	}
+	if ( result.error && ! result.success ) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * ReAct Agent Configuration
  */
 const REACT_CONFIG = {
@@ -362,9 +385,9 @@ class ReactAgent {
 					const truncatedResult =
 						resultStr.length > this.config.maxToolResultLength
 							? resultStr.substring(
-								0,
-								this.config.maxToolResultLength
-							) + '...[truncated]'
+									0,
+									this.config.maxToolResultLength
+							  ) + '...[truncated]'
 							: resultStr;
 
 					// Add observation to conversation with JSON format reminder
@@ -765,7 +788,8 @@ class ReactAgent {
 			// Execute the tool
 			const result = await tool.execute( { userMessage, ...args } );
 
-			this.callbacks.onToolEnd( toolId, result, true );
+			const toolSuccess = isToolResultSuccess( result );
+			this.callbacks.onToolEnd( toolId, result, toolSuccess );
 
 			// Generate plain-English interpretation for the LLM.
 			// This helps small models understand tool results correctly,

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -2785,6 +2785,10 @@
 				background: #00a32a;
 			}
 
+			&--info {
+				background: #2271b1;
+			}
+
 			&--error {
 				background: #d63638;
 			}
@@ -2819,6 +2823,11 @@
 		&--success {
 			border-color: #b8e6bf;
 			background: #f7fcf8;
+		}
+
+		&--info {
+			border-color: #b8d4e6;
+			background: #f0f6fc;
 		}
 
 		&--error {
@@ -2859,6 +2868,10 @@
 				color: #00a32a;
 			}
 
+			.agentic-tool--info & {
+				color: #2271b1;
+			}
+
 			.agentic-tool--error & {
 				color: #d63638;
 			}
@@ -2889,13 +2902,12 @@
 		}
 
 		&__expand {
-			display: flex;
-			align-items: center;
-			color: #8c8f94;
-			transition: transform 0.2s ease;
+			font-size: 12px;
+			color: #2271b1;
+			margin-left: 8px;
 
-			&--open {
-				transform: rotate(180deg);
+			&:hover {
+				text-decoration: underline;
 			}
 		}
 


### PR DESCRIPTION
## What does this PR do?

When an ability fails at the business level (e.g., plugin activation fails or plugin not found), the UI now shows a blue info state with an eye icon and descriptive messaging instead of a misleading green "Completed" checkmark. Also replaces the expand/collapse chevron arrow with a "Show details"/"Hide details" text link for better discoverability.

## Type

- [ ] New ability
- [ ] New workflow
- [x] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

1. Load the plugin and open the chat interface
2. Ask the assistant to activate a plugin that doesn't exist (e.g., "activate xyz") — verify blue dot, blue border, eye icon, message reads "Finished processing but could not perform the task", and "Show details" link appears
3. Ask the assistant to activate a plugin that has a known activation issue — verify same blue info state
4. Ask the assistant to list plugins — verify green dot, green border, checkmark icon, message reads "Task completed successfully"
5. Click "Show details" — verify it expands to show result JSON and text changes to "Hide details"
6. Run `npm test` — 43/43 tests pass
7. Run `npm run build` — compiles without errors

## Screenshots (if UI changes)

<img width="649" height="145" alt="image" src="https://github.com/user-attachments/assets/2fc17eca-6a5e-48f1-be9c-8c7e7cbf5173" />

Fixes: [UI] Plugin incorrectly reports task completion upon failure #74
