### PR TITLE
fix: remove beforeunload popup when navigating away

### DIFF
--- a/src/extensions/App.jsx
+++ b/src/extensions/App.jsx
@@ -127,25 +127,6 @@ const App = () => {
 	}, [] );
 
 	/**
-	 * Warn user before leaving page if model is loaded
-	 */
-	useEffect( () => {
-		const handleBeforeUnload = ( e ) => {
-			if ( modelReady ) {
-				const message =
-					'The AI model is loaded. Leaving this page will unload it and require re-initialization on return.';
-				e.preventDefault();
-				e.returnValue = message;
-				return message;
-			}
-		};
-
-		window.addEventListener( 'beforeunload', handleBeforeUnload );
-		return () =>
-			window.removeEventListener( 'beforeunload', handleBeforeUnload );
-	}, [ modelReady ] );
-
-	/**
 	 * Handle model ready callback
 	 */
 	const handleModelReady = useCallback( () => {


### PR DESCRIPTION
## Summary
- Removes the `beforeunload` event listener that showed "are you sure you want to leave" when the AI model was loaded
- The popup was disruptive — users can re-initialize the model when they return

## Test plan
- [ ] Load the AI model, then navigate away — no popup should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)