### PR TITLE
fix: contextual field filtering in interpretResult for core/get-site-…

### DIFF
--- a/src/extensions/abilities/core-site-info.js
+++ b/src/extensions/abilities/core-site-info.js
@@ -37,6 +37,36 @@ import {
 } from '../services/agentic-abilities-api';
 
 /**
+ * Map of data fields to the keywords that indicate a user is asking about them.
+ */
+const FIELD_KEYWORDS = {
+	name: [ 'name', 'title' ],
+	url: [ 'url', 'address' ],
+	description: [ 'tagline', 'description' ],
+	version: [ 'version' ],
+	admin_email: [ 'email' ],
+	language: [ 'language', 'locale' ],
+	charset: [ 'charset', 'encoding' ],
+};
+
+/**
+ * Detect which site-info fields a user message is asking about.
+ *
+ * @param {string} message - The user's message.
+ * @return {string[]} Array of field names, empty if no specific fields detected.
+ */
+function detectRequestedFields( message ) {
+	const lower = message.toLowerCase();
+	const fields = [];
+	for ( const [ field, keywords ] of Object.entries( FIELD_KEYWORDS ) ) {
+		if ( keywords.some( ( kw ) => lower.includes( kw ) ) ) {
+			fields.push( field );
+		}
+	}
+	return fields;
+}
+
+/**
  * Register the core/get-site-info ability with the chat system.
  */
 export function registerCoreSiteInfo() {
@@ -105,32 +135,45 @@ export function registerCoreSiteInfo() {
 		/**
 		 * Plain-English interpretation of the result for the LLM.
 		 *
-		 * @param {Object} result - The result from WordPress core.
+		 * Filters output to only the fields the user asked about,
+		 * so small models return focused answers instead of dumping everything.
+		 *
+		 * @param {Object} result        - The result from WordPress core.
+		 * @param {string} [userMessage] - The user's original message.
 		 * @return {string} Plain-English interpretation.
 		 */
-		interpretResult: ( result ) => {
+		interpretResult: ( result, userMessage ) => {
 			if ( ! result || typeof result !== 'object' ) {
 				return 'Unable to retrieve site information.';
 			}
-			const parts = [];
-			if ( result.name ) {
-				parts.push( `site name is "${ result.name }"` );
-			}
-			if ( result.description ) {
-				parts.push( `tagline is "${ result.description }"` );
-			}
-			if ( result.url ) {
-				parts.push( `URL is ${ result.url }` );
-			}
-			if ( result.version ) {
-				parts.push( `WordPress ${ result.version }` );
-			}
-			if ( result.language ) {
-				parts.push( `language: ${ result.language }` );
-			}
-			if ( result.admin_email ) {
-				parts.push( `admin email: ${ result.admin_email }` );
-			}
+
+			const fieldBuilders = {
+				name: () => result.name && `site name is "${ result.name }"`,
+				description: () =>
+					result.description &&
+					`tagline is "${ result.description }"`,
+				url: () => result.url && `URL is ${ result.url }`,
+				version: () =>
+					result.version && `WordPress ${ result.version }`,
+				language: () =>
+					result.language && `language: ${ result.language }`,
+				admin_email: () =>
+					result.admin_email &&
+					`admin email: ${ result.admin_email }`,
+				charset: () => result.charset && `charset: ${ result.charset }`,
+			};
+
+			const requested = userMessage
+				? detectRequestedFields( userMessage )
+				: [];
+
+			const fieldsToInclude =
+				requested.length > 0 ? requested : Object.keys( fieldBuilders );
+
+			const parts = fieldsToInclude
+				.map( ( f ) => fieldBuilders[ f ]?.() )
+				.filter( Boolean );
+
 			if ( parts.length === 0 ) {
 				return 'Site information was retrieved but contained no data.';
 			}
@@ -161,42 +204,7 @@ export function registerCoreSiteInfo() {
 		 * @return {Object} Extracted parameters.
 		 */
 		parseIntent: ( message ) => {
-			const lowerMessage = message.toLowerCase();
-			const fields = [];
-
-			// Check for specific field requests
-			if ( lowerMessage.includes( 'version' ) ) {
-				fields.push( 'version' );
-			}
-			if (
-				lowerMessage.includes( 'name' ) ||
-				lowerMessage.includes( 'title' )
-			) {
-				fields.push( 'name' );
-			}
-			if (
-				lowerMessage.includes( 'url' ) ||
-				lowerMessage.includes( 'address' )
-			) {
-				fields.push( 'url' );
-			}
-			if (
-				lowerMessage.includes( 'tagline' ) ||
-				lowerMessage.includes( 'description' )
-			) {
-				fields.push( 'description' );
-			}
-			if ( lowerMessage.includes( 'email' ) ) {
-				fields.push( 'admin_email' );
-			}
-			if (
-				lowerMessage.includes( 'language' ) ||
-				lowerMessage.includes( 'locale' )
-			) {
-				fields.push( 'language' );
-			}
-
-			// Return empty fields to get all info if no specific request
+			const fields = detectRequestedFields( message );
 			return fields.length > 0 ? { fields } : {};
 		},
 

--- a/src/extensions/services/__tests__/core-site-info.test.js
+++ b/src/extensions/services/__tests__/core-site-info.test.js
@@ -1,0 +1,180 @@
+/**
+ * Core Site Info Ability Tests
+ *
+ * Tests contextual field filtering in interpretResult and parseIntent.
+ * Verifies that the LLM receives focused interpretations when users
+ * ask about specific fields (issue #79).
+ */
+
+// We need to mock the agentic-abilities-api before importing the module
+// so registerAbility captures the ability config for us to test.
+let registeredAbility = null;
+
+jest.mock( '../../services/agentic-abilities-api', () => ( {
+	registerAbility: ( id, config ) => {
+		registeredAbility = { id, ...config };
+	},
+	executeAbility: jest.fn(),
+} ) );
+
+import { registerCoreSiteInfo } from '../../abilities/core-site-info';
+
+// Register the ability so we can access its methods.
+registerCoreSiteInfo();
+
+const MOCK_RESULT = {
+	name: 'My WordPress Site',
+	description: 'Just another WordPress site',
+	url: 'https://example.com',
+	version: '6.9.0',
+	language: 'en_US',
+	admin_email: 'admin@example.com',
+	charset: 'UTF-8',
+};
+
+describe( 'core/get-site-info', () => {
+	describe( 'interpretResult', () => {
+		it( 'returns full interpretation when no userMessage is provided', () => {
+			const result = registeredAbility.interpretResult( MOCK_RESULT );
+			expect( result ).toContain( 'site name is' );
+			expect( result ).toContain( 'URL is' );
+			expect( result ).toContain( 'tagline is' );
+			expect( result ).toContain( 'WordPress 6.9.0' );
+			expect( result ).toContain( 'admin email:' );
+		} );
+
+		it( 'returns full interpretation for general queries', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'tell me about my site'
+			);
+			expect( result ).toContain( 'site name is' );
+			expect( result ).toContain( 'URL is' );
+			expect( result ).toContain( 'tagline is' );
+		} );
+
+		it( 'returns only URL when user asks about URL', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what is my site URL?'
+			);
+			expect( result ).toContain( 'URL is https://example.com' );
+			expect( result ).not.toContain( 'site name is' );
+			expect( result ).not.toContain( 'tagline is' );
+			expect( result ).not.toContain( 'WordPress 6.9.0' );
+		} );
+
+		it( 'returns only URL when user asks about address', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what is my address URL'
+			);
+			expect( result ).toContain( 'URL is https://example.com' );
+			expect( result ).not.toContain( 'site name is' );
+		} );
+
+		it( 'returns only name when user asks about site name', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what is the site name?'
+			);
+			expect( result ).toContain( 'site name is "My WordPress Site"' );
+			expect( result ).not.toContain( 'URL is' );
+			expect( result ).not.toContain( 'tagline is' );
+		} );
+
+		it( 'returns only version when user asks about version', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what WordPress version am I running?'
+			);
+			expect( result ).toContain( 'WordPress 6.9.0' );
+			expect( result ).not.toContain( 'site name is' );
+			expect( result ).not.toContain( 'URL is' );
+		} );
+
+		it( 'returns only email when user asks about email', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what is the admin email?'
+			);
+			expect( result ).toContain( 'admin email: admin@example.com' );
+			expect( result ).not.toContain( 'site name is' );
+			expect( result ).not.toContain( 'URL is' );
+		} );
+
+		it( 'returns only language when user asks about language', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what language is my site in?'
+			);
+			expect( result ).toContain( 'language: en_US' );
+			expect( result ).not.toContain( 'site name is' );
+		} );
+
+		it( 'returns multiple fields when user asks about several', () => {
+			const result = registeredAbility.interpretResult(
+				MOCK_RESULT,
+				'what is my site name and email?'
+			);
+			expect( result ).toContain( 'site name is' );
+			expect( result ).toContain( 'admin email:' );
+			expect( result ).not.toContain( 'URL is' );
+			expect( result ).not.toContain( 'WordPress 6.9.0' );
+		} );
+
+		it( 'handles empty result gracefully', () => {
+			const result = registeredAbility.interpretResult( {} );
+			expect( result ).toBe(
+				'Site information was retrieved but contained no data.'
+			);
+		} );
+
+		it( 'handles null result gracefully', () => {
+			const result = registeredAbility.interpretResult( null );
+			expect( result ).toBe( 'Unable to retrieve site information.' );
+		} );
+	} );
+
+	describe( 'parseIntent', () => {
+		it( 'returns empty object for general queries', () => {
+			expect(
+				registeredAbility.parseIntent( 'tell me about my site' )
+			).toEqual( {} );
+		} );
+
+		it( 'detects URL field', () => {
+			expect(
+				registeredAbility.parseIntent( 'what is my site URL?' )
+			).toEqual( { fields: [ 'url' ] } );
+		} );
+
+		it( 'detects name field from "title"', () => {
+			expect(
+				registeredAbility.parseIntent( 'what is the site title?' )
+			).toEqual( { fields: [ 'name' ] } );
+		} );
+
+		it( 'detects address as URL', () => {
+			expect(
+				registeredAbility.parseIntent( 'what is my address' )
+			).toEqual( { fields: [ 'url' ] } );
+		} );
+
+		it( 'detects multiple fields', () => {
+			const result = registeredAbility.parseIntent(
+				'show me the name and version'
+			);
+			expect( result.fields ).toContain( 'name' );
+			expect( result.fields ).toContain( 'version' );
+		} );
+
+		it( 'detects charset field via encoding keyword', () => {
+			expect(
+				registeredAbility.parseIntent(
+					'what encoding does my site use?'
+				)
+			).toEqual( { fields: [ 'charset' ] } );
+		} );
+	} );
+} );

