### PR TITLE
a11y: Add WCAG 2.2 AA accessibility support across chat interface

### DIFF
--- a/src/extensions/admin-sidebar.js
+++ b/src/extensions/admin-sidebar.js
@@ -35,10 +35,14 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	);
 
 	if ( toggleBtn ) {
+		const toggleLink = toggleBtn.querySelector( 'a' ) || toggleBtn;
+		toggleLink.setAttribute( 'aria-expanded', 'false' );
+
 		toggleBtn.addEventListener( 'click', ( e ) => {
 			e.preventDefault();
 			const isOpen = container.classList.toggle( 'is-open' );
 			toggleBtn.classList.toggle( 'is-active', isOpen );
+			toggleLink.setAttribute( 'aria-expanded', String( isOpen ) );
 		} );
 	}
 
@@ -51,9 +55,24 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			container.classList.remove( 'is-open' );
 			if ( toggleBtn ) {
 				toggleBtn.classList.remove( 'is-active' );
+				const toggleLink = toggleBtn.querySelector( 'a' ) || toggleBtn;
+				toggleLink.setAttribute( 'aria-expanded', 'false' );
 			}
 		} );
 	}
+
+	// Close sidebar on Escape key and return focus to toggle button.
+	document.addEventListener( 'keydown', ( e ) => {
+		if ( e.key === 'Escape' && container.classList.contains( 'is-open' ) ) {
+			container.classList.remove( 'is-open' );
+			if ( toggleBtn ) {
+				toggleBtn.classList.remove( 'is-active' );
+				const toggleLink = toggleBtn.querySelector( 'a' ) || toggleBtn;
+				toggleLink.setAttribute( 'aria-expanded', 'false' );
+				toggleLink.focus();
+			}
+		}
+	} );
 
 	const root = createRoot( container );
 	root.render( <AdminSidebar /> );

