### PR TITLE
fix: dry-run shows destructive confirmation when it should not

### DIFF
--- a/src/extensions/abilities/file-scan.js
+++ b/src/extensions/abilities/file-scan.js
@@ -85,7 +85,9 @@ export function registerFileScan() {
 			}
 			if ( result.mu_plugins_scanned?.length > 0 ) {
 				lines.push(
-					`**MU-Plugins scanned** (${ result.mu_plugins_scanned.length }): ${ result.mu_plugins_scanned.join( ', ' ) }`
+					`**MU-Plugins scanned** (${
+						result.mu_plugins_scanned.length
+					}): ${ result.mu_plugins_scanned.join( ', ' ) }`
 				);
 			} else {
 				lines.push( '**MU-Plugins scanned:** none found' );
@@ -127,7 +129,9 @@ export function registerFileScan() {
 			const files = result.findings
 				.map(
 					( f ) =>
-						`${ f.file } (${ f.patterns.map( ( p ) => p.label ).join( ', ' ) })`
+						`${ f.file } (${ f.patterns
+							.map( ( p ) => p.label )
+							.join( ', ' ) })`
 				)
 				.join( '; ' );
 

--- a/src/extensions/abilities/plugin-activate.js
+++ b/src/extensions/abilities/plugin-activate.js
@@ -68,7 +68,10 @@ export function registerPluginActivate() {
 		 */
 		summarize: ( result ) => {
 			if ( result.actions?.length ) {
-				return result.message || 'Multiple plugins matched. Please select one:';
+				return (
+					result.message ||
+					'Multiple plugins matched. Please select one:'
+				);
 			}
 			const base = formatPluginActionResult(
 				result,
@@ -88,7 +91,9 @@ export function registerPluginActivate() {
 		 */
 		interpretResult: ( result ) => {
 			if ( result.actions?.length ) {
-				const names = result.actions.map( ( a ) => a.label ).join( ', ' );
+				const names = result.actions
+					.map( ( a ) => a.label )
+					.join( ', ' );
 				return `Multiple plugins matched. Candidates: ${ names }. Ask the user which one to activate.`;
 			}
 			if ( result.error ) {

--- a/src/extensions/abilities/plugin-deactivate.js
+++ b/src/extensions/abilities/plugin-deactivate.js
@@ -83,7 +83,10 @@ export function registerPluginDeactivate() {
 		 */
 		summarize: ( result ) => {
 			if ( result.actions?.length ) {
-				return result.message || 'Multiple plugins matched. Please select one:';
+				return (
+					result.message ||
+					'Multiple plugins matched. Please select one:'
+				);
 			}
 			const base = formatPluginActionResult(
 				result,
@@ -103,7 +106,9 @@ export function registerPluginDeactivate() {
 		 */
 		interpretResult: ( result ) => {
 			if ( result.actions?.length ) {
-				const names = result.actions.map( ( a ) => a.label ).join( ', ' );
+				const names = result.actions
+					.map( ( a ) => a.label )
+					.join( ', ' );
 				return `Multiple plugins matched. Candidates: ${ names }. Ask the user which one to deactivate.`;
 			}
 			if ( result.error ) {

--- a/src/extensions/abilities/role-capabilities-check.js
+++ b/src/extensions/abilities/role-capabilities-check.js
@@ -73,9 +73,7 @@ export function registerRoleCapabilitiesCheck() {
 
 				for ( const role of result.roles ) {
 					const added =
-						role.added?.length > 0
-							? role.added.join( ', ' )
-							: '—';
+						role.added?.length > 0 ? role.added.join( ', ' ) : '—';
 					const removed =
 						role.removed?.length > 0
 							? role.removed.join( ', ' )
@@ -99,9 +97,7 @@ export function registerRoleCapabilitiesCheck() {
 				lines.push( '' );
 				lines.push( '**Non-Default Roles**' );
 				lines.push( '' );
-				lines.push(
-					'| Role | Capabilities | Admin Access | Risk |'
-				);
+				lines.push( '| Role | Capabilities | Admin Access | Risk |' );
 				lines.push( '|---|---|---|---|' );
 
 				for ( const role of result.extra_roles ) {
@@ -138,12 +134,16 @@ export function registerRoleCapabilitiesCheck() {
 			for ( const role of modified ) {
 				if ( role.added?.length > 0 ) {
 					parts.push(
-						`${ role.role_name } gained: ${ role.added.join( ', ' ) }`
+						`${ role.role_name } gained: ${ role.added.join(
+							', '
+						) }`
 					);
 				}
 				if ( role.removed?.length > 0 ) {
 					parts.push(
-						`${ role.role_name } lost: ${ role.removed.join( ', ' ) }`
+						`${ role.role_name } lost: ${ role.removed.join(
+							', '
+						) }`
 					);
 				}
 			}
@@ -153,7 +153,9 @@ export function registerRoleCapabilitiesCheck() {
 			);
 			if ( dangerousExtras.length > 0 ) {
 				parts.push(
-					`Non-default roles with admin access: ${ dangerousExtras.map( ( r ) => r.role_name ).join( ', ' ) }`
+					`Non-default roles with admin access: ${ dangerousExtras
+						.map( ( r ) => r.role_name )
+						.join( ', ' ) }`
 				);
 			}
 

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -230,6 +230,10 @@ const ChatContainer = ( {
 					label: tool.label || tool.id,
 					message:
 						tool.confirmationMessage || `Execute ${ tool.id }?`,
+					isDestructive:
+						tool.isDestructive !== undefined
+							? tool.isDestructive
+							: true,
 					isWorkflow,
 					workflowDetails,
 					resolve,
@@ -1006,7 +1010,8 @@ const ChatContainer = ( {
 						<Button
 							variant="primary"
 							isDestructive={
-								! pendingConfirmation.isIntentConfirmation
+								! pendingConfirmation.isIntentConfirmation &&
+								pendingConfirmation.isDestructive !== false
 							}
 							onClick={ handleConfirm }
 						>

--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -388,7 +388,7 @@ const getAbilityLabel = ( abilityId ) => {
  * @param {Object}        props.message       - Message object
  * @param {boolean}       props.feedbackOptIn - Whether the user has opted in to feedback
  * @param {Function|null} props.onFeedback    - Called with (messageId, rating) when a thumb is clicked
- * @param {Function} props.onAction - Callback to execute an ability action
+ * @param {Function}      props.onAction      - Callback to execute an ability action
  * @return {JSX.Element} Rendered message
  */
 const MessageItem = ( {

--- a/src/extensions/components/MessageList.jsx
+++ b/src/extensions/components/MessageList.jsx
@@ -15,7 +15,7 @@ import MessageItem from './MessageItem';
  * @param {Array}         props.messages      - Array of message objects
  * @param {boolean}       props.feedbackOptIn - Whether the user has opted in to feedback
  * @param {Function|null} props.onFeedback    - Called with (messageId, rating) on thumb click
- * @param {Function} props.onAction - Callback to execute an ability action
+ * @param {Function}      props.onAction      - Callback to execute an ability action
  * @return {JSX.Element} Rendered message list
  */
 const MessageList = ( {

--- a/src/extensions/components/ModelStatus.jsx
+++ b/src/extensions/components/ModelStatus.jsx
@@ -175,12 +175,13 @@ const getLoadingStage = ( message, progress ) => {
 /**
  * ModelStatus component
  *
- * @param {Object}      props              - Component props
- * @param {Function}    props.onModelReady - Callback when model is ready
- * @param {Function}    props.onModelError - Callback when model loading fails
- * @param {string|null} props.initPhase    - Current initialization phase ('checking', 'loading', or null)
- * @param {string}      props.initMessage  - Message to display during initialization
- * @param {number}      props.initProgress - Progress percentage during initialization
+ * @param {Object}      props               - Component props
+ * @param {Function}    props.onModelReady  - Callback when model is ready
+ * @param {Function}    props.onModelError  - Callback when model loading fails
+ * @param {string|null} props.initPhase     - Current initialization phase ('checking', 'loading', or null)
+ * @param {string}      props.initMessage   - Message to display during initialization
+ * @param {number}      props.initProgress  - Progress percentage during initialization
+ * @param               props.onModelUnload
  */
 const ModelStatus = ( {
 	onModelReady,

--- a/src/extensions/services/chat-orchestrator.js
+++ b/src/extensions/services/chat-orchestrator.js
@@ -494,7 +494,16 @@ class ChatOrchestrator {
 		}
 
 		if ( needsConfirmation ) {
-			const confirmed = await this.requestConfirmation( tool );
+			// Pass params-aware confirmation message and destructive flag
+			const confirmationMessage = tool.getConfirmationMessage
+				? tool.getConfirmationMessage( params )
+				: tool.confirmationMessage || `Execute ${ tool.id }?`;
+
+			const confirmed = await this.requestConfirmation( {
+				...tool,
+				confirmationMessage,
+				isDestructive: true,
+			} );
 			if ( ! confirmed ) {
 				this.session.addAssistantMessage( 'Action cancelled.' );
 				return { success: true, cancelled: true };
@@ -518,8 +527,8 @@ class ChatOrchestrator {
 		let success = true;
 
 		try {
-			// Pass userMessage to execute so tools can extract parameters
-			result = await tool.execute( { userMessage } );
+			// Pass userMessage and parsed params to execute
+			result = await tool.execute( { userMessage, ...params } );
 			success = isToolResultSuccess( result );
 			this.session.addToolResult( tool.id, result, success );
 		} catch ( error ) {

--- a/src/extensions/workflows/check-if-hacked.js
+++ b/src/extensions/workflows/check-if-hacked.js
@@ -81,16 +81,13 @@ export function registerCheckIfHackedWorkflow() {
 			);
 			const pluginResult = results.find(
 				( r ) =>
-					r.abilityId ===
-					'wp-agentic-admin/verify-plugin-checksums'
+					r.abilityId === 'wp-agentic-admin/verify-plugin-checksums'
 			);
 			const dbResult = results.find(
-				( r ) =>
-					r.abilityId === 'wp-agentic-admin/database-check'
+				( r ) => r.abilityId === 'wp-agentic-admin/database-check'
 			);
 			const fileScanResult = results.find(
-				( r ) =>
-					r.abilityId === 'wp-agentic-admin/file-scan'
+				( r ) => r.abilityId === 'wp-agentic-admin/file-scan'
 			);
 
 			const lines = [];
@@ -152,17 +149,16 @@ export function registerCheckIfHackedWorkflow() {
 							);
 						} else if ( plugin.status === 'failed' ) {
 							const issues = plugin.issues || [];
-							for ( const issue of issues.slice(
-								0,
-								10
-							) ) {
+							for ( const issue of issues.slice( 0, 10 ) ) {
 								lines.push(
 									`| ${ plugin.plugin } | \`${ issue.file }\` | **${ issue.status }** |`
 								);
 							}
 							if ( issues.length > 10 ) {
 								lines.push(
-									`| ${ plugin.plugin } | ...and ${ issues.length - 10 } more | |`
+									`| ${ plugin.plugin } | ...and ${
+										issues.length - 10
+									} more | |`
 								);
 							}
 						}
@@ -200,7 +196,9 @@ export function registerCheckIfHackedWorkflow() {
 						}
 						if ( check.findings.length > 5 ) {
 							lines.push(
-								`| ${ check.name } | ...and ${ check.findings.length - 5 } more | — |`
+								`| ${ check.name } | ...and ${
+									check.findings.length - 5
+								} more | — |`
 							);
 						}
 					}
@@ -236,7 +234,9 @@ export function registerCheckIfHackedWorkflow() {
 				}
 				if ( fs.mu_plugins_scanned?.length > 0 ) {
 					lines.push(
-						`MU-Plugins (${ fs.mu_plugins_scanned.length }): ${ fs.mu_plugins_scanned.join( ', ' ) }`
+						`MU-Plugins (${
+							fs.mu_plugins_scanned.length
+						}): ${ fs.mu_plugins_scanned.join( ', ' ) }`
 					);
 				} else {
 					lines.push( 'MU-Plugins: none found' );
@@ -261,7 +261,9 @@ export function registerCheckIfHackedWorkflow() {
 					}
 					if ( fs.findings.length > 15 ) {
 						lines.push(
-							`| ...and ${ fs.findings.length - 15 } more files | | | |`
+							`| ...and ${
+								fs.findings.length - 15
+							} more files | | | |`
 						);
 					}
 				}
@@ -274,8 +276,7 @@ export function registerCheckIfHackedWorkflow() {
 			// --- Role capabilities table ---
 			const roleResult = results.find(
 				( r ) =>
-					r.abilityId ===
-					'wp-agentic-admin/role-capabilities-check'
+					r.abilityId === 'wp-agentic-admin/role-capabilities-check'
 			);
 
 			lines.push( '**Role Capabilities**' );
@@ -326,7 +327,9 @@ export function registerCheckIfHackedWorkflow() {
 							allClear = false;
 							lines.push( '' );
 							lines.push(
-								`Non-default roles with admin access: ${ dangerous.map( ( r ) => `**${ r.role_name }**` ).join( ', ' ) }`
+								`Non-default roles with admin access: ${ dangerous
+									.map( ( r ) => `**${ r.role_name }**` )
+									.join( ', ' ) }`
 							);
 						}
 					}
@@ -362,12 +365,17 @@ export function registerCheckIfHackedWorkflow() {
 function formatDbFinding( f ) {
 	if ( f.option_name ) {
 		const preview = f.preview
-			? ': ' + ( f.preview.length > 80 ? f.preview.substring( 0, 80 ) + '...' : f.preview )
+			? ': ' +
+			  ( f.preview.length > 80
+					? f.preview.substring( 0, 80 ) + '...'
+					: f.preview )
 			: '';
 		return `\`${ f.option_name }\`${ preview }`;
 	}
 	if ( f.post_id && f.title ) {
-		return `Post #${ f.post_id } "${ f.title }" (${ f.post_type || 'post' }${ f.status ? ', ' + f.status : '' })`;
+		return `Post #${ f.post_id } "${ f.title }" (${
+			f.post_type || 'post'
+		}${ f.status ? ', ' + f.status : '' })`;
 	}
 	if ( f.user_id && f.meta_key ) {
 		return `User #${ f.user_id } meta \`${ f.meta_key }\``;


### PR DESCRIPTION
## Summary

- **Pass parsed params to `tool.execute()`** — `parseIntent()` results (e.g. `dry_run`, `keep_last`) were being used for the `requiresConfirmation` check but discarded before calling `execute()`, so abilities always ran with default params
- **Use params-aware confirmation message** — calls `getConfirmationMessage(params)` when available so the modal shows context like retention count
- **Forward `isDestructive` flag to confirmation modal** — the confirm button was always red for non-intent confirmations; now respects an explicit `isDestructive` flag from the orchestrator

## Root causes fixed

1. `chat-orchestrator.js:522` — `tool.execute({ userMessage })` discarded parsed params → `dry_run` was always `undefined`/`false`
2. `ChatContainer.jsx:1008` — `isDestructive={ !pendingConfirmation.isIntentConfirmation }` made all ability confirmations red
3. `chat-orchestrator.js:497` — `requestConfirmation(tool)` did not pass params-aware message

## Test plan

- [ ] Say "revision-cleanup dry-run" → should execute immediately with no confirmation dialog, result shows dry-run data
- [ ] Say "clean up revisions" → should show confirmation dialog with red destructive button and params-aware message
- [ ] Confirm the dialog → revisions are deleted (not cancelled)
- [ ] Cancel the dialog → shows "Action cancelled"
- [ ] Unit tests pass (`npm test` — 43/43)
- [ ] Lint passes for both modified files

Closes #114
Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)