--- a/src/extensions/services/__tests__/core-site-info.test.js
+++ b/src/extensions/services/__tests__/core-site-info.test.js
@@ -3,7 +3,7 @@
  *
  * Tests contextual field filtering in interpretResult and parseIntent.
  * Verifies that the LLM receives focused interpretations when users
- * ask about specific fields (issue #79).
+ * ask about specific fields (issue #109).
  */
 
 // We need to mock the agentic-abilities-api before importing the module


### PR DESCRIPTION
## fix: contextual field filtering in interpretResult for core/get-site-info

Make `interpretResult` context-aware so small models return focused answers instead of dumping all fields. Uses the `userMessage` parameter (already passed by the ReAct agent) to detect which fields the user asked about and filters the interpretation accordingly.

Extracts shared `FIELD_KEYWORDS` map and `detectRequestedFields()` helper, reused by both `interpretResult` and `parseIntent`.

Closes #109

## What does this PR do?

Fixes the LLM returning all site info fields when the user asks for a specific one (e.g., "what is my site URL?" now yields only the URL instead of name, tagline, version, email, etc.). The fix filters `interpretResult` output to match the user's question, so the 1.7B model receives — and relays — only the relevant fields.

## Type

- [ ] New ability
- [ ] New workflow
- [x] Bug fix
- [ ] Enhancement
- [ ] Docs

## How to test

1. Build the plugin: `npm run build`
2. Ask "what is my site URL?" — the LLM should respond with just the URL, not all fields
3. Ask "what is the site name?" — should return only the site name
4. Ask "tell me about my site" — should still return all fields (general query)
5. Ask "what is my email and site name?" — should return only those two fields
6. Run unit tests: `npm test` — all 88 tests pass, including 17 new contextual filtering tests

## Screenshots 
<img width="662" height="274" alt="image" src="https://github.com/user-attachments/assets/8cd3a37a-00d5-43d6-a4e7-cfd7e1feb04b" />

