### PR TITLE
feat: fuzzy plugin name matching with candidate selection

### DIFF
--- a/includes/abilities/plugin-activate.php
+++ b/includes/abilities/plugin-activate.php
@@ -23,14 +23,14 @@ function wp_agentic_admin_register_plugin_activate(): void {
 		// PHP configuration for WordPress Abilities API.
 		array(
 			'label'               => __( 'Activate Plugin', 'wp-agentic-admin' ),
-			'description'         => __( 'Activate a specific plugin by its slug.', 'wp-agentic-admin' ),
+			'description'         => __( 'Activate a specific plugin by its name or slug.', 'wp-agentic-admin' ),
 			'category'            => 'sre-tools',
 			'input_schema'        => array(
 				'type'                 => 'object',
 				'properties'           => array(
 					'plugin' => array(
 						'type'        => 'string',
-						'description' => __( 'The plugin file path (slug) to activate.', 'wp-agentic-admin' ),
+						'description' => __( 'The plugin name or file path (slug) to activate.', 'wp-agentic-admin' ),
 					),
 				),
 				'required'             => array( 'plugin' ),

--- a/includes/abilities/plugin-deactivate.php
+++ b/includes/abilities/plugin-deactivate.php
@@ -23,14 +23,14 @@ function wp_agentic_admin_register_plugin_deactivate(): void {
 		// PHP configuration for WordPress Abilities API.
 		array(
 			'label'               => __( 'Deactivate Plugin', 'wp-agentic-admin' ),
-			'description'         => __( 'Deactivate a specific plugin by its slug.', 'wp-agentic-admin' ),
+			'description'         => __( 'Deactivate a specific plugin by its name or slug.', 'wp-agentic-admin' ),
 			'category'            => 'sre-tools',
 			'input_schema'        => array(
 				'type'                 => 'object',
 				'properties'           => array(
 					'plugin' => array(
 						'type'        => 'string',
-						'description' => __( 'The plugin file path (slug) to deactivate.', 'wp-agentic-admin' ),
+						'description' => __( 'The plugin name or file path (slug) to deactivate.', 'wp-agentic-admin' ),
 					),
 				),
 				'required'             => array( 'plugin' ),

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -81,6 +81,165 @@ function wp_agentic_admin_get_all_plugins( string $status_filter = 'all' ): arra
 
 
 /**
+ * Resolve a plugin identifier (name, slug, or partial match) to a plugin file path.
+ *
+ * Uses tiered matching with certainty scoring:
+ * - Tier 1 (10.0): Exact slug match (e.g. "akismet/akismet.php")
+ * - Tier 2 (9.5):  Exact name match, case-insensitive
+ * - Tier 3 (9.0):  Slug directory prefix (e.g. "akismet" matches "akismet/akismet.php")
+ * - Tier 4 (8.0):  Name starts with input
+ * - Tier 5 (6.0):  Input is substring of name
+ * - Tier 6 (5.0):  Name is substring of input
+ *
+ * If multiple plugins match at the same tier, certainty is reduced by 1.0.
+ *
+ * @param string $identifier Plugin name, slug, or partial string.
+ * @return array {
+ *     @type string|null $plugin_file Resolved plugin file path, or null if no match.
+ *     @type string|null $plugin_name Display name of the matched plugin.
+ *     @type float       $certainty   Match confidence from 1.0 to 10.0.
+ *     @type array       $candidates  Top candidates with their certainty scores.
+ * }
+ */
+function wp_agentic_admin_resolve_plugin( string $identifier ): array {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$all_plugins = get_plugins();
+	$input_lower = strtolower( trim( $identifier ) );
+
+	if ( '' === $input_lower ) {
+		return array(
+			'plugin_file' => null,
+			'plugin_name' => null,
+			'certainty'   => 0.0,
+			'candidates'  => array(),
+		);
+	}
+
+	// Collect all matches with their tier and certainty.
+	$matches = array();
+
+	foreach ( $all_plugins as $plugin_file => $plugin_data ) {
+		$name_lower = strtolower( $plugin_data['Name'] );
+		$slug_dir   = strtolower( dirname( $plugin_file ) );
+
+		// Tier 1: Exact slug match.
+		if ( strtolower( $plugin_file ) === $input_lower ) {
+			$matches[] = array(
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_data['Name'],
+				'tier'        => 1,
+				'certainty'   => 10.0,
+			);
+			continue;
+		}
+
+		// Tier 2: Exact name match (case-insensitive).
+		if ( $name_lower === $input_lower ) {
+			$matches[] = array(
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_data['Name'],
+				'tier'        => 2,
+				'certainty'   => 9.5,
+			);
+			continue;
+		}
+
+		// Tier 3: Slug directory prefix (e.g. "akismet" matches "akismet/akismet.php").
+		if ( '.' !== $slug_dir && $slug_dir === $input_lower ) {
+			$matches[] = array(
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_data['Name'],
+				'tier'        => 3,
+				'certainty'   => 9.0,
+			);
+			continue;
+		}
+
+		// Tier 4: Name starts with input.
+		if ( str_starts_with( $name_lower, $input_lower ) ) {
+			$matches[] = array(
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_data['Name'],
+				'tier'        => 4,
+				'certainty'   => 8.0,
+			);
+			continue;
+		}
+
+		// Tier 5: Input is substring of name.
+		if ( false !== strpos( $name_lower, $input_lower ) ) {
+			$matches[] = array(
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_data['Name'],
+				'tier'        => 5,
+				'certainty'   => 6.0,
+			);
+			continue;
+		}
+
+		// Tier 6: Name is substring of input.
+		if ( false !== strpos( $input_lower, $name_lower ) ) {
+			$matches[] = array(
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_data['Name'],
+				'tier'        => 6,
+				'certainty'   => 5.0,
+			);
+			continue;
+		}
+	}
+
+	if ( empty( $matches ) ) {
+		return array(
+			'plugin_file' => null,
+			'plugin_name' => null,
+			'certainty'   => 0.0,
+			'candidates'  => array(),
+		);
+	}
+
+	// Sort by tier (ascending = best first), then by name length (shorter = more specific).
+	usort(
+		$matches,
+		function ( $a, $b ) {
+			if ( $a['tier'] !== $b['tier'] ) {
+				return $a['tier'] - $b['tier'];
+			}
+			return strlen( $a['plugin_name'] ) - strlen( $b['plugin_name'] );
+		}
+	);
+
+	$best      = $matches[0];
+	$best_tier = $best['tier'];
+
+	// Count how many matches share the best tier.
+	$same_tier_count = 0;
+	foreach ( $matches as $match ) {
+		if ( $match['tier'] === $best_tier ) {
+			++$same_tier_count;
+		}
+	}
+
+	// Reduce certainty if multiple plugins matched at the same tier.
+	if ( $same_tier_count > 1 ) {
+		$best['certainty'] = max( 1.0, $best['certainty'] - 1.0 );
+	}
+
+	// Build candidates list (top 5).
+	$candidates = array_slice( $matches, 0, 5 );
+
+	return array(
+		'plugin_file' => $best['plugin_file'],
+		'plugin_name' => $best['plugin_name'],
+		'certainty'   => $best['certainty'],
+		'candidates'  => $candidates,
+	);
+}
+
+/**
  * Get plugin data by slug.
  *
  * @param string $plugin_file The plugin file path (slug).
@@ -109,38 +268,58 @@ function wp_agentic_admin_get_plugin_by_slug( string $plugin_file ): ?array {
 }
 
 /**
- * Activate a plugin by its slug.
+ * Activate a plugin by its slug or name.
  *
- * @param string $plugin_file The plugin file path (slug) to activate.
- * @return array Result with success status and message.
+ * Accepts either an exact plugin file path (e.g. "akismet/akismet.php") or a
+ * display name / partial match. Uses fuzzy resolution with certainty scoring.
+ * If certainty is below 8.0, returns action buttons for the top candidates
+ * instead of activating.
+ *
+ * @param string $plugin_identifier The plugin file path, name, or partial match.
+ * @return array Result with success status, message, certainty, and optional actions.
  */
-function wp_agentic_admin_activate_plugin_by_slug( string $plugin_file ): array {
-	$plugin_file = sanitize_text_field( $plugin_file );
-	$plugin_data = wp_agentic_admin_get_plugin_by_slug( $plugin_file );
+function wp_agentic_admin_activate_plugin_by_slug( string $plugin_identifier ): array {
+	$plugin_identifier = sanitize_text_field( $plugin_identifier );
+	$resolved          = wp_agentic_admin_resolve_plugin( $plugin_identifier );
 
-	// Check if plugin exists.
-	if ( null === $plugin_data ) {
+	// No match at all.
+	if ( null === $resolved['plugin_file'] ) {
 		return array(
-			'success' => false,
-			'message' => sprintf(
-				/* translators: %s: plugin file path */
-				__( 'Plugin "%s" not found.', 'wp-agentic-admin' ),
-				$plugin_file
+			'success'   => false,
+			'message'   => sprintf(
+				/* translators: %s: plugin identifier */
+				__( 'No plugin found matching "%s".', 'wp-agentic-admin' ),
+				$plugin_identifier
 			),
+			'certainty' => 0.0,
 		);
 	}
 
-	$plugin_name = $plugin_data['name'];
+	// Low certainty — return candidates as action buttons.
+	if ( $resolved['certainty'] < 8.0 ) {
+		return wp_agentic_admin_build_candidate_response(
+			$resolved,
+			$plugin_identifier,
+			'wp-agentic-admin/plugin-activate',
+			__( 'Activate', 'wp-agentic-admin' )
+		);
+	}
+
+	$plugin_file = $resolved['plugin_file'];
+	$plugin_name = $resolved['plugin_name'];
+	$certainty   = $resolved['certainty'];
 
 	// Check if already active.
-	if ( $plugin_data['active'] ) {
+	if ( is_plugin_active( $plugin_file ) ) {
 		return array(
-			'success' => true,
-			'message' => sprintf(
+			'success'        => true,
+			'message'        => sprintf(
 				/* translators: %s: plugin name */
 				__( 'Plugin "%s" is already active.', 'wp-agentic-admin' ),
 				$plugin_name
 			),
+			'matched_plugin' => $plugin_name,
+			'certainty'      => $certainty,
 		);
 	}
 
@@ -150,71 +329,97 @@ function wp_agentic_admin_activate_plugin_by_slug( string $plugin_file ): array 
 	// Check if activation failed.
 	if ( is_wp_error( $result ) ) {
 		return array(
-			'success' => false,
-			'message' => sprintf(
+			'success'        => false,
+			'message'        => sprintf(
 				/* translators: 1: plugin name, 2: error message */
 				__( 'Failed to activate plugin "%1$s": %2$s', 'wp-agentic-admin' ),
 				$plugin_name,
 				$result->get_error_message()
 			),
+			'matched_plugin' => $plugin_name,
+			'certainty'      => $certainty,
 		);
 	}
 
 	// Verify activation.
 	if ( ! is_plugin_active( $plugin_file ) ) {
 		return array(
-			'success' => false,
-			'message' => sprintf(
+			'success'        => false,
+			'message'        => sprintf(
 				/* translators: %s: plugin name */
 				__( 'Failed to activate plugin "%s".', 'wp-agentic-admin' ),
 				$plugin_name
 			),
+			'matched_plugin' => $plugin_name,
+			'certainty'      => $certainty,
 		);
 	}
 
 	return array(
-		'success' => true,
-		'message' => sprintf(
+		'success'        => true,
+		'message'        => sprintf(
 			/* translators: %s: plugin name */
 			__( 'Plugin "%s" has been activated successfully.', 'wp-agentic-admin' ),
 			$plugin_name
 		),
+		'matched_plugin' => $plugin_name,
+		'certainty'      => $certainty,
 	);
 }
 
 /**
- * Deactivate a plugin by its slug.
+ * Deactivate a plugin by its slug or name.
  *
- * @param string $plugin_file The plugin file path (slug) to deactivate.
- * @return array Result with success status and message.
+ * Accepts either an exact plugin file path (e.g. "akismet/akismet.php") or a
+ * display name / partial match. Uses fuzzy resolution with certainty scoring.
+ * If certainty is below 8.0, returns action buttons for the top candidates
+ * instead of deactivating.
+ *
+ * @param string $plugin_identifier The plugin file path, name, or partial match.
+ * @return array Result with success status, message, certainty, and optional actions.
  */
-function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_file ): array {
-	$plugin_file = sanitize_text_field( $plugin_file );
-	$plugin_data = wp_agentic_admin_get_plugin_by_slug( $plugin_file );
+function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_identifier ): array {
+	$plugin_identifier = sanitize_text_field( $plugin_identifier );
+	$resolved          = wp_agentic_admin_resolve_plugin( $plugin_identifier );
 
-	// Check if plugin exists.
-	if ( null === $plugin_data ) {
+	// No match at all.
+	if ( null === $resolved['plugin_file'] ) {
 		return array(
-			'success' => false,
-			'message' => sprintf(
-				/* translators: %s: plugin file path */
-				__( 'Plugin "%s" not found.', 'wp-agentic-admin' ),
-				$plugin_file
+			'success'   => false,
+			'message'   => sprintf(
+				/* translators: %s: plugin identifier */
+				__( 'No plugin found matching "%s".', 'wp-agentic-admin' ),
+				$plugin_identifier
 			),
+			'certainty' => 0.0,
 		);
 	}
 
-	$plugin_name = $plugin_data['name'];
+	// Low certainty — return candidates as action buttons.
+	if ( $resolved['certainty'] < 8.0 ) {
+		return wp_agentic_admin_build_candidate_response(
+			$resolved,
+			$plugin_identifier,
+			'wp-agentic-admin/plugin-deactivate',
+			__( 'Deactivate', 'wp-agentic-admin' )
+		);
+	}
+
+	$plugin_file = $resolved['plugin_file'];
+	$plugin_name = $resolved['plugin_name'];
+	$certainty   = $resolved['certainty'];
 
 	// Check if already inactive.
-	if ( ! $plugin_data['active'] ) {
+	if ( ! is_plugin_active( $plugin_file ) ) {
 		return array(
-			'success' => true,
-			'message' => sprintf(
+			'success'        => true,
+			'message'        => sprintf(
 				/* translators: %s: plugin name */
 				__( 'Plugin "%s" is already inactive.', 'wp-agentic-admin' ),
 				$plugin_name
 			),
+			'matched_plugin' => $plugin_name,
+			'certainty'      => $certainty,
 		);
 	}
 
@@ -224,21 +429,61 @@ function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_file ): arra
 	// Verify deactivation.
 	if ( is_plugin_active( $plugin_file ) ) {
 		return array(
-			'success' => false,
-			'message' => sprintf(
+			'success'        => false,
+			'message'        => sprintf(
 				/* translators: %s: plugin name */
 				__( 'Failed to deactivate plugin "%s".', 'wp-agentic-admin' ),
 				$plugin_name
 			),
+			'matched_plugin' => $plugin_name,
+			'certainty'      => $certainty,
 		);
 	}
 
 	return array(
-		'success' => true,
-		'message' => sprintf(
+		'success'        => true,
+		'message'        => sprintf(
 			/* translators: %s: plugin name */
 			__( 'Plugin "%s" has been deactivated.', 'wp-agentic-admin' ),
 			$plugin_name
 		),
+		'matched_plugin' => $plugin_name,
+		'certainty'      => $certainty,
+	);
+}
+
+/**
+ * Build a response with candidate action buttons when certainty is low.
+ *
+ * Returns a structured response with action buttons for the top plugin
+ * candidates, allowing the user to select the correct one.
+ *
+ * @param array  $resolved         Result from wp_agentic_admin_resolve_plugin().
+ * @param string $original_input   The user's original input string.
+ * @param string $action_id        The ability action ID (e.g. "wp-agentic-admin/plugin-activate").
+ * @param string $button_label     Label for the action button (e.g. "Activate").
+ * @return array Response with actions for UI buttons.
+ */
+function wp_agentic_admin_build_candidate_response( array $resolved, string $original_input, string $action_id, string $button_label ): array {
+	$actions = array();
+
+	foreach ( $resolved['candidates'] as $candidate ) {
+		$actions[] = array(
+			'label'        => sprintf( '%s (%.1f/10)', $candidate['plugin_name'], $candidate['certainty'] ),
+			'button_label' => $button_label,
+			'action'       => $action_id,
+			'args'         => array( 'plugin' => $candidate['plugin_file'] ),
+		);
+	}
+
+	return array(
+		'success'   => false,
+		'message'   => sprintf(
+			/* translators: %s: user input */
+			__( 'Multiple plugins match "%s". Please select the correct one:', 'wp-agentic-admin' ),
+			$original_input
+		),
+		'certainty' => $resolved['certainty'],
+		'actions'   => $actions,
 	);
 }

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -109,6 +109,9 @@ function    wp_agentic_admin_resolve_plugin( string $identifier ): array {
 	$all_plugins = get_plugins();
 	$input_lower = strtolower( trim( $identifier ) );
 
+	// Strip trailing "plugin" (e.g. "blocks plugin" → "blocks").
+	$input_lower = preg_replace( '/\s+plugin$/', '', $input_lower );
+
 	if ( '' === $input_lower ) {
 		return array(
 			'plugin_file' => null,

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -101,7 +101,7 @@ function wp_agentic_admin_get_all_plugins( string $status_filter = 'all' ): arra
  *     @type array       $candidates  Top candidates with their certainty scores.
  * }
  */
-function wp_agentic_admin_resolve_plugin( string $identifier ): array {
+function    wp_agentic_admin_resolve_plugin( string $identifier ): array {
 	if ( ! function_exists( 'get_plugins' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}

--- a/src/extensions/abilities/plugin-activate.js
+++ b/src/extensions/abilities/plugin-activate.js
@@ -67,6 +67,9 @@ export function registerPluginActivate() {
 		 * @return {string} Human-readable summary.
 		 */
 		summarize: ( result ) => {
+			if ( result.actions?.length ) {
+				return result.message || 'Multiple plugins matched. Please select one:';
+			}
 			const base = formatPluginActionResult(
 				result,
 				'Plugin has been activated successfully.'
@@ -84,6 +87,10 @@ export function registerPluginActivate() {
 		 * @return {string} Plain-English interpretation.
 		 */
 		interpretResult: ( result ) => {
+			if ( result.actions?.length ) {
+				const names = result.actions.map( ( a ) => a.label ).join( ', ' );
+				return `Multiple plugins matched. Candidates: ${ names }. Ask the user which one to activate.`;
+			}
 			if ( result.error ) {
 				return `Plugin activation failed: ${ result.error }.`;
 			}

--- a/src/extensions/abilities/plugin-activate.js
+++ b/src/extensions/abilities/plugin-activate.js
@@ -67,10 +67,14 @@ export function registerPluginActivate() {
 		 * @return {string} Human-readable summary.
 		 */
 		summarize: ( result ) => {
-			return formatPluginActionResult(
+			const base = formatPluginActionResult(
 				result,
 				'Plugin has been activated successfully.'
 			);
+			if ( result.certainty && result.success ) {
+				return `${ base } (match confidence: ${ result.certainty }/10)`;
+			}
+			return base;
 		},
 
 		/**
@@ -83,7 +87,12 @@ export function registerPluginActivate() {
 			if ( result.error ) {
 				return `Plugin activation failed: ${ result.error }.`;
 			}
-			return result.message || 'The plugin was activated successfully.';
+			let msg =
+				result.message || 'The plugin was activated successfully.';
+			if ( result.certainty ) {
+				msg += ` Match confidence: ${ result.certainty }/10.`;
+			}
+			return msg;
 		},
 
 		// Export extractParams so it can be tested or reused.

--- a/src/extensions/abilities/plugin-deactivate.js
+++ b/src/extensions/abilities/plugin-deactivate.js
@@ -82,10 +82,14 @@ export function registerPluginDeactivate() {
 		 * @return {string} Human-readable summary.
 		 */
 		summarize: ( result ) => {
-			return formatPluginActionResult(
+			const base = formatPluginActionResult(
 				result,
 				'Plugin has been deactivated successfully.'
 			);
+			if ( result.certainty && result.success ) {
+				return `${ base } (match confidence: ${ result.certainty }/10)`;
+			}
+			return base;
 		},
 
 		/**
@@ -98,7 +102,12 @@ export function registerPluginDeactivate() {
 			if ( result.error ) {
 				return `Plugin deactivation failed: ${ result.error }.`;
 			}
-			return result.message || 'The plugin was deactivated successfully.';
+			let msg =
+				result.message || 'The plugin was deactivated successfully.';
+			if ( result.certainty ) {
+				msg += ` Match confidence: ${ result.certainty }/10.`;
+			}
+			return msg;
 		},
 
 		// Export extractParams so it can be tested or reused.

--- a/src/extensions/abilities/plugin-deactivate.js
+++ b/src/extensions/abilities/plugin-deactivate.js
@@ -82,6 +82,9 @@ export function registerPluginDeactivate() {
 		 * @return {string} Human-readable summary.
 		 */
 		summarize: ( result ) => {
+			if ( result.actions?.length ) {
+				return result.message || 'Multiple plugins matched. Please select one:';
+			}
 			const base = formatPluginActionResult(
 				result,
 				'Plugin has been deactivated successfully.'
@@ -99,6 +102,10 @@ export function registerPluginDeactivate() {
 		 * @return {string} Plain-English interpretation.
 		 */
 		interpretResult: ( result ) => {
+			if ( result.actions?.length ) {
+				const names = result.actions.map( ( a ) => a.label ).join( ', ' );
+				return `Multiple plugins matched. Candidates: ${ names }. Ask the user which one to deactivate.`;
+			}
 			if ( result.error ) {
 				return `Plugin deactivation failed: ${ result.error }.`;
 			}

--- a/src/extensions/abilities/shared/plugin-helpers.js
+++ b/src/extensions/abilities/shared/plugin-helpers.js
@@ -88,28 +88,19 @@ export function extractPluginParams( userMessage, actionKeywords = [] ) {
 		}
 	}
 
-	// Third, try to extract plugin name with regex patterns using the action keywords.
+	// Third, try to extract the plugin name from the message and pass it
+	// directly to PHP for fuzzy resolution (PHP has the full plugin list).
 	if ( actionKeywords.length > 0 ) {
 		const keywordPattern = actionKeywords.join( '|' );
-		const patterns = [
-			new RegExp(
-				`( ?: ${ keywordPattern } )\\s + ( ?: the\\s + ) ? ( ?: plugin\\s + ) ? ["']?([a-z0-9-_ ]+)["'] ? `,
-				'i'
-			),
-		];
+		const pattern = new RegExp(
+			`(?:${ keywordPattern })\\s+(?:the\\s+)?(?:plugin\\s+)?["']?([a-z0-9][a-z0-9-_ ]+[a-z0-9])["']?`,
+			'i'
+		);
 
-		for ( const pattern of patterns ) {
-			const match = userMessage.match( pattern );
-			if ( match && match[ 1 ] ) {
-				// Convert to slug format: lowercase, replace spaces with hyphens.
-				const slug = match[ 1 ]
-					.trim()
-					.toLowerCase()
-					.replace( /\s+/g, '-' );
-
-				// Guess common plugin path format: plugin-name/plugin-name.php
-				return { plugin: `${ slug } / ${ slug }.php` };
-			}
+		const match = userMessage.match( pattern );
+		if ( match && match[ 1 ] ) {
+			// Pass the raw name to PHP — it will resolve against installed plugins.
+			return { plugin: match[ 1 ].trim() };
 		}
 	}
 

--- a/src/extensions/abilities/shared/plugin-helpers.js
+++ b/src/extensions/abilities/shared/plugin-helpers.js
@@ -99,8 +99,11 @@ export function extractPluginParams( userMessage, actionKeywords = [] ) {
 
 		const match = userMessage.match( pattern );
 		if ( match && match[ 1 ] ) {
-			// Pass the raw name to PHP — it will resolve against installed plugins.
-			return { plugin: match[ 1 ].trim() };
+			// Strip trailing "plugin" (e.g. "blocks plugin" → "blocks").
+			const name = match[ 1 ].trim().replace( /\s+plugin$/i, '' );
+			if ( name ) {
+				return { plugin: name };
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **Fuzzy plugin resolution**: Activate/deactivate now accept plugin display names, not just slugs. PHP resolves against installed plugins with tiered matching (exact slug → exact name → prefix → substring).
- **Candidate action buttons**: When certainty is below 8.0 or multiple plugins match, returns top 5 candidates as clickable action buttons instead of guessing wrong.
- **Smarter name extraction**: JS strips trailing "plugin" from input (e.g. "activate the blocks plugin" → extracts "blocks").
- **LLM-aware responses**: `interpretResult` tells the LLM to ask the user to choose when match is ambiguous.

Closes #53

## Test plan
- [ ] "activate akismet" → activates directly (high certainty)
- [ ] "activate the blocks plugin" → extracts "blocks", matches correctly
- [ ] "activate cache" → shows candidate buttons if multiple cache plugins installed
- [ ] "deactivate nonexistent-plugin" → returns "no plugin found" error
- [ ] Action buttons from candidates work when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)