### PR TITLE
feat: add plugin vulnerability scanning

### DIFF
--- a/includes/abilities/security-scan.php
+++ b/includes/abilities/security-scan.php
@@ -163,16 +163,6 @@ function wp_agentic_admin_execute_security_scan( array $input = array() ): array
 		}
 	}
 
-	$vulnerabilities = array(
-		'plugins'               => array(),
-		'total'                 => 0,
-		'active'                => 0,
-		'total_vulnerabilities' => 0,
-		'plugins_with_issues'   => 0,
-		'scan_errors'           => 0,
-		'scanned_at'            => gmdate( 'c' ),
-	);
-
 	$vulnerabilities = wp_agentic_admin_scan_for_vulnerabilities();
 
 	$checks[] = array(

--- a/includes/abilities/security-scan.php
+++ b/includes/abilities/security-scan.php
@@ -34,11 +34,11 @@ function wp_agentic_admin_register_security_scan(): void {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'checks'   => array(
+					'checks'  => array(
 						'type'        => 'array',
 						'description' => __( 'List of security check results.', 'wp-agentic-admin' ),
 					),
-					'summary'  => array(
+					'summary' => array(
 						'type'        => 'object',
 						'description' => __( 'Count by severity.', 'wp-agentic-admin' ),
 					),
@@ -110,7 +110,7 @@ function wp_agentic_admin_execute_security_scan( array $input = array() ): array
 	}
 
 	// 4. Check for default auth salts.
-	$salt      = wp_salt( 'auth' );
+	$salt       = wp_salt( 'auth' );
 	$is_default = ( 'put your unique phrase here' === $salt );
 	$checks[]   = array(
 		'check'    => 'Authentication salts',
@@ -136,8 +136,8 @@ function wp_agentic_admin_execute_security_scan( array $input = array() ): array
 	$uploads_path = $uploads_dir['basedir'];
 	$htaccess     = $uploads_path . '/.htaccess';
 	$index_file   = $uploads_path . '/index.php';
-	$has_protect   = file_exists( $htaccess ) || file_exists( $index_file );
-	$checks[]      = array(
+	$has_protect  = file_exists( $htaccess ) || file_exists( $index_file );
+	$checks[]     = array(
 		'check'    => 'Uploads directory listing',
 		'status'   => $has_protect ? 'pass' : 'fail',
 		'severity' => 'warning',
@@ -146,7 +146,49 @@ function wp_agentic_admin_execute_security_scan( array $input = array() ): array
 			: 'Uploads directory may allow directory listing.',
 	);
 
-	// Summary by severity.
+	$summary = array(
+		'critical' => 0,
+		'warning'  => 0,
+		'info'     => 0,
+		'passed'   => 0,
+		'failed'   => 0,
+	);
+
+	foreach ( $checks as $check ) {
+		if ( 'fail' === $check['status'] ) {
+			++$summary['failed'];
+			++$summary[ $check['severity'] ];
+		} else {
+			++$summary['passed'];
+		}
+	}
+
+	$vulnerabilities = array(
+		'plugins'               => array(),
+		'total'                 => 0,
+		'active'                => 0,
+		'total_vulnerabilities' => 0,
+		'plugins_with_issues'   => 0,
+		'scan_errors'           => 0,
+		'scanned_at'            => gmdate( 'c' ),
+	);
+
+	$vulnerabilities = wp_agentic_admin_scan_for_vulnerabilities();
+
+	$checks[] = array(
+		'check'    => 'Plugin vulnerabilities',
+		'status'   => ! empty( $vulnerabilities['total_vulnerabilities'] ) ? 'fail' : 'pass',
+		'severity' => 'critical',
+		'message'  => ! empty( $vulnerabilities['total_vulnerabilities'] )
+			? sprintf(
+				/* translators: 1: vulnerabilities count, 2: affected plugin count */
+				__( 'Detected %1$d known vulnerabilities across %2$d plugin(s).', 'wp-agentic-admin' ),
+				(int) $vulnerabilities['total_vulnerabilities'],
+				(int) $vulnerabilities['plugins_with_issues']
+			)
+			: __( 'No known plugin vulnerabilities detected for scanned plugins.', 'wp-agentic-admin' ),
+	);
+
 	$summary = array(
 		'critical' => 0,
 		'warning'  => 0,
@@ -165,7 +207,8 @@ function wp_agentic_admin_execute_security_scan( array $input = array() ): array
 	}
 
 	return array(
-		'checks'  => $checks,
-		'summary' => $summary,
+		'checks'          => $checks,
+		'summary'         => $summary,
+		'vulnerabilities' => $vulnerabilities,
 	);
 }

--- a/includes/abilities/security-scan.php
+++ b/includes/abilities/security-scan.php
@@ -146,23 +146,6 @@ function wp_agentic_admin_execute_security_scan( array $input = array() ): array
 			: 'Uploads directory may allow directory listing.',
 	);
 
-	$summary = array(
-		'critical' => 0,
-		'warning'  => 0,
-		'info'     => 0,
-		'passed'   => 0,
-		'failed'   => 0,
-	);
-
-	foreach ( $checks as $check ) {
-		if ( 'fail' === $check['status'] ) {
-			++$summary['failed'];
-			++$summary[ $check['severity'] ];
-		} else {
-			++$summary['passed'];
-		}
-	}
-
 	$vulnerabilities = wp_agentic_admin_scan_for_vulnerabilities();
 
 	$checks[] = array(

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -310,7 +310,9 @@ function wp_agentic_admin_scan_for_vulnerabilities( string $status_filter = 'act
 			continue;
 		}
 
-		foreach ( $decoded['vulnerabilities'] as $vulnerability ) {
+		$vulnerabilities = array_reverse( array_slice( $decoded['vulnerabilities'], -30 ) );
+
+		foreach ( $vulnerabilities as $vulnerability ) {
 			if ( empty( $vulnerability['cve'] ) || ! is_array( $vulnerability['cve'] ) ) {
 				continue;
 			}
@@ -350,6 +352,8 @@ function wp_agentic_admin_scan_for_vulnerabilities( string $status_filter = 'act
 				'vector'                  => isset( $cvss['vector'] ) ? $cvss['vector'] : '',
 				'affected_version_source' => 'mitre',
 			);
+
+			break;
 		}
 
 		$plugins[ $index ]['vulnerability_count'] = count( $plugins[ $index ]['vulnerabilities'] );

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -411,12 +411,14 @@ function wp_agentic_admin_is_plugin_version_affected_from_mitre( string $plugin_
 	$normalized_slug    = strtolower( trim( $plugin_slug ) );
 	$evaluated_ranges   = false;
 	$matched_package    = false;
+	$normalized_name    = trim( $plugin_name );
 
 	foreach ( $mitre_record['containers']['cna']['affected'] as $affected ) {
-		$collection_url = isset( $affected['collectionURL'] ) ? trim( (string) $affected['collectionURL'] ) : '';
-		$package_name   = isset( $affected['packageName'] ) ? strtolower( trim( (string) $affected['packageName'] ) ) : '';
+		$collection_url   = isset( $affected['collectionURL'] ) ? trim( (string) $affected['collectionURL'] ) : '';
+		$package_name     = isset( $affected['packageName'] ) ? strtolower( trim( (string) $affected['packageName'] ) ) : '';
+		$affected_product = isset( $affected['product'] ) ? trim( (string) $affected['product'] ) : '';
 
-		if ( trim( $plugin_name ) !== trim( $affected['product'] ) ) {
+		if ( $normalized_name !== $affected_product ) {
 			if ( 'https://wordpress.org/plugins' !== $collection_url ) {
 				continue;
 			}

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -562,68 +562,6 @@ function wp_agentic_admin_normalize_mitre_bound( string $bound ): string {
 }
 
 /**
- * Check whether a plugin version is affected by CVE configuration ranges.
- *
- * @param string $plugin_version Installed plugin version.
- * @param array  $cve            CVE payload.
- * @return bool
- */
-function wp_agentic_admin_is_plugin_version_affected( string $plugin_version, array $cve ): bool {
-	if ( '' === trim( $plugin_version ) ) {
-		return true;
-	}
-
-	if ( empty( $cve['configurations'] ) || ! is_array( $cve['configurations'] ) ) {
-		return true;
-	}
-
-	$normalized_version = ltrim( trim( $plugin_version ), 'vV' );
-	$has_cpe_matches    = false;
-
-	foreach ( $cve['configurations'] as $configuration ) {
-		if ( empty( $configuration['nodes'] ) || ! is_array( $configuration['nodes'] ) ) {
-			continue;
-		}
-
-		foreach ( $configuration['nodes'] as $node ) {
-			if ( empty( $node['cpeMatch'] ) || ! is_array( $node['cpeMatch'] ) ) {
-				continue;
-			}
-
-			foreach ( $node['cpeMatch'] as $cpe_match ) {
-				if ( empty( $cpe_match['vulnerable'] ) ) {
-					continue;
-				}
-
-				$has_cpe_matches = true;
-
-				$in_range = true;
-
-				if ( isset( $cpe_match['versionStartIncluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionStartIncluding'], '<' ) ) {
-					$in_range = false;
-				}
-				if ( isset( $cpe_match['versionStartExcluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionStartExcluding'], '<=' ) ) {
-					$in_range = false;
-				}
-				if ( isset( $cpe_match['versionEndIncluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionEndIncluding'], '>' ) ) {
-					$in_range = false;
-				}
-				if ( isset( $cpe_match['versionEndExcluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionEndExcluding'], '>=' ) ) {
-					$in_range = false;
-				}
-
-				if ( $in_range ) {
-					return true;
-				}
-			}
-		}
-	}
-
-	// If no vulnerable CPE ranges are available, keep a conservative match.
-	return ! $has_cpe_matches;
-}
-
-/**
  * Extract the first English CVE description.
  *
  * @param array $cve CVE payload.

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -221,3 +221,471 @@ function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_file ): arra
 		),
 	);
 }
+
+/**
+ * Scan plugins for known vulnerabilities using the NVD API.
+ *
+ * TODO: This is a solution that does not required any API key, authentication, or an setup,
+ * but it is not an extremely accurate wa for checking vulenrabilities and may produce false positives/negatives.
+ * In the future we can consider integrating with a more reliable service via a partnership.
+ *
+ * @param string $status_filter Optional. Filter by status: 'all', 'active', or 'inactive'. Default 'all'.
+ * @return array Array with plugins and their vulnerabilities.
+ */
+function wp_agentic_admin_scan_for_vulnerabilities( string $status_filter = 'active' ): array {
+	$plugins_data = wp_agentic_admin_get_all_plugins( $status_filter );
+	$plugins      = $plugins_data['plugins'];
+
+	$total_vulnerabilities = 0;
+	$scan_errors           = 0;
+	$endpoint              = 'https://services.nvd.nist.gov/rest/json/cves/2.0';
+
+	foreach ( $plugins as $index => $plugin ) {
+		$plugin_name    = sanitize_text_field( $plugin['name'] );
+		$plugin_version = isset( $plugin['version'] ) ? (string) $plugin['version'] : '';
+		$plugin_slug    = wp_agentic_admin_normalize_plugin_slug( isset( $plugin['slug'] ) ? (string) $plugin['slug'] : '' );
+
+		$plugins[ $index ]['vulnerabilities']      = array();
+		$plugins[ $index ]['vulnerability_count']  = 0;
+		$plugins[ $index ]['has_vulnerabilities']  = false;
+		$plugins[ $index ]['vulnerability_source'] = 'mitre';
+
+		if ( '' === $plugin_name ) {
+			continue;
+		}
+
+		$cache_key = 'wp_agentic_admin_nvd_' . md5( strtolower( $plugin_name ) );
+		$response  = get_transient( $cache_key );
+
+		if ( false === $response ) {
+			$request_url = add_query_arg(
+				array(
+					'keywordSearch'     => $plugin_name,
+					'keywordExactMatch' => '',
+					'resultsPerPage'    => 30,
+				),
+				$endpoint
+			);
+
+			$headers = array(
+				'Accept' => 'application/json',
+			);
+
+			$response = wp_remote_get(
+				$request_url,
+				array(
+					'timeout' => 30,
+					'headers' => $headers,
+				)
+			);
+
+			set_transient( $cache_key, $response, 3 * HOUR_IN_SECONDS );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			$plugins[ $index ]['scan_error'] = $response->get_error_message();
+			++$scan_errors;
+			continue;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $status_code ) {
+			$plugins[ $index ]['scan_error'] = sprintf(
+				/* translators: %d: HTTP status code */
+				__( 'NVD request failed with status code %d.', 'wp-agentic-admin' ),
+				$status_code
+			);
+			++$scan_errors;
+			continue;
+		}
+
+		$body    = wp_remote_retrieve_body( $response );
+		$decoded = json_decode( $body, true );
+
+		if ( ! is_array( $decoded ) || empty( $decoded['vulnerabilities'] ) || ! is_array( $decoded['vulnerabilities'] ) ) {
+			continue;
+		}
+
+		foreach ( $decoded['vulnerabilities'] as $vulnerability ) {
+			if ( empty( $vulnerability['cve'] ) || ! is_array( $vulnerability['cve'] ) ) {
+				continue;
+			}
+
+			$cve    = $vulnerability['cve'];
+			$cve_id = isset( $cve['id'] ) ? (string) $cve['id'] : '';
+
+			if ( '' === $cve_id ) {
+				continue;
+			}
+
+			$mitre_record = wp_agentic_admin_get_mitre_cve_record( $cve_id );
+			if ( is_wp_error( $mitre_record ) ) {
+				continue;
+			}
+
+			$mitre_match = wp_agentic_admin_is_plugin_version_affected_from_mitre(
+				$plugin_name,
+				$plugin_version,
+				$plugin_slug,
+				$mitre_record
+			);
+
+			if ( true !== $mitre_match ) {
+				continue;
+			}
+
+			$cvss = wp_agentic_admin_extract_cvss_data( $cve );
+
+			$plugins[ $index ]['vulnerabilities'][] = array(
+				'cve_id'                  => $cve_id,
+				'published'               => isset( $cve['published'] ) ? $cve['published'] : '',
+				'last_modified'           => isset( $cve['lastModified'] ) ? $cve['lastModified'] : '',
+				'description'             => wp_agentic_admin_extract_english_description( $cve ),
+				'severity'                => isset( $cvss['severity'] ) ? $cvss['severity'] : '',
+				'base_score'              => isset( $cvss['base_score'] ) ? $cvss['base_score'] : null,
+				'vector'                  => isset( $cvss['vector'] ) ? $cvss['vector'] : '',
+				'affected_version_source' => 'mitre',
+			);
+		}
+
+		$plugins[ $index ]['vulnerability_count'] = count( $plugins[ $index ]['vulnerabilities'] );
+		$plugins[ $index ]['has_vulnerabilities'] = $plugins[ $index ]['vulnerability_count'] > 0;
+		$total_vulnerabilities                   += $plugins[ $index ]['vulnerability_count'];
+	}
+
+	$plugins_data['plugins']               = $plugins;
+	$plugins_data['total_vulnerabilities'] = $total_vulnerabilities;
+	$plugins_data['plugins_with_issues']   = count(
+		array_filter(
+			$plugins,
+			static function ( array $plugin ): bool {
+				return ! empty( $plugin['has_vulnerabilities'] );
+			}
+		)
+	);
+	$plugins_data['scan_errors']           = $scan_errors;
+	$plugins_data['scanned_at']            = gmdate( 'c' );
+
+	return $plugins_data;
+}
+
+/**
+ * Normalize plugin file path to WordPress.org slug.
+ *
+ * @param string $plugin_file Plugin file path.
+ * @return string
+ */
+function wp_agentic_admin_normalize_plugin_slug( string $plugin_file ): string {
+	$plugin_file = trim( $plugin_file );
+
+	if ( '' === $plugin_file ) {
+		return '';
+	}
+
+	$directory = dirname( $plugin_file );
+	if ( '.' !== $directory && '' !== $directory ) {
+		return strtolower( sanitize_title( $directory ) );
+	}
+
+	return strtolower( sanitize_title( basename( $plugin_file, '.php' ) ) );
+}
+
+/**
+ * Match plugin version using MITRE CVE affected/versions data.
+ *
+ * @param string $plugin_name    Installed plugin name.
+ * @param string $plugin_version Installed plugin version.
+ * @param string $plugin_slug    Installed plugin slug.
+ * @param array  $mitre_record   MITRE CVE record payload.
+ * @return bool|null True if affected, false if not affected, null if cannot decide.
+ */
+function wp_agentic_admin_is_plugin_version_affected_from_mitre( string $plugin_name, string $plugin_version, string $plugin_slug, array $mitre_record ): ?bool {
+	if (
+		empty( $mitre_record['containers']['cna']['affected'] ) ||
+		! is_array( $mitre_record['containers']['cna']['affected'] )
+	) {
+		return null;
+	}
+
+	$normalized_version = ltrim( trim( $plugin_version ), 'vV' );
+	$normalized_slug    = strtolower( trim( $plugin_slug ) );
+	$evaluated_ranges   = false;
+	$matched_package    = false;
+
+	foreach ( $mitre_record['containers']['cna']['affected'] as $affected ) {
+		$collection_url = isset( $affected['collectionURL'] ) ? trim( (string) $affected['collectionURL'] ) : '';
+		$package_name   = isset( $affected['packageName'] ) ? strtolower( trim( (string) $affected['packageName'] ) ) : '';
+
+		if ( trim( $plugin_name ) !== trim( $affected['product'] ) ) {
+			if ( 'https://wordpress.org/plugins' !== $collection_url ) {
+				continue;
+			}
+
+			if ( '' === $package_name || $package_name !== $normalized_slug ) {
+				continue;
+			}
+		}
+
+		$matched_package = true;
+
+		$default_status = isset( $affected['defaultStatus'] ) ? strtolower( (string) $affected['defaultStatus'] ) : '';
+
+		if ( empty( $affected['versions'] ) || ! is_array( $affected['versions'] ) ) {
+			if ( 'affected' === $default_status ) {
+				return true;
+			}
+			if ( 'unaffected' === $default_status ) {
+				return false;
+			}
+			continue;
+		}
+
+		foreach ( $affected['versions'] as $version_rule ) {
+			$status = isset( $version_rule['status'] ) ? strtolower( (string) $version_rule['status'] ) : $default_status;
+			if ( '' === $status ) {
+				continue;
+			}
+
+			if ( '' === $normalized_version ) {
+				return 'affected' === $status;
+			}
+
+			$exact = isset( $version_rule['version'] ) ? trim( (string) $version_rule['version'] ) : '';
+			$lt    = isset( $version_rule['lessThan'] ) ? wp_agentic_admin_normalize_mitre_bound( (string) $version_rule['lessThan'] ) : '';
+			$lte   = isset( $version_rule['lessThanOrEqual'] ) ? wp_agentic_admin_normalize_mitre_bound( (string) $version_rule['lessThanOrEqual'] ) : '';
+
+			$in_range = true;
+
+			if ( '' !== $lt && version_compare( $normalized_version, $lt, '>=' ) ) {
+				$in_range = false;
+			}
+			if ( '' !== $lte && version_compare( $normalized_version, $lte, '>' ) ) {
+				$in_range = false;
+			}
+
+			if ( '' !== $exact && ! in_array( strtolower( $exact ), array( 'n/a', '*', 'all' ), true ) && '' === $lt && '' === $lte ) {
+				$in_range = ( 0 === version_compare( $normalized_version, ltrim( $exact, 'vV' ) ) );
+			}
+
+			$evaluated_ranges = true;
+
+			if ( $in_range ) {
+				return 'affected' === $status;
+			}
+		}
+	}
+
+	if ( ! $matched_package ) {
+		return false;
+	}
+
+	if ( $evaluated_ranges ) {
+		return false;
+	}
+
+	return null;
+}
+
+/**
+ * Retrieve CVE JSON from MITRE CVE API.
+ *
+ * @param string $cve_id CVE identifier.
+ * @return array|WP_Error
+ */
+function wp_agentic_admin_get_mitre_cve_record( string $cve_id ) {
+	$cve_id    = strtoupper( trim( $cve_id ) );
+	$cache_key = 'wp_agentic_admin_mitre_' . md5( $cve_id );
+	$cached    = get_transient( $cache_key );
+
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	$request_url = 'https://cveawg.mitre.org/api/cve/' . rawurlencode( $cve_id );
+	$response    = wp_remote_get(
+		$request_url,
+		array(
+			'timeout' => 30,
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		)
+	);
+
+	if ( is_wp_error( $response ) ) {
+		set_transient( $cache_key, $response, 15 * MINUTE_IN_SECONDS );
+		return $response;
+	}
+
+	$status_code = (int) wp_remote_retrieve_response_code( $response );
+	if ( 200 !== $status_code ) {
+		$error = new WP_Error(
+			'wp_agentic_admin_mitre_http_error',
+			sprintf(
+				/* translators: %d: HTTP status code */
+				__( 'MITRE CVE request failed with status code %d.', 'wp-agentic-admin' ),
+				$status_code
+			)
+		);
+		set_transient( $cache_key, $error, 5 * MINUTE_IN_SECONDS );
+		return $error;
+	}
+
+	$body    = wp_remote_retrieve_body( $response );
+	$decoded = json_decode( $body, true );
+
+	if ( ! is_array( $decoded ) ) {
+		$error = new WP_Error(
+			'wp_agentic_admin_mitre_invalid_json',
+			__( 'Invalid MITRE CVE response.', 'wp-agentic-admin' )
+		);
+		set_transient( $cache_key, $error, 5 * MINUTE_IN_SECONDS );
+		return $error;
+	}
+
+	set_transient( $cache_key, $decoded, 6 * HOUR_IN_SECONDS );
+
+	return $decoded;
+}
+
+/**
+ * Normalize MITRE version bounds like "<= 1.2.3" to "1.2.3".
+ *
+ * @param string $bound Version bound.
+ * @return string
+ */
+function wp_agentic_admin_normalize_mitre_bound( string $bound ): string {
+	$bound = trim( $bound );
+	$bound = preg_replace( '/^[<>=\s]+/', '', $bound );
+
+	return is_string( $bound ) ? ltrim( $bound, 'vV' ) : '';
+}
+
+/**
+ * Check whether a plugin version is affected by CVE configuration ranges.
+ *
+ * @param string $plugin_version Installed plugin version.
+ * @param array  $cve            CVE payload.
+ * @return bool
+ */
+function wp_agentic_admin_is_plugin_version_affected( string $plugin_version, array $cve ): bool {
+	if ( '' === trim( $plugin_version ) ) {
+		return true;
+	}
+
+	if ( empty( $cve['configurations'] ) || ! is_array( $cve['configurations'] ) ) {
+		return true;
+	}
+
+	$normalized_version = ltrim( trim( $plugin_version ), 'vV' );
+	$has_cpe_matches    = false;
+
+	foreach ( $cve['configurations'] as $configuration ) {
+		if ( empty( $configuration['nodes'] ) || ! is_array( $configuration['nodes'] ) ) {
+			continue;
+		}
+
+		foreach ( $configuration['nodes'] as $node ) {
+			if ( empty( $node['cpeMatch'] ) || ! is_array( $node['cpeMatch'] ) ) {
+				continue;
+			}
+
+			foreach ( $node['cpeMatch'] as $cpe_match ) {
+				if ( empty( $cpe_match['vulnerable'] ) ) {
+					continue;
+				}
+
+				$has_cpe_matches = true;
+
+				$in_range = true;
+
+				if ( isset( $cpe_match['versionStartIncluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionStartIncluding'], '<' ) ) {
+					$in_range = false;
+				}
+				if ( isset( $cpe_match['versionStartExcluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionStartExcluding'], '<=' ) ) {
+					$in_range = false;
+				}
+				if ( isset( $cpe_match['versionEndIncluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionEndIncluding'], '>' ) ) {
+					$in_range = false;
+				}
+				if ( isset( $cpe_match['versionEndExcluding'] ) && version_compare( $normalized_version, (string) $cpe_match['versionEndExcluding'], '>=' ) ) {
+					$in_range = false;
+				}
+
+				if ( $in_range ) {
+					return true;
+				}
+			}
+		}
+	}
+
+	// If no vulnerable CPE ranges are available, keep a conservative match.
+	return ! $has_cpe_matches;
+}
+
+/**
+ * Extract the first English CVE description.
+ *
+ * @param array $cve CVE payload.
+ * @return string
+ */
+function wp_agentic_admin_extract_english_description( array $cve ): string {
+	if ( empty( $cve['descriptions'] ) || ! is_array( $cve['descriptions'] ) ) {
+		return '';
+	}
+
+	foreach ( $cve['descriptions'] as $description ) {
+		if ( isset( $description['lang'], $description['value'] ) && 'en' === $description['lang'] ) {
+			return (string) $description['value'];
+		}
+	}
+
+	if ( isset( $cve['descriptions'][0]['value'] ) ) {
+		return (string) $cve['descriptions'][0]['value'];
+	}
+
+	return '';
+}
+
+/**
+ * Extract CVSS severity details from CVE metrics.
+ *
+ * @param array $cve CVE payload.
+ * @return array
+ */
+function wp_agentic_admin_extract_cvss_data( array $cve ): array {
+	if ( empty( $cve['metrics'] ) || ! is_array( $cve['metrics'] ) ) {
+		return array();
+	}
+
+	$metric_sets = array( 'cvssMetricV31', 'cvssMetricV30', 'cvssMetricV2' );
+
+	foreach ( $metric_sets as $set_key ) {
+		if ( empty( $cve['metrics'][ $set_key ] ) || ! is_array( $cve['metrics'][ $set_key ] ) ) {
+			continue;
+		}
+
+		$metric = $cve['metrics'][ $set_key ][0];
+
+		if ( ! empty( $cve['metrics'][ $set_key ] ) ) {
+			foreach ( $cve['metrics'][ $set_key ] as $candidate ) {
+				if ( isset( $candidate['type'] ) && 'Primary' === $candidate['type'] ) {
+					$metric = $candidate;
+					break;
+				}
+			}
+		}
+
+		if ( empty( $metric['cvssData'] ) || ! is_array( $metric['cvssData'] ) ) {
+			continue;
+		}
+
+		return array(
+			'severity'   => isset( $metric['cvssData']['baseSeverity'] ) ? $metric['cvssData']['baseSeverity'] : '',
+			'base_score' => isset( $metric['cvssData']['baseScore'] ) ? $metric['cvssData']['baseScore'] : null,
+			'vector'     => isset( $metric['cvssData']['vectorString'] ) ? $metric['cvssData']['vectorString'] : '',
+		);
+	}
+
+	return array();
+}

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -223,11 +223,15 @@ function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_file ): arra
 }
 
 /**
- * Scan plugins for known vulnerabilities using the NVD API.
+ * Scan plugins for known vulnerabilities using public CVE data sources.
+ *
+ * This function currently queries the NVD API and additionally uses MITRE CVE
+ * records (where available) to help determine affected versions of plugins.
  *
  * TODO: This is a solution that does not require any API key, authentication, or setup,
- * but it is not an extremely accurate way of checking vulnerabilities and may produce false positives/negatives.
- * In the future we can consider integrating with a more reliable service via a partnership.
+ * but it is not an extremely accurate way of checking vulnerabilities and may produce
+ * false positives/negatives. In the future we can consider integrating with a more
+ * reliable service via a partnership.
  *
  * @param string $status_filter Optional. Filter by status: 'all', 'active', or 'inactive'. Default 'all'.
  * @return array Array with plugins and their vulnerabilities.

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -233,7 +233,7 @@ function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_file ): arra
  * false positives/negatives. In the future we can consider integrating with a more
  * reliable service via a partnership.
  *
- * @param string $status_filter Optional. Filter by status: 'all', 'active', or 'inactive'. Default 'all'.
+ * @param string $status_filter Optional. Filter by status: 'all', 'active', or 'inactive'. Default 'active'.
  * @return array Array with plugins and their vulnerabilities.
  */
 function wp_agentic_admin_scan_for_vulnerabilities( string $status_filter = 'active' ): array {

--- a/includes/abilities/shared/plugin-helpers.php
+++ b/includes/abilities/shared/plugin-helpers.php
@@ -225,8 +225,8 @@ function wp_agentic_admin_deactivate_plugin_by_slug( string $plugin_file ): arra
 /**
  * Scan plugins for known vulnerabilities using the NVD API.
  *
- * TODO: This is a solution that does not required any API key, authentication, or an setup,
- * but it is not an extremely accurate wa for checking vulenrabilities and may produce false positives/negatives.
+ * TODO: This is a solution that does not require any API key, authentication, or setup,
+ * but it is not an extremely accurate way of checking vulnerabilities and may produce false positives/negatives.
  * In the future we can consider integrating with a more reliable service via a partnership.
  *
  * @param string $status_filter Optional. Filter by status: 'all', 'active', or 'inactive'. Default 'all'.

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -189,8 +189,8 @@ class Abilities {
 
 		if ( function_exists( 'wp_agentic_admin_register_database_check' ) ) {
 			wp_agentic_admin_register_database_check();
-    }
-    
+		}
+
 		if ( function_exists( 'wp_agentic_admin_register_theme_list' ) ) {
 			wp_agentic_admin_register_theme_list();
 		}


### PR DESCRIPTION
This pull request enhances the security scan functionality by introducing plugin vulnerability detection and improving the summary of scan results. The main changes include adding a check for known plugin vulnerabilities and providing a more detailed breakdown of scan outcomes by severity.

**Security scan improvements:**

* Added a vulnerability scan for plugins using `wp_agentic_admin_scan_for_vulnerabilities()`, and included a new check in the results indicating whether any known plugin vulnerabilities were detected.
* Expanded the summary to count the number of checks by severity (`critical`, `warning`, `info`) and by pass/fail status, giving a clearer overview of scan results.
* Updated the return value of `wp_agentic_admin_execute_security_scan()` to include detailed vulnerability data in the `vulnerabilities` field.