--- a/src/extensions/components/AbilityBrowser.jsx
+++ b/src/extensions/components/AbilityBrowser.jsx
@@ -122,6 +122,7 @@ const AbilityCard = ( { ability, onExecute, isExecuting } ) => {
 						type="button"
 						className="button button-link wp-agentic-admin-ability-card__toggle"
 						onClick={ () => setShowInput( ! showInput ) }
+						aria-expanded={ showInput }
 					>
 						{ showInput ? 'Hide parameters' : 'Show parameters' }
 					</button>
@@ -135,6 +136,7 @@ const AbilityCard = ( { ability, onExecute, isExecuting } ) => {
 									setInputJson( e.target.value )
 								}
 								placeholder='{"param": "value"}'
+								aria-label={ `JSON parameters for ${ ability.label }` }
 								rows="3"
 							/>
 							{ inputError && (
@@ -155,6 +157,7 @@ const AbilityCard = ( { ability, onExecute, isExecuting } ) => {
 					}` }
 					onClick={ handleExecute }
 					disabled={ isExecuting }
+					aria-busy={ isExecuting }
 				>
 					{ isExecuting ? (
 						<>
@@ -191,6 +194,8 @@ const ResultPanel = ( { result, onClear } ) => {
 					? 'wp-agentic-admin-result-panel--error'
 					: 'wp-agentic-admin-result-panel--success'
 			}` }
+			role="status"
+			aria-live="polite"
 		>
 			<div className="wp-agentic-admin-result-panel__header">
 				<h4>

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -809,7 +809,11 @@ const ChatContainer = ( {
 						<div className="agentic-timeline__line" />
 						<div className="agentic-timeline__dot agentic-timeline__dot--workflow" />
 					</div>
-					<div className="agentic-workflow-progress">
+					<div
+						className="agentic-workflow-progress"
+						role="status"
+						aria-live="polite"
+					>
 						<div className="agentic-workflow-progress__header">
 							<span className="agentic-workflow-progress__step">
 								Step { workflowProgress.step } of{ ' ' }
@@ -819,7 +823,14 @@ const ChatContainer = ( {
 								{ workflowProgress.label }
 							</span>
 						</div>
-						<div className="agentic-workflow-progress__bar">
+						<div
+							className="agentic-workflow-progress__bar"
+							role="progressbar"
+							aria-valuenow={ workflowProgress.percentage }
+							aria-valuemin={ 0 }
+							aria-valuemax={ 100 }
+							aria-label={ `Workflow progress: ${ workflowProgress.percentage }%` }
+						>
 							<div
 								className="agentic-workflow-progress__fill"
 								style={ {

--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -464,7 +464,7 @@ const MessageItem = ( {
 
 		return (
 			<div className="agentic-message agentic-message--tool">
-				<div className="agentic-timeline">
+				<div className="agentic-timeline" aria-hidden="true">
 					<div className="agentic-timeline__line" />
 					<div
 						className={ `agentic-timeline__dot agentic-timeline__dot--${
@@ -481,6 +481,12 @@ const MessageItem = ( {
 						className="agentic-tool__header agentic-tool__header--clickable"
 						onClick={ () => setIsExpanded( ! isExpanded ) }
 						type="button"
+						aria-expanded={ isExpanded }
+						aria-label={
+							thinkingIsStreaming
+								? 'Thinking in progress'
+								: 'Toggle thought process details'
+						}
 					>
 						<span className="agentic-tool__icon">
 							{ thinkingIsStreaming ? (
@@ -493,6 +499,7 @@ const MessageItem = ( {
 									fill="none"
 									stroke="currentColor"
 									strokeWidth="2"
+									aria-hidden="true"
 								>
 									<circle cx="12" cy="12" r="10" />
 									<path d="M12 16v-4" />
@@ -517,6 +524,7 @@ const MessageItem = ( {
 								fill="none"
 								stroke="currentColor"
 								strokeWidth="2"
+								aria-hidden="true"
 							>
 								<polyline points="6 9 12 15 18 9" />
 							</svg>
@@ -539,11 +547,11 @@ const MessageItem = ( {
 	if ( type === 'loading' ) {
 		return (
 			<div className="agentic-message agentic-message--loading">
-				<div className="agentic-timeline">
+				<div className="agentic-timeline" aria-hidden="true">
 					<div className="agentic-timeline__line" />
 					<div className="agentic-timeline__dot agentic-timeline__dot--loading" />
 				</div>
-				<div className="agentic-loading">
+				<div className="agentic-loading" role="status">
 					<div className="agentic-loading__spinner" />
 					<span className="agentic-loading__text">{ content }</span>
 				</div>
@@ -622,7 +630,7 @@ const MessageItem = ( {
 
 		return (
 			<div className="agentic-message agentic-message--assistant">
-				<div className="agentic-timeline">
+				<div className="agentic-timeline" aria-hidden="true">
 					<div className="agentic-timeline__line" />
 					<div className="agentic-timeline__dot" />
 				</div>
@@ -785,7 +793,7 @@ const MessageItem = ( {
 	if ( type === MessageType.ABILITY_REQUEST ) {
 		return (
 			<div className="agentic-message agentic-message--tool">
-				<div className="agentic-timeline">
+				<div className="agentic-timeline" aria-hidden="true">
 					<div className="agentic-timeline__line" />
 					<div className="agentic-timeline__dot agentic-timeline__dot--tool" />
 				</div>
@@ -799,6 +807,7 @@ const MessageItem = ( {
 								fill="none"
 								stroke="currentColor"
 								strokeWidth="2"
+								aria-hidden="true"
 							>
 								<circle cx="12" cy="12" r="3" />
 								<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
@@ -839,7 +848,7 @@ const MessageItem = ( {
 
 		return (
 			<div className="agentic-message agentic-message--tool">
-				<div className="agentic-timeline">
+				<div className="agentic-timeline" aria-hidden="true">
 					<div className="agentic-timeline__line" />
 					<div
 						className={ `agentic-timeline__dot agentic-timeline__dot--${ resultStatus }` }
@@ -852,6 +861,10 @@ const MessageItem = ( {
 						className="agentic-tool__header agentic-tool__header--clickable"
 						onClick={ () => setIsExpanded( ! isExpanded ) }
 						type="button"
+						aria-expanded={ isExpanded }
+						aria-label={ `Toggle ${
+							isSuccess ? 'completed' : 'failed'
+						} result details for ${ meta?.abilityId }` }
 					>
 						<span className="agentic-tool__icon">
 							{ resultStatus === 'success' && (
@@ -862,6 +875,7 @@ const MessageItem = ( {
 									fill="none"
 									stroke="currentColor"
 									strokeWidth="2"
+									aria-hidden="true"
 								>
 									<polyline points="20 6 9 17 4 12" />
 								</svg>
@@ -874,6 +888,7 @@ const MessageItem = ( {
 									fill="none"
 									stroke="currentColor"
 									strokeWidth="2"
+									aria-hidden="true"
 								>
 									<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
 									<circle cx="12" cy="12" r="3" />
@@ -887,7 +902,8 @@ const MessageItem = ( {
 									fill="none"
 									stroke="currentColor"
 									strokeWidth="2"
-								>
+									aria-hidden="true"
+							>
 									<circle cx="12" cy="12" r="10" />
 									<line x1="15" y1="9" x2="9" y2="15" />
 									<line x1="9" y1="9" x2="15" y2="15" />
@@ -918,11 +934,11 @@ const MessageItem = ( {
 	if ( type === MessageType.ERROR ) {
 		return (
 			<div className="agentic-message agentic-message--error">
-				<div className="agentic-timeline">
+				<div className="agentic-timeline" aria-hidden="true">
 					<div className="agentic-timeline__line" />
 					<div className="agentic-timeline__dot agentic-timeline__dot--error" />
 				</div>
-				<div className="agentic-error">
+				<div className="agentic-error" role="alert">
 					<span className="agentic-error__icon">
 						<svg
 							width="16"
@@ -931,6 +947,7 @@ const MessageItem = ( {
 							fill="none"
 							stroke="currentColor"
 							strokeWidth="2"
+							aria-hidden="true"
 						>
 							<circle cx="12" cy="12" r="10" />
 							<line x1="12" y1="8" x2="12" y2="12" />

--- a/src/extensions/components/MessageList.jsx
+++ b/src/extensions/components/MessageList.jsx
@@ -34,7 +34,13 @@ const MessageList = ( {
 	}, [ messages ] );
 
 	return (
-		<div className="wp-agentic-admin-messages" ref={ listRef }>
+		<div
+			className="wp-agentic-admin-messages"
+			ref={ listRef }
+			role="log"
+			aria-live="polite"
+			aria-label="Chat messages"
+		>
 			{ messages.map( ( message ) => (
 				<MessageItem
 					key={ message.id }

--- a/src/extensions/components/ModelStatus.jsx
+++ b/src/extensions/components/ModelStatus.jsx
@@ -487,7 +487,14 @@ const ModelStatus = ( {
 						</span>
 					</div>
 
-					<div className="wp-agentic-admin-loading-card__progress">
+					<div
+						className="wp-agentic-admin-loading-card__progress"
+						role="progressbar"
+						aria-valuenow={ displayProgress }
+						aria-valuemin={ 0 }
+						aria-valuemax={ 100 }
+						aria-label={ `${ getLoadingTitle() }: ${ displayProgress }%` }
+					>
 						<div
 							className="wp-agentic-admin-loading-card__progress-bar"
 							style={ { width: `${ displayProgress }%` } }
@@ -507,7 +514,17 @@ const ModelStatus = ( {
 				<div className="wp-agentic-admin-status">
 					<span
 						className={ `wp-agentic-admin-status__indicator ${ getStatusClass() }` }
+						aria-hidden="true"
 					/>
+					<span className="screen-reader-text">
+						{ status === 'ready'
+							? 'Ready'
+							: status === 'error'
+							? 'Error'
+							: status === 'loading'
+							? 'Loading'
+							: 'Not loaded' }
+					</span>
 					<div className="wp-agentic-admin-status__info">
 						<span className="wp-agentic-admin-status__text">
 							{ status === 'ready' && loadedModelInfo
@@ -562,7 +579,16 @@ const ModelStatus = ( {
 										<span className="context__label">
 											Context:
 										</span>
-										<span className="context__bar">
+										<span
+											className="context__bar"
+											role="progressbar"
+											aria-valuenow={
+												contextUsage.percentage
+											}
+											aria-valuemin={ 0 }
+											aria-valuemax={ 100 }
+											aria-label={ `Context usage: ${ contextUsage.percentage }%` }
+										>
 											<span
 												className="context__fill"
 												style={ {
@@ -611,9 +637,15 @@ const ModelStatus = ( {
 			{ ( status === 'not-loaded' || status === 'error' ) && (
 				<div className="wp-agentic-admin-provider">
 					{ /* Provider toggle */ }
-					<div className="wp-agentic-admin-provider__toggle">
+					<div
+						className="wp-agentic-admin-provider__toggle"
+						role="tablist"
+						aria-label="Provider selection"
+					>
 						<button
 							type="button"
+							role="tab"
+							aria-selected={ providerMode === 'local' }
 							className={ `wp-agentic-admin-provider__tab ${
 								providerMode === 'local' ? 'is-active' : ''
 							}` }
@@ -623,6 +655,8 @@ const ModelStatus = ( {
 						</button>
 						<button
 							type="button"
+							role="tab"
+							aria-selected={ providerMode === 'remote' }
 							className={ `wp-agentic-admin-provider__tab ${
 								providerMode === 'remote' ? 'is-active' : ''
 							}` }
@@ -639,6 +673,7 @@ const ModelStatus = ( {
 								<select
 									className="wp-agentic-admin-model-select"
 									value={ selectedModel }
+									aria-label="Select AI model"
 									onChange={ ( e ) => {
 										const modelId = e.target.value;
 										setSelectedModel( modelId );

--- a/src/extensions/styles/admin-sidebar.scss
+++ b/src/extensions/styles/admin-sidebar.scss
@@ -312,3 +312,15 @@
 		z-index: 1000000 !important;
 	}
 }
+
+// Respect user motion preferences
+@media ( prefers-reduced-motion: reduce ) {
+
+	#wp-agentic-admin-sidebar {
+		transition: none;
+	}
+
+	.wp-agentic-admin-sidebar-overlay {
+		transition: none;
+	}
+}

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -335,8 +335,8 @@
 		-webkit-appearance: none;
 
 		&:focus {
-			outline: none;
 			box-shadow: none;
+			outline: 2px solid transparent; // Visible in Windows High Contrast Mode; wrapper :focus-within handles visual indicator
 		}
 
 		&:disabled {
@@ -1289,7 +1289,7 @@
 			&:focus {
 				border-color: #2271b1;
 				box-shadow: 0 0 0 1px #2271b1;
-				outline: none;
+				outline: 2px solid transparent; // Visible in Windows High Contrast Mode
 			}
 		}
 	}
@@ -1734,9 +1734,10 @@
 				color: #1d2327;
 			}
 
-			&:focus {
+			&:focus-visible {
 				box-shadow: none;
-				outline: 1px dotted #646970;
+				outline: 2px solid #2271b1;
+				outline-offset: 2px;
 			}
 		}
 	}
@@ -1892,7 +1893,7 @@
 		&:focus {
 			border-color: #2271b1;
 			box-shadow: 0 0 0 1px #2271b1;
-			outline: none;
+			outline: 2px solid transparent; // Visible in Windows High Contrast Mode
 		}
 	}
 
@@ -3333,6 +3334,44 @@
 	}
 }
 
+// Global focus-visible styles for interactive elements
+.wp-agentic-admin-app,
+#wp-agentic-admin-sidebar {
+
+	button:focus-visible,
+	a:focus-visible,
+	select:focus-visible {
+		outline: 2px solid #2271b1;
+		outline-offset: 2px;
+	}
+
+	.agentic-tool__header--clickable:focus-visible {
+		outline: 2px solid #2271b1;
+		outline-offset: 1px;
+		background: rgba(0, 0, 0, 0.04);
+	}
+
+	.agentic-message__copy:focus-visible {
+		outline: 2px solid #2271b1;
+		outline-offset: 1px;
+	}
+}
+
+// Respect user motion preferences (WCAG 2.3.3)
+@media ( prefers-reduced-motion: reduce ) {
+
+	.wp-agentic-admin-app,
+	#wp-agentic-admin-sidebar {
+
+		*,
+		*::before,
+		*::after {
+			animation-duration: 0.01ms !important;
+			animation-iteration-count: 1 !important;
+			transition-duration: 0.01ms !important;
+		}
+	}
+}
 
 // Code block rendering (fenced ``` blocks from read-file and similar)
 .agentic-code-block {


### PR DESCRIPTION
## What does this PR do?

Adds WCAG 2.2 Level AA accessibility support across the entire chat interface — visible focus indicators, ARIA labels/roles on all interactive elements, live regions for dynamic content, and prefers-reduced-motion support.

## Type

- [ ] New ability
- [ ] New workflow
- [ ] Bug fix
- [x] Enhancement
- [ ] Docs

## How to test

  1. Keyboard navigation: Tab through the full UI (model status, chat input, message buttons, ability browser). Every
  interactive element should show a visible blue focus ring.
  2. Screen reader (VoiceOver): Navigate the chat — expand/collapse buttons announce their state
  ("expanded"/"collapsed"), the message list announces new messages, progress bars read their percentage.
  3. Reduced motion: Enable "Reduce motion" in System Settings → Accessibility → Display. All animations (spinners,
  pulses, shimmer, sidebar slide) should stop.
  4. Sidebar: Click the admin bar icon to open sidebar, press Escape — sidebar closes and focus returns to the toggle
  button.
  5. High Contrast Mode (Windows): Focus outlines remain visible on all inputs/textareas.

## Screenshots (if UI changes)

No visual changes in default mode — all improvements are for assistive technology and keyboard users.
