### PR TITLE
Add local voice input (Whisper) with push-to-talk and visual feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.5",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "@huggingface/transformers": "^3.8.1",
         "@mlc-ai/web-llm": "^0.2.82",
         "@wordpress/icons": "^12.0.0",
         "fastest-levenshtein": "^1.0.16",
@@ -2278,7 +2279,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2541,6 +2541,25 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.6.tgz",
+      "integrity": "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2602,6 +2621,457 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4386,6 +4856,60 @@
         "@opentelemetry/api": "^1.8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
@@ -5149,7 +5673,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -7907,6 +8430,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -8319,6 +8848,14 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chrome-launcher": {
@@ -9405,7 +9942,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -9433,7 +9969,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -9616,9 +10151,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9637,7 +10170,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/devtools-protocol": {
@@ -10037,7 +10569,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10047,7 +10578,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10148,6 +10678,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -10169,7 +10704,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11773,6 +12307,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="
+    },
     "node_modules/flatted": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
@@ -12208,6 +12747,33 @@
         "node": "*"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
@@ -12271,7 +12837,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -12316,7 +12881,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12338,6 +12902,11 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -12399,7 +12968,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -14750,6 +15318,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/json2php": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.9.tgz",
@@ -15240,6 +15813,11 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
     "node_modules/lookup-closest-locale": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
@@ -15486,6 +16064,17 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -15894,6 +16483,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -16461,7 +17069,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16612,6 +17219,45 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="
     },
     "node_modules/open": {
       "version": "8.4.2",
@@ -17051,6 +17697,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/playwright": {
       "version": "1.58.2",
@@ -18003,6 +18654,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -18731,6 +19405,27 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
     "node_modules/robots-parser": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
@@ -19092,6 +19787,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+    },
     "node_modules/send": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
@@ -19156,6 +19856,31 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-javascript": {
@@ -19363,6 +20088,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -20771,6 +21550,21 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.12",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.12.tgz",
+      "integrity": "sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -20812,6 +21606,14 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teex": {
@@ -21494,7 +22296,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -21779,8 +22580,7 @@
     "node_modules/voy-search": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/voy-search/-/voy-search-0.6.3.tgz",
-      "integrity": "sha512-GRwrXcT3Qmzr/CuwpwX55XWpgqM2hUqLipSwI8bGcfsDTJGa+mFxsOXzWHNMRpcYd+U2RP73f2USLDWQu5yFdQ==",
-      "license": "MIT OR Apache 2.0"
+      "integrity": "sha512-GRwrXcT3Qmzr/CuwpwX55XWpgqM2hUqLipSwI8bGcfsDTJGa+mFxsOXzWHNMRpcYd+U2RP73f2USLDWQu5yFdQ=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "del-cli": "^5.1.0"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.8.1",
     "@mlc-ai/web-llm": "^0.2.82",
     "@wordpress/icons": "^12.0.0",
     "fastest-levenshtein": "^1.0.16",

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -865,7 +865,7 @@ const ChatContainer = ( {
 						? 'Load the AI model to start chatting...'
 						: isLoading || isStreaming
 							? 'Thinking...'
-							: 'Describe your issue or what you want to do...'
+							: 'Describe your issue or what you want to do… (hold Space to speak)'
 				}
 			/>
 

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -864,8 +864,8 @@ const ChatContainer = ( {
 					! modelReady
 						? 'Load the AI model to start chatting...'
 						: isLoading || isStreaming
-							? 'Thinking...'
-							: 'Describe your issue or what you want to do… (hold Space to speak)'
+						? 'Thinking...'
+						: 'Describe your issue or what you want to do… (hold Space to speak)'
 				}
 			/>
 

--- a/src/extensions/components/ChatInput.jsx
+++ b/src/extensions/components/ChatInput.jsx
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/icons';
 import ABILITY_BUNDLES from '../data/ability-bundles';
 import pluginAbilitiesManager from '../services/plugin-abilities-manager';
+import VoiceButton from './VoiceButton';
 
 /**
  * Map of bundle icon names to @wordpress/icons components.
@@ -47,14 +48,23 @@ const BUNDLE_ICONS = {
 const ChatInput = ( {
 	onSend,
 	disabled = false,
-	placeholder = 'Type your message...',
+	placeholder = 'Describe your issue or what you want to do… (hold Space to speak)',
 	isLoading = false,
 } ) => {
 	const [ message, setMessage ] = useState( '' );
 	const [ selectedBundle, setSelectedBundle ] = useState( null );
 	const [ webSearchEnabled, setWebSearchEnabled ] = useState( false );
 	const [ pluginBundles, setPluginBundles ] = useState( [] );
+	const [ voiceState, setVoiceState ] = useState( 'idle' );
 	const textareaRef = useRef( null );
+	const voiceButtonRef = useRef( null );
+	const isSpaceDownRef = useRef( false );
+	const spacePressTimerRef = useRef( null );
+
+	// Cancel pending push-to-talk timer on unmount.
+	useEffect( () => {
+		return () => clearTimeout( spacePressTimerRef.current );
+	}, [] );
 
 	// Subscribe to plugin abilities manager for dynamic bundles
 	useEffect( () => {
@@ -82,6 +92,11 @@ const ChatInput = ( {
 			e.preventDefault();
 		}
 
+		// Prevent accidental submit while recording or transcribing.
+		if ( isVoiceActive ) {
+			return;
+		}
+
 		const trimmedMessage = message.trim();
 		if ( ! trimmedMessage || disabled || isLoading ) {
 			return;
@@ -96,7 +111,12 @@ const ChatInput = ( {
 	};
 
 	/**
-	 * Handle keydown for Enter to send (Shift+Enter for new line)
+	 * Handle keydown: Enter sends, Space on empty input starts recording.
+	 *
+	 * A 200 ms threshold distinguishes a quick tap (insert space) from a
+	 * deliberate hold (push-to-talk). The OS key-repeat delay is ~500 ms,
+	 * so we also suppress repeat events once recording is active to prevent
+	 * spaces from being inserted while the user holds the key.
 	 *
 	 * @param {KeyboardEvent} e - Keyboard event
 	 */
@@ -104,6 +124,55 @@ const ChatInput = ( {
 		if ( e.key === 'Enter' && ! e.shiftKey ) {
 			e.preventDefault();
 			handleSubmit( e );
+			return;
+		}
+
+		if ( e.key === ' ' ) {
+			// Suppress OS key-repeat events while push-to-talk or its timer is active.
+			if (
+				isSpaceDownRef.current ||
+				spacePressTimerRef.current !== null
+			) {
+				e.preventDefault();
+				return;
+			}
+
+			// Empty input + idle: arm the 200 ms push-to-talk timer.
+			if (
+				message === '' &&
+				voiceState === 'idle' &&
+				! e.repeat &&
+				! isDisabled
+			) {
+				e.preventDefault();
+				spacePressTimerRef.current = setTimeout( () => {
+					spacePressTimerRef.current = null;
+					isSpaceDownRef.current = true;
+					voiceButtonRef.current?.start();
+				}, 200 );
+			}
+		}
+	};
+
+	/**
+	 * Handle keyup: Space release either inserts a space (quick tap) or stops recording.
+	 *
+	 * @param {KeyboardEvent} e - Keyboard event
+	 */
+	const handleKeyUp = ( e ) => {
+		if ( e.key !== ' ' ) {
+			return;
+		}
+
+		if ( spacePressTimerRef.current !== null ) {
+			// Released before the 200 ms threshold — treat as a normal space character.
+			clearTimeout( spacePressTimerRef.current );
+			spacePressTimerRef.current = null;
+			setMessage( ( prev ) => prev + ' ' );
+		} else if ( isSpaceDownRef.current ) {
+			// Released after recording started — stop push-to-talk.
+			isSpaceDownRef.current = false;
+			voiceButtonRef.current?.stop();
 		}
 	};
 
@@ -116,8 +185,24 @@ const ChatInput = ( {
 		setMessage( e.target.value );
 	};
 
+	/**
+	 * Set the final transcription result and focus the textarea for editing.
+	 *
+	 * @param {string} text - Final transcribed text from Whisper.
+	 */
+	const handleTranscript = ( text ) => {
+		setMessage( text );
+		// Give focus back so the user can immediately edit or send.
+		requestAnimationFrame( () => textareaRef.current?.focus() );
+	};
+
 	const isDisabled = disabled || isLoading;
+	const isVoiceActive = voiceState !== 'idle';
+	const isTranscribing = voiceState === 'transcribing';
 	const canSend = message.trim().length > 0 && ! isDisabled;
+	// Mic is visible on an empty input, or while voice is active (recording /
+	// transcribing) so the component stays mounted through the full cycle.
+	const showMic = message === '' || isVoiceActive;
 
 	return (
 		<div className="wp-agentic-admin-input-area">
@@ -132,16 +217,37 @@ const ChatInput = ( {
 						: ''
 				}` }
 			>
-				<textarea
-					ref={ textareaRef }
-					className="wp-agentic-admin-input"
-					value={ message }
-					onChange={ handleChange }
-					onKeyDown={ handleKeyDown }
-					placeholder={ placeholder }
-					rows="3"
-					disabled={ isDisabled }
-				/>
+				<div className="wp-agentic-admin-textarea-container">
+					<textarea
+						ref={ textareaRef }
+						className="wp-agentic-admin-input"
+						value={ message }
+						onChange={ handleChange }
+						onKeyDown={ handleKeyDown }
+						onKeyUp={ handleKeyUp }
+						placeholder={ placeholder }
+						rows="3"
+						disabled={ isDisabled }
+					/>
+					{ isTranscribing && (
+						<div
+							className="wp-agentic-admin-transcribing-overlay"
+							aria-live="polite"
+							aria-label="Transcribing audio"
+						>
+							<div className="wp-agentic-admin-transcribing-wave">
+								<span />
+								<span />
+								<span />
+								<span />
+								<span />
+							</div>
+							<span className="wp-agentic-admin-transcribing-label">
+								Transcribing…
+							</span>
+						</div>
+					) }
+				</div>
 				<div className="wp-agentic-admin-input-toolbar">
 					<div className="wp-agentic-admin-input-toolbar__left">
 						<Dropdown
@@ -286,15 +392,24 @@ const ChatInput = ( {
 						) }
 					</div>
 					<div className="wp-agentic-admin-input-toolbar__right">
-						<button
-							type="button"
-							className="wp-agentic-admin-send-button"
-							onClick={ handleSubmit }
-							disabled={ ! canSend }
-							aria-label="Send message"
-						>
-							<Icon icon={ send } size={ 20 } />
-						</button>
+						{ showMic ? (
+							<VoiceButton
+								ref={ voiceButtonRef }
+								onTranscript={ handleTranscript }
+								onStateChange={ setVoiceState }
+								disabled={ isDisabled }
+							/>
+						) : (
+							<button
+								type="button"
+								className="wp-agentic-admin-send-button"
+								onClick={ handleSubmit }
+								disabled={ ! canSend }
+								aria-label="Send message"
+							>
+								<Icon icon={ send } size={ 20 } />
+							</button>
+						) }
 					</div>
 				</div>
 			</div>

--- a/src/extensions/components/ChatInput.jsx
+++ b/src/extensions/components/ChatInput.jsx
@@ -126,6 +126,10 @@ const ChatInput = ( {
 					isDisabled
 						? ' wp-agentic-admin-input-wrapper--disabled'
 						: ''
+				}${
+					voiceState === 'recording'
+						? ' wp-agentic-admin-input-wrapper--recording'
+						: ''
 				}` }
 			>
 				<textarea

--- a/src/extensions/components/VoiceButton.jsx
+++ b/src/extensions/components/VoiceButton.jsx
@@ -103,27 +103,24 @@ const ThinkingDots = () => (
  *
  * Renders null if the browser does not support MediaRecorder or getUserMedia.
  *
- * @param {Object}   props                       - Component props.
- * @param {Function} props.onTranscript          - Called with the final transcribed string.
- * @param {Function} [props.onPartialTranscript] - Called with interim status text.
- * @param {Function} [props.onStateChange]       - Called on every state transition.
- * @param {boolean}  props.disabled              - Whether the button is disabled.
- * @param {Object}   ref                         - Imperative ref exposing start/stop.
+ * @param {Object}   props                 - Component props.
+ * @param {Function} props.onTranscript    - Called with the final transcribed string.
+ * @param {Function} [props.onStateChange] - Called on every state transition.
+ * @param {boolean}  props.disabled        - Whether the button is disabled.
+ * @param {Object}   ref                   - Imperative ref exposing start/stop.
  * @return {JSX.Element|null} The voice button, or null if unsupported.
  */
 const VoiceButton = forwardRef(
-	( { onTranscript, onPartialTranscript, onStateChange, disabled }, ref ) => {
+	( { onTranscript, onStateChange, disabled }, ref ) => {
 		const [ state, setState ] = useState( 'idle' ); // 'idle' | 'recording' | 'transcribing'
 		const [ recordingSeconds, setRecordingSeconds ] = useState( 0 );
 
 		// Stable refs for callbacks — never go stale inside async handlers.
 		const onTranscriptRef = useRef( onTranscript );
-		const onPartialTranscriptRef = useRef( onPartialTranscript );
 		const onStateChangeRef = useRef( onStateChange );
 
 		useEffect( () => {
 			onTranscriptRef.current = onTranscript;
-			onPartialTranscriptRef.current = onPartialTranscript;
 			onStateChangeRef.current = onStateChange;
 		} );
 
@@ -308,7 +305,6 @@ const VoiceButton = forwardRef(
 							[ pcmData.buffer ]
 						);
 					} catch {
-						onPartialTranscriptRef.current?.( '' );
 						transition( 'idle' );
 					}
 				} );
@@ -329,9 +325,6 @@ const VoiceButton = forwardRef(
 					if ( mediaRecorderRef.current?.state === 'recording' ) {
 						mediaRecorderRef.current.stop();
 						transition( 'transcribing' );
-						onPartialTranscriptRef.current?.(
-							'Transcribing your voice...'
-						);
 					}
 				}, MAX_RECORDING_SECONDS * 1000 );
 			} catch {
@@ -346,11 +339,6 @@ const VoiceButton = forwardRef(
 			if ( mediaRecorderRef.current?.state === 'recording' ) {
 				mediaRecorderRef.current.stop();
 				transition( 'transcribing' );
-				// Show in-progress text inside the textarea so the user knows
-				// transcription is running. Replaced by the real result on success.
-				onPartialTranscriptRef.current?.(
-					'Transcribing your voice...'
-				);
 			}
 		};
 

--- a/src/extensions/components/VoiceButton.jsx
+++ b/src/extensions/components/VoiceButton.jsx
@@ -1,0 +1,382 @@
+/**
+ * VoiceButton Component
+ *
+ * Microphone button for speech-to-text voice input.
+ *
+ * Flow:
+ *   1. User clicks mic → MediaRecorder starts.
+ *   2. User clicks the stop icon (or 30 s elapses) → recording stops, state
+ *      moves to 'transcribing'.
+ *   3. Full audio blob is decoded and sent to the Whisper Web Worker.
+ *   4. Final transcript is passed to onTranscript callback.
+ *
+ * States:
+ *   idle         — mic icon, visible only on empty input
+ *   recording    — stop icon + countdown badge; click to stop
+ *   transcribing — three pulsing dots while Whisper runs
+ *
+ * iOS Safari: audio/webm unsupported → falls back to audio/mp4.
+ * WebGPU unavailable on iOS → worker uses WASM backend automatically.
+ *
+ * @since 0.10.0
+ */
+
+import { useState, useRef, useEffect } from '@wordpress/element';
+
+/** Maximum recording duration in seconds — matches Whisper's context window. */
+const MAX_RECORDING_SECONDS = 30;
+
+/**
+ * Find the best supported MIME type for MediaRecorder.
+ *
+ * Safari/iOS does not support audio/webm — falls back to audio/mp4.
+ *
+ * @return {string} Supported MIME type, or empty string for browser default.
+ */
+function getSupportedMimeType() {
+	const candidates = [
+		'audio/webm;codecs=opus',
+		'audio/webm',
+		'audio/mp4',
+		'audio/ogg;codecs=opus',
+	];
+
+	for ( const type of candidates ) {
+		if (
+			typeof MediaRecorder !== 'undefined' &&
+			MediaRecorder.isTypeSupported( type )
+		) {
+			return type;
+		}
+	}
+
+	return '';
+}
+
+/** Material Design "mic" path (24 × 24 viewBox). */
+const MicIcon = () => (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 24 24"
+		fill="currentColor"
+		aria-hidden="true"
+	>
+		<path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.91-3c-.49 0-.9.36-.98.85C16.52 14.2 14.47 16 12 16s-4.52-1.8-4.93-4.15c-.08-.49-.49-.85-.98-.85-.61 0-1.09.54-1 1.14.49 3 2.89 5.35 5.91 5.78V20c0 .55.45 1 1 1s1-.45 1-1v-2.08c3.02-.43 5.42-2.78 5.91-5.78.1-.6-.39-1.14-1-1.14z" />
+	</svg>
+);
+
+/** Material Design "stop" square (24 × 24 viewBox). */
+const StopIcon = () => (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 24 24"
+		fill="currentColor"
+		aria-hidden="true"
+	>
+		<rect x="6" y="6" width="12" height="12" rx="1" />
+	</svg>
+);
+
+/** Three pulsing dots shown while Whisper is running the final pass. */
+const ThinkingDots = () => (
+	<span className="wp-agentic-admin-voice-dots" aria-hidden="true">
+		<span />
+		<span />
+		<span />
+	</span>
+);
+
+/**
+ * VoiceButton component.
+ *
+ * Renders null if the browser does not support MediaRecorder or getUserMedia.
+ *
+ * @param {Object}   props                       - Component props.
+ * @param {Function} props.onTranscript          - Called with the final transcribed string.
+ * @param {Function} [props.onPartialTranscript] - Reserved for future live transcription.
+ * @param {Function} [props.onStateChange]       - Called on every state transition.
+ * @param {boolean}  props.disabled              - Whether the button is disabled.
+ * @return {JSX.Element|null} The voice button, or null if unsupported.
+ */
+const VoiceButton = ( {
+	onTranscript,
+	onPartialTranscript,
+	onStateChange,
+	disabled,
+} ) => {
+	const [ state, setState ] = useState( 'idle' ); // 'idle' | 'recording' | 'transcribing'
+	const [ recordingSeconds, setRecordingSeconds ] = useState( 0 );
+
+	// Stable refs for callbacks — never go stale inside async handlers.
+	const onTranscriptRef = useRef( onTranscript );
+	const onPartialTranscriptRef = useRef( onPartialTranscript );
+	const onStateChangeRef = useRef( onStateChange );
+
+	useEffect( () => {
+		onTranscriptRef.current = onTranscript;
+		onPartialTranscriptRef.current = onPartialTranscript;
+		onStateChangeRef.current = onStateChange;
+	} );
+
+	const mediaRecorderRef = useRef( null );
+	const mimeTypeRef = useRef( '' );
+	const workerRef = useRef( null );
+	const decodeCtxRef = useRef( null );
+	const requestIdRef = useRef( 0 );
+	const autoStopTimeoutRef = useRef( null );
+	const countdownIntervalRef = useRef( null );
+
+	/**
+	 * Transition to a new state and notify the parent.
+	 *
+	 * @param {string} next - New state value.
+	 */
+	const transition = ( next ) => {
+		setState( next );
+		onStateChangeRef.current?.( next );
+	};
+
+	/**
+	 * Lazily create (and cache) the Whisper Web Worker.
+	 *
+	 * @return {Worker|null} Worker instance, or null when pluginUrl is unavailable.
+	 */
+	const getWorker = () => {
+		if ( workerRef.current ) {
+			return workerRef.current;
+		}
+
+		const pluginUrl = window.wpAgenticAdmin?.pluginUrl;
+
+		if ( ! pluginUrl ) {
+			return null;
+		}
+
+		const worker = new Worker(
+			pluginUrl + 'build-extensions/whisper-worker.js'
+		);
+
+		worker.addEventListener( 'message', ( e ) => {
+			const { type: msgType, text } = e.data;
+
+			if ( msgType === 'result' ) {
+				onTranscriptRef.current?.( text );
+				transition( 'idle' );
+			} else if ( msgType === 'error' ) {
+				transition( 'idle' );
+			}
+		} );
+
+		workerRef.current = worker;
+		return worker;
+	};
+
+	// Clean up everything on unmount.
+	useEffect( () => {
+		return () => {
+			workerRef.current?.terminate();
+			decodeCtxRef.current?.close();
+			clearTimeout( autoStopTimeoutRef.current );
+			clearInterval( countdownIntervalRef.current );
+		};
+	}, [] );
+
+	// Pre-warm the Whisper model on mount so first voice use is instant.
+	// getWorker() accesses only stable refs and window globals — safe with [].
+	useEffect( () => {
+		if (
+			typeof MediaRecorder === 'undefined' ||
+			! navigator?.mediaDevices?.getUserMedia
+		) {
+			return;
+		}
+		const worker = getWorker();
+		if ( worker ) {
+			worker.postMessage( { type: 'warmup' } );
+		}
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	// Return null if the browser lacks the required APIs.
+	if (
+		typeof MediaRecorder === 'undefined' ||
+		! navigator?.mediaDevices?.getUserMedia
+	) {
+		return null;
+	}
+
+	/**
+	 * Get (or create) the 16 kHz AudioContext used to decode recorded audio.
+	 *
+	 * Reusing the same context avoids hitting browser limits on
+	 * AudioContext instances.
+	 *
+	 * @return {AudioContext} Decode context.
+	 */
+	const getDecodeCtx = () => {
+		if (
+			! decodeCtxRef.current ||
+			decodeCtxRef.current.state === 'closed'
+		) {
+			decodeCtxRef.current = new AudioContext( { sampleRate: 16000 } );
+		}
+
+		return decodeCtxRef.current;
+	};
+
+	const startRecording = async () => {
+		try {
+			const stream = await navigator.mediaDevices.getUserMedia( {
+				audio: true,
+			} );
+
+			const mimeType = getSupportedMimeType();
+			mimeTypeRef.current = mimeType;
+
+			const options = mimeType ? { mimeType } : {};
+			const recorder = new MediaRecorder( stream, options );
+			const chunks = [];
+
+			recorder.addEventListener( 'dataavailable', ( e ) => {
+				if ( e.data.size > 0 ) {
+					chunks.push( e.data );
+				}
+			} );
+
+			recorder.addEventListener( 'stop', async () => {
+				stream.getTracks().forEach( ( track ) => track.stop() );
+
+				if ( ! chunks.length ) {
+					transition( 'idle' );
+					return;
+				}
+
+				try {
+					const blob = new Blob( chunks, {
+						type: mimeTypeRef.current || 'audio/webm',
+					} );
+					const arrayBuffer = await blob.arrayBuffer();
+					const audioCtx = getDecodeCtx();
+					const audioBuffer =
+						await audioCtx.decodeAudioData( arrayBuffer );
+					const pcmData = audioBuffer.getChannelData( 0 );
+					const worker = getWorker();
+
+					if ( ! worker ) {
+						transition( 'idle' );
+						return;
+					}
+
+					const id = ++requestIdRef.current;
+					// Derive the site language from the <html lang="…"> attribute
+					// that WordPress sets, e.g. "en-US" → "en", "de-DE" → "de".
+					const lang =
+						document.documentElement.lang
+							?.split( '-' )[ 0 ]
+							?.toLowerCase() || 'en';
+
+					worker.postMessage(
+						{
+							type: 'transcribe',
+							audioData: pcmData,
+							sampleRate: 16000,
+							id,
+							language: lang,
+						},
+						[ pcmData.buffer ]
+					);
+				} catch {
+					onPartialTranscriptRef.current?.( '' );
+					transition( 'idle' );
+				}
+			} );
+
+			mediaRecorderRef.current = recorder;
+			recorder.start();
+			transition( 'recording' );
+
+			// Tick the countdown every second.
+			countdownIntervalRef.current = setInterval( () => {
+				setRecordingSeconds( ( s ) => s + 1 );
+			}, 1000 );
+
+			// Hard-stop at the Whisper context-window limit.
+			autoStopTimeoutRef.current = setTimeout( () => {
+				clearInterval( countdownIntervalRef.current );
+				setRecordingSeconds( 0 );
+				if ( mediaRecorderRef.current?.state === 'recording' ) {
+					mediaRecorderRef.current.stop();
+					transition( 'transcribing' );
+					onPartialTranscriptRef.current?.(
+						'Transcribing your voice...'
+					);
+				}
+			}, MAX_RECORDING_SECONDS * 1000 );
+		} catch {
+			transition( 'idle' );
+		}
+	};
+
+	const stopRecording = () => {
+		clearTimeout( autoStopTimeoutRef.current );
+		clearInterval( countdownIntervalRef.current );
+		setRecordingSeconds( 0 );
+		if ( mediaRecorderRef.current?.state === 'recording' ) {
+			mediaRecorderRef.current.stop();
+			transition( 'transcribing' );
+			// Show in-progress text inside the textarea so the user knows
+			// transcription is running. Replaced by the real result on success.
+			onPartialTranscriptRef.current?.( 'Transcribing your voice...' );
+		}
+	};
+
+	const handleClick = () => {
+		if ( state === 'idle' ) {
+			startRecording();
+		} else if ( state === 'recording' ) {
+			stopRecording();
+		}
+	};
+
+	const isProcessing = state === 'transcribing';
+	const ariaLabel =
+		state === 'recording' ? 'Stop recording' : 'Start voice input';
+	const remaining = MAX_RECORDING_SECONDS - recordingSeconds;
+	const isNearLimit = state === 'recording' && remaining <= 10;
+
+	let content;
+	if ( state === 'recording' ) {
+		content = (
+			<>
+				<StopIcon />
+				<span
+					className="wp-agentic-admin-voice-timer"
+					aria-hidden="true"
+				>
+					{ remaining }s
+				</span>
+			</>
+		);
+	} else if ( state === 'transcribing' ) {
+		content = <ThinkingDots />;
+	} else {
+		content = <MicIcon />;
+	}
+
+	return (
+		<button
+			type="button"
+			className={ `wp-agentic-admin-voice-button wp-agentic-admin-voice-button--${ state }${
+				isNearLimit ? ' wp-agentic-admin-voice-button--warning' : ''
+			}` }
+			onClick={ handleClick }
+			disabled={ disabled || isProcessing }
+			aria-label={ ariaLabel }
+		>
+			{ content }
+		</button>
+	);
+};
+
+export default VoiceButton;

--- a/src/extensions/components/VoiceButton.jsx
+++ b/src/extensions/components/VoiceButton.jsx
@@ -4,9 +4,9 @@
  * Microphone button for speech-to-text voice input.
  *
  * Flow:
- *   1. User clicks mic → MediaRecorder starts.
- *   2. User clicks the stop icon (or 30 s elapses) → recording stops, state
- *      moves to 'transcribing'.
+ *   1. User clicks mic (or parent calls ref.start()) → MediaRecorder starts.
+ *   2. User clicks stop / releases Space / 30 s elapses → recording stops,
+ *      state moves to 'transcribing'.
  *   3. Full audio blob is decoded and sent to the Whisper Web Worker.
  *   4. Final transcript is passed to onTranscript callback.
  *
@@ -15,13 +15,23 @@
  *   recording    — stop icon + countdown badge; click to stop
  *   transcribing — three pulsing dots while Whisper runs
  *
+ * Imperative handle (via ref):
+ *   ref.start() — start recording programmatically
+ *   ref.stop()  — stop recording programmatically
+ *
  * iOS Safari: audio/webm unsupported → falls back to audio/mp4.
  * WebGPU unavailable on iOS → worker uses WASM backend automatically.
  *
  * @since 0.10.0
  */
 
-import { useState, useRef, useEffect } from '@wordpress/element';
+import {
+	useState,
+	useRef,
+	useEffect,
+	useImperativeHandle,
+	forwardRef,
+} from '@wordpress/element';
 
 /** Maximum recording duration in seconds — matches Whisper's context window. */
 const MAX_RECORDING_SECONDS = 30;
@@ -95,288 +105,308 @@ const ThinkingDots = () => (
  *
  * @param {Object}   props                       - Component props.
  * @param {Function} props.onTranscript          - Called with the final transcribed string.
- * @param {Function} [props.onPartialTranscript] - Reserved for future live transcription.
+ * @param {Function} [props.onPartialTranscript] - Called with interim status text.
  * @param {Function} [props.onStateChange]       - Called on every state transition.
  * @param {boolean}  props.disabled              - Whether the button is disabled.
+ * @param {Object}   ref                         - Imperative ref exposing start/stop.
  * @return {JSX.Element|null} The voice button, or null if unsupported.
  */
-const VoiceButton = ( {
-	onTranscript,
-	onPartialTranscript,
-	onStateChange,
-	disabled,
-} ) => {
-	const [ state, setState ] = useState( 'idle' ); // 'idle' | 'recording' | 'transcribing'
-	const [ recordingSeconds, setRecordingSeconds ] = useState( 0 );
+const VoiceButton = forwardRef(
+	( { onTranscript, onPartialTranscript, onStateChange, disabled }, ref ) => {
+		const [ state, setState ] = useState( 'idle' ); // 'idle' | 'recording' | 'transcribing'
+		const [ recordingSeconds, setRecordingSeconds ] = useState( 0 );
 
-	// Stable refs for callbacks — never go stale inside async handlers.
-	const onTranscriptRef = useRef( onTranscript );
-	const onPartialTranscriptRef = useRef( onPartialTranscript );
-	const onStateChangeRef = useRef( onStateChange );
+		// Stable refs for callbacks — never go stale inside async handlers.
+		const onTranscriptRef = useRef( onTranscript );
+		const onPartialTranscriptRef = useRef( onPartialTranscript );
+		const onStateChangeRef = useRef( onStateChange );
 
-	useEffect( () => {
-		onTranscriptRef.current = onTranscript;
-		onPartialTranscriptRef.current = onPartialTranscript;
-		onStateChangeRef.current = onStateChange;
-	} );
-
-	const mediaRecorderRef = useRef( null );
-	const mimeTypeRef = useRef( '' );
-	const workerRef = useRef( null );
-	const decodeCtxRef = useRef( null );
-	const requestIdRef = useRef( 0 );
-	const autoStopTimeoutRef = useRef( null );
-	const countdownIntervalRef = useRef( null );
-
-	/**
-	 * Transition to a new state and notify the parent.
-	 *
-	 * @param {string} next - New state value.
-	 */
-	const transition = ( next ) => {
-		setState( next );
-		onStateChangeRef.current?.( next );
-	};
-
-	/**
-	 * Lazily create (and cache) the Whisper Web Worker.
-	 *
-	 * @return {Worker|null} Worker instance, or null when pluginUrl is unavailable.
-	 */
-	const getWorker = () => {
-		if ( workerRef.current ) {
-			return workerRef.current;
-		}
-
-		const pluginUrl = window.wpAgenticAdmin?.pluginUrl;
-
-		if ( ! pluginUrl ) {
-			return null;
-		}
-
-		const worker = new Worker(
-			pluginUrl + 'build-extensions/whisper-worker.js'
-		);
-
-		worker.addEventListener( 'message', ( e ) => {
-			const { type: msgType, text } = e.data;
-
-			if ( msgType === 'result' ) {
-				onTranscriptRef.current?.( text );
-				transition( 'idle' );
-			} else if ( msgType === 'error' ) {
-				transition( 'idle' );
-			}
+		useEffect( () => {
+			onTranscriptRef.current = onTranscript;
+			onPartialTranscriptRef.current = onPartialTranscript;
+			onStateChangeRef.current = onStateChange;
 		} );
 
-		workerRef.current = worker;
-		return worker;
-	};
+		const mediaRecorderRef = useRef( null );
+		const mimeTypeRef = useRef( '' );
+		const workerRef = useRef( null );
+		const decodeCtxRef = useRef( null );
+		const requestIdRef = useRef( 0 );
+		const autoStopTimeoutRef = useRef( null );
+		const countdownIntervalRef = useRef( null );
 
-	// Clean up everything on unmount.
-	useEffect( () => {
-		return () => {
-			workerRef.current?.terminate();
-			decodeCtxRef.current?.close();
-			clearTimeout( autoStopTimeoutRef.current );
-			clearInterval( countdownIntervalRef.current );
+		// Mutable refs so the imperative handle can delegate to the real functions
+		// even though those are defined after the early-return check below.
+		const startRecordingRef = useRef( null );
+		const stopRecordingRef = useRef( null );
+
+		// Expose start/stop to parent via ref (e.g. for Space-bar push-to-talk).
+		useImperativeHandle(
+			ref,
+			() => ( {
+				start: () => startRecordingRef.current?.(),
+				stop: () => stopRecordingRef.current?.(),
+			} ),
+			[]
+		); // eslint-disable-line react-hooks/exhaustive-deps
+
+		/**
+		 * Transition to a new state and notify the parent.
+		 *
+		 * @param {string} next - New state value.
+		 */
+		const transition = ( next ) => {
+			setState( next );
+			onStateChangeRef.current?.( next );
 		};
-	}, [] );
 
-	// Pre-warm the Whisper model on mount so first voice use is instant.
-	// getWorker() accesses only stable refs and window globals — safe with [].
-	useEffect( () => {
+		/**
+		 * Lazily create (and cache) the Whisper Web Worker.
+		 *
+		 * @return {Worker|null} Worker instance, or null when pluginUrl is unavailable.
+		 */
+		const getWorker = () => {
+			if ( workerRef.current ) {
+				return workerRef.current;
+			}
+
+			const pluginUrl = window.wpAgenticAdmin?.pluginUrl;
+
+			if ( ! pluginUrl ) {
+				return null;
+			}
+
+			const worker = new Worker(
+				pluginUrl + 'build-extensions/whisper-worker.js'
+			);
+
+			worker.addEventListener( 'message', ( e ) => {
+				const { type: msgType, text } = e.data;
+
+				if ( msgType === 'result' ) {
+					onTranscriptRef.current?.( text );
+					transition( 'idle' );
+				} else if ( msgType === 'error' ) {
+					transition( 'idle' );
+				}
+			} );
+
+			workerRef.current = worker;
+			return worker;
+		};
+
+		// Clean up everything on unmount.
+		useEffect( () => {
+			return () => {
+				workerRef.current?.terminate();
+				decodeCtxRef.current?.close();
+				clearTimeout( autoStopTimeoutRef.current );
+				clearInterval( countdownIntervalRef.current );
+			};
+		}, [] );
+
+		// Pre-warm the Whisper model on mount so first voice use is instant.
+		// getWorker() accesses only stable refs and window globals — safe with [].
+		useEffect( () => {
+			if (
+				typeof MediaRecorder === 'undefined' ||
+				! navigator?.mediaDevices?.getUserMedia
+			) {
+				return;
+			}
+			const worker = getWorker();
+			if ( worker ) {
+				worker.postMessage( { type: 'warmup' } );
+			}
+		}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+		// Return null if the browser lacks the required APIs.
 		if (
 			typeof MediaRecorder === 'undefined' ||
 			! navigator?.mediaDevices?.getUserMedia
 		) {
-			return;
-		}
-		const worker = getWorker();
-		if ( worker ) {
-			worker.postMessage( { type: 'warmup' } );
-		}
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
-
-	// Return null if the browser lacks the required APIs.
-	if (
-		typeof MediaRecorder === 'undefined' ||
-		! navigator?.mediaDevices?.getUserMedia
-	) {
-		return null;
-	}
-
-	/**
-	 * Get (or create) the 16 kHz AudioContext used to decode recorded audio.
-	 *
-	 * Reusing the same context avoids hitting browser limits on
-	 * AudioContext instances.
-	 *
-	 * @return {AudioContext} Decode context.
-	 */
-	const getDecodeCtx = () => {
-		if (
-			! decodeCtxRef.current ||
-			decodeCtxRef.current.state === 'closed'
-		) {
-			decodeCtxRef.current = new AudioContext( { sampleRate: 16000 } );
+			return null;
 		}
 
-		return decodeCtxRef.current;
-	};
+		/**
+		 * Get (or create) the 16 kHz AudioContext used to decode recorded audio.
+		 *
+		 * @return {AudioContext} Decode context.
+		 */
+		const getDecodeCtx = () => {
+			if (
+				! decodeCtxRef.current ||
+				decodeCtxRef.current.state === 'closed'
+			) {
+				decodeCtxRef.current = new AudioContext( {
+					sampleRate: 16000,
+				} );
+			}
 
-	const startRecording = async () => {
-		try {
-			const stream = await navigator.mediaDevices.getUserMedia( {
-				audio: true,
-			} );
+			return decodeCtxRef.current;
+		};
 
-			const mimeType = getSupportedMimeType();
-			mimeTypeRef.current = mimeType;
+		const startRecording = async () => {
+			try {
+				const stream = await navigator.mediaDevices.getUserMedia( {
+					audio: true,
+				} );
 
-			const options = mimeType ? { mimeType } : {};
-			const recorder = new MediaRecorder( stream, options );
-			const chunks = [];
+				const mimeType = getSupportedMimeType();
+				mimeTypeRef.current = mimeType;
 
-			recorder.addEventListener( 'dataavailable', ( e ) => {
-				if ( e.data.size > 0 ) {
-					chunks.push( e.data );
-				}
-			} );
+				const options = mimeType ? { mimeType } : {};
+				const recorder = new MediaRecorder( stream, options );
+				const chunks = [];
 
-			recorder.addEventListener( 'stop', async () => {
-				stream.getTracks().forEach( ( track ) => track.stop() );
+				recorder.addEventListener( 'dataavailable', ( e ) => {
+					if ( e.data.size > 0 ) {
+						chunks.push( e.data );
+					}
+				} );
 
-				if ( ! chunks.length ) {
-					transition( 'idle' );
-					return;
-				}
+				recorder.addEventListener( 'stop', async () => {
+					stream.getTracks().forEach( ( track ) => track.stop() );
 
-				try {
-					const blob = new Blob( chunks, {
-						type: mimeTypeRef.current || 'audio/webm',
-					} );
-					const arrayBuffer = await blob.arrayBuffer();
-					const audioCtx = getDecodeCtx();
-					const audioBuffer =
-						await audioCtx.decodeAudioData( arrayBuffer );
-					const pcmData = audioBuffer.getChannelData( 0 );
-					const worker = getWorker();
-
-					if ( ! worker ) {
+					if ( ! chunks.length ) {
 						transition( 'idle' );
 						return;
 					}
 
-					const id = ++requestIdRef.current;
-					// Derive the site language from the <html lang="…"> attribute
-					// that WordPress sets, e.g. "en-US" → "en", "de-DE" → "de".
-					const lang =
-						document.documentElement.lang
-							?.split( '-' )[ 0 ]
-							?.toLowerCase() || 'en';
+					try {
+						const blob = new Blob( chunks, {
+							type: mimeTypeRef.current || 'audio/webm',
+						} );
+						const arrayBuffer = await blob.arrayBuffer();
+						const audioCtx = getDecodeCtx();
+						const audioBuffer =
+							await audioCtx.decodeAudioData( arrayBuffer );
+						const pcmData = audioBuffer.getChannelData( 0 );
+						const worker = getWorker();
 
-					worker.postMessage(
-						{
-							type: 'transcribe',
-							audioData: pcmData,
-							sampleRate: 16000,
-							id,
-							language: lang,
-						},
-						[ pcmData.buffer ]
-					);
-				} catch {
-					onPartialTranscriptRef.current?.( '' );
-					transition( 'idle' );
-				}
-			} );
+						if ( ! worker ) {
+							transition( 'idle' );
+							return;
+						}
 
-			mediaRecorderRef.current = recorder;
-			recorder.start();
-			transition( 'recording' );
+						const id = ++requestIdRef.current;
+						// Derive the site language from the <html lang="…"> attribute
+						// that WordPress sets, e.g. "en-US" → "en", "de-DE" → "de".
+						const lang =
+							document.documentElement.lang
+								?.split( '-' )[ 0 ]
+								?.toLowerCase() || 'en';
 
-			// Tick the countdown every second.
-			countdownIntervalRef.current = setInterval( () => {
-				setRecordingSeconds( ( s ) => s + 1 );
-			}, 1000 );
+						worker.postMessage(
+							{
+								type: 'transcribe',
+								audioData: pcmData,
+								sampleRate: 16000,
+								id,
+								language: lang,
+							},
+							[ pcmData.buffer ]
+						);
+					} catch {
+						onPartialTranscriptRef.current?.( '' );
+						transition( 'idle' );
+					}
+				} );
 
-			// Hard-stop at the Whisper context-window limit.
-			autoStopTimeoutRef.current = setTimeout( () => {
-				clearInterval( countdownIntervalRef.current );
-				setRecordingSeconds( 0 );
-				if ( mediaRecorderRef.current?.state === 'recording' ) {
-					mediaRecorderRef.current.stop();
-					transition( 'transcribing' );
-					onPartialTranscriptRef.current?.(
-						'Transcribing your voice...'
-					);
-				}
-			}, MAX_RECORDING_SECONDS * 1000 );
-		} catch {
-			transition( 'idle' );
+				mediaRecorderRef.current = recorder;
+				recorder.start();
+				transition( 'recording' );
+
+				// Tick the countdown every second.
+				countdownIntervalRef.current = setInterval( () => {
+					setRecordingSeconds( ( s ) => s + 1 );
+				}, 1000 );
+
+				// Hard-stop at the Whisper context-window limit.
+				autoStopTimeoutRef.current = setTimeout( () => {
+					clearInterval( countdownIntervalRef.current );
+					setRecordingSeconds( 0 );
+					if ( mediaRecorderRef.current?.state === 'recording' ) {
+						mediaRecorderRef.current.stop();
+						transition( 'transcribing' );
+						onPartialTranscriptRef.current?.(
+							'Transcribing your voice...'
+						);
+					}
+				}, MAX_RECORDING_SECONDS * 1000 );
+			} catch {
+				transition( 'idle' );
+			}
+		};
+
+		const stopRecording = () => {
+			clearTimeout( autoStopTimeoutRef.current );
+			clearInterval( countdownIntervalRef.current );
+			setRecordingSeconds( 0 );
+			if ( mediaRecorderRef.current?.state === 'recording' ) {
+				mediaRecorderRef.current.stop();
+				transition( 'transcribing' );
+				// Show in-progress text inside the textarea so the user knows
+				// transcription is running. Replaced by the real result on success.
+				onPartialTranscriptRef.current?.(
+					'Transcribing your voice...'
+				);
+			}
+		};
+
+		// Populate the imperative-handle refs now that the real functions exist.
+		startRecordingRef.current = startRecording;
+		stopRecordingRef.current = stopRecording;
+
+		const handleClick = () => {
+			if ( state === 'idle' ) {
+				startRecording();
+			} else if ( state === 'recording' ) {
+				stopRecording();
+			}
+		};
+
+		const isProcessing = state === 'transcribing';
+		const ariaLabel =
+			state === 'recording' ? 'Stop recording' : 'Start voice input';
+		const remaining = MAX_RECORDING_SECONDS - recordingSeconds;
+		const isNearLimit = state === 'recording' && remaining <= 10;
+
+		let content;
+		if ( state === 'recording' ) {
+			content = (
+				<>
+					<StopIcon />
+					<span
+						className="wp-agentic-admin-voice-timer"
+						aria-hidden="true"
+					>
+						{ remaining }s
+					</span>
+				</>
+			);
+		} else if ( state === 'transcribing' ) {
+			content = <ThinkingDots />;
+		} else {
+			content = <MicIcon />;
 		}
-	};
 
-	const stopRecording = () => {
-		clearTimeout( autoStopTimeoutRef.current );
-		clearInterval( countdownIntervalRef.current );
-		setRecordingSeconds( 0 );
-		if ( mediaRecorderRef.current?.state === 'recording' ) {
-			mediaRecorderRef.current.stop();
-			transition( 'transcribing' );
-			// Show in-progress text inside the textarea so the user knows
-			// transcription is running. Replaced by the real result on success.
-			onPartialTranscriptRef.current?.( 'Transcribing your voice...' );
-		}
-	};
-
-	const handleClick = () => {
-		if ( state === 'idle' ) {
-			startRecording();
-		} else if ( state === 'recording' ) {
-			stopRecording();
-		}
-	};
-
-	const isProcessing = state === 'transcribing';
-	const ariaLabel =
-		state === 'recording' ? 'Stop recording' : 'Start voice input';
-	const remaining = MAX_RECORDING_SECONDS - recordingSeconds;
-	const isNearLimit = state === 'recording' && remaining <= 10;
-
-	let content;
-	if ( state === 'recording' ) {
-		content = (
-			<>
-				<StopIcon />
-				<span
-					className="wp-agentic-admin-voice-timer"
-					aria-hidden="true"
-				>
-					{ remaining }s
-				</span>
-			</>
+		return (
+			<button
+				type="button"
+				className={ `wp-agentic-admin-voice-button wp-agentic-admin-voice-button--${ state }${
+					isNearLimit ? ' wp-agentic-admin-voice-button--warning' : ''
+				}` }
+				onClick={ handleClick }
+				disabled={ disabled || isProcessing }
+				aria-label={ ariaLabel }
+			>
+				{ content }
+			</button>
 		);
-	} else if ( state === 'transcribing' ) {
-		content = <ThinkingDots />;
-	} else {
-		content = <MicIcon />;
 	}
+);
 
-	return (
-		<button
-			type="button"
-			className={ `wp-agentic-admin-voice-button wp-agentic-admin-voice-button--${ state }${
-				isNearLimit ? ' wp-agentic-admin-voice-button--warning' : ''
-			}` }
-			onClick={ handleClick }
-			disabled={ disabled || isProcessing }
-			aria-label={ ariaLabel }
-		>
-			{ content }
-		</button>
-	);
-};
+VoiceButton.displayName = 'VoiceButton';
 
 export default VoiceButton;

--- a/src/extensions/services/__tests__/external-engine.test.js
+++ b/src/extensions/services/__tests__/external-engine.test.js
@@ -22,7 +22,7 @@ describe( 'ExternalEngine', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-		
+
 		// Mock window.wpAgenticAdmin
 		global.window = {
 			wpAgenticAdmin: {
@@ -76,7 +76,11 @@ describe( 'ExternalEngine', () => {
 	} );
 
 	it( 'should handle gpt-5 models correctly', async () => {
-		const gpt5Engine = new ExternalEngine( endpointUrl, 'gpt-5.1-preview', apiKey );
+		const gpt5Engine = new ExternalEngine(
+			endpointUrl,
+			'gpt-5.1-preview',
+			apiKey
+		);
 		await gpt5Engine.chat.completions.create( {
 			messages: [ { role: 'user', content: 'hello' } ],
 			max_tokens: 200,

--- a/src/extensions/services/__tests__/message-router.test.js
+++ b/src/extensions/services/__tests__/message-router.test.js
@@ -176,9 +176,7 @@ describe( 'MessageRouter', () => {
 
 		it( 'should route knowledge questions about tool topics to conversational', () => {
 			// Has keyword "transient" but is a knowledge question
-			expect( route( 'what is a transient?' ).type ).toBe(
-				'react'
-			);
+			expect( route( 'what is a transient?' ).type ).toBe( 'react' );
 			expect( route( 'explain what transients are' ).type ).toBe(
 				'react'
 			);
@@ -188,12 +186,8 @@ describe( 'MessageRouter', () => {
 			expect(
 				route( 'explain the difference between posts and pages' ).type
 			).toBe( 'react' );
-			expect( route( 'what is WordPress?' ).type ).toBe(
-				'react'
-			);
-			expect( route( 'tell me about hooks' ).type ).toBe(
-				'react'
-			);
+			expect( route( 'what is WordPress?' ).type ).toBe( 'react' );
+			expect( route( 'tell me about hooks' ).type ).toBe( 'react' );
 		} );
 
 		it( 'should route "how many" questions with keywords to ReAct', () => {
@@ -282,9 +276,7 @@ describe( 'MessageRouter', () => {
 		} );
 
 		it( '"what is a transient?" → conversational', () => {
-			expect( route( 'what is a transient?' ).type ).toBe(
-				'react'
-			);
+			expect( route( 'what is a transient?' ).type ).toBe( 'react' );
 		} );
 
 		it( '"why is my site so slow?" → ReAct (with thinking)', () => {

--- a/src/extensions/services/chat-orchestrator.js
+++ b/src/extensions/services/chat-orchestrator.js
@@ -340,11 +340,7 @@ class ChatOrchestrator {
 			);
 		} catch ( error ) {
 			log.error( 'Web search pre-step failed:', error );
-			this.callbacks.onToolEnd(
-				toolId,
-				{ error: error.message },
-				false
-			);
+			this.callbacks.onToolEnd( toolId, { error: error.message }, false );
 			this.session.addToolResult(
 				toolId,
 				{ error: error.message },

--- a/src/extensions/services/chat-session.js
+++ b/src/extensions/services/chat-session.js
@@ -283,8 +283,7 @@ class ChatSession {
 		//    leading to stale answers (issue #158)
 		const relevantMessages = this.messages.filter(
 			( m ) =>
-				m.type === MessageType.USER ||
-				m.type === MessageType.ASSISTANT
+				m.type === MessageType.USER || m.type === MessageType.ASSISTANT
 		);
 
 		const history = relevantMessages.map( ( m ) => ( {

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -317,6 +317,22 @@ class ReactAgent {
 
 					log.info( `LLM requested tool: ${ toolName }`, toolArgs );
 
+					// Guard: small models occasionally omit the tool name entirely.
+					if ( ! toolName ) {
+						log.warn(
+							'LLM returned tool_call with no tool name — skipping iteration'
+						);
+						observations.push( {
+							tool: 'unknown',
+							args: toolArgs,
+							result: {
+								success: false,
+								error: 'No tool name provided by model.',
+							},
+						} );
+						continue;
+					}
+
 					// Detect repeated tool calls (same tool twice in a row)
 					if (
 						toolsUsed.length > 0 &&
@@ -732,6 +748,15 @@ class ReactAgent {
 	 * @return {Promise<Object>} Tool result
 	 */
 	async executeTool( toolId, args, userMessage ) {
+		// Guard against missing tool name (model returned tool_call with no tool field).
+		if ( ! toolId ) {
+			log.warn( 'executeTool called with undefined toolId' );
+			return {
+				success: false,
+				error: 'No tool name provided by model.',
+			};
+		}
+
 		// Enforce bundle filter — block tools outside the active bundle
 		if (
 			this.currentToolFilter &&

--- a/src/extensions/services/whisper-worker.js
+++ b/src/extensions/services/whisper-worker.js
@@ -1,0 +1,162 @@
+/**
+ * Whisper Web Worker
+ *
+ * Runs speech-to-text transcription inside a Web Worker using
+ * the @huggingface/transformers library and Xenova/whisper-tiny model (~40 MB ONNX).
+ *
+ * The model is downloaded from HuggingFace Hub on first use and cached in
+ * the browser's Cache Storage — subsequent uses are instant.
+ *
+ * Message protocol:
+ *   In:  { type: 'transcribe', audioData: Float32Array, sampleRate: number, id: number, language: string }
+ *        { type: 'warmup' }
+ *   Out: { type: 'result',  text: string, id: number }
+ *        { type: 'ready' }
+ *        { type: 'error',  message: string, id: number }
+ *
+ * @since 0.10.0
+ */
+
+import { pipeline } from '@huggingface/transformers';
+
+/** @type {Function|null} Cached pipeline instance. */
+let transcriber = null;
+
+/**
+ * Map ISO 639-1 codes to the full language names Whisper expects.
+ * Falls back to 'english' for any unmapped code.
+ *
+ * @type {Object.<string,string>}
+ */
+const ISO_TO_WHISPER = {
+	en: 'english',
+	de: 'german',
+	fr: 'french',
+	es: 'spanish',
+	it: 'italian',
+	pt: 'portuguese',
+	nl: 'dutch',
+	pl: 'polish',
+	ru: 'russian',
+	ja: 'japanese',
+	ko: 'korean',
+	zh: 'chinese',
+	ar: 'arabic',
+	tr: 'turkish',
+	sv: 'swedish',
+	da: 'danish',
+	fi: 'finnish',
+	nb: 'norwegian',
+	nn: 'norwegian',
+	cs: 'czech',
+	sk: 'slovak',
+	hu: 'hungarian',
+	ro: 'romanian',
+	uk: 'ukrainian',
+};
+
+/**
+ * Resolve a language value (ISO code or full name) to the full name
+ * that Whisper's forced-decoder token expects.
+ *
+ * @param {string} lang - ISO 639-1 code or full Whisper language name.
+ * @return {string} Full Whisper language name, e.g. 'english'.
+ */
+function resolveLanguage( lang ) {
+	if ( ! lang ) {
+		return 'english';
+	}
+	// Already a full name (e.g. passed explicitly as 'english').
+	if ( lang.length > 3 ) {
+		return lang.toLowerCase();
+	}
+	return ISO_TO_WHISPER[ lang.toLowerCase() ] ?? 'english';
+}
+
+/**
+ * Lazily initialise the Whisper pipeline.
+ *
+ * Uses WASM (not WebGPU) to avoid q8 precision issues observed on some
+ * GPU drivers. WASM is reliable and fast enough for short voice clips.
+ *
+ * @return {Promise<Function>} Ready-to-call ASR pipeline.
+ */
+async function getTranscriber() {
+	if ( transcriber ) {
+		return transcriber;
+	}
+
+	transcriber = await pipeline(
+		'automatic-speech-recognition',
+		'Xenova/whisper-tiny',
+		{ device: 'wasm', dtype: 'q8' }
+	);
+
+	return transcriber;
+}
+
+self.addEventListener( 'message', async ( event ) => {
+	const { type, audioData, sampleRate, id, language } = event.data;
+
+	// eslint-disable-next-line no-console
+	console.log( '[whisper-worker] message received:', type );
+
+	// Pre-warm: load the model without processing any audio.
+	if ( type === 'warmup' ) {
+		try {
+			await getTranscriber();
+			self.postMessage( { type: 'ready' } );
+			// eslint-disable-next-line no-console
+			console.log( '[whisper-worker] warmup complete' );
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( '[whisper-worker] warmup error:', err );
+		}
+		return;
+	}
+
+	if ( type !== 'transcribe' && type !== 'transcribe-partial' ) {
+		return;
+	}
+
+	try {
+		const model = await getTranscriber();
+		const resolvedLang = resolveLanguage( language );
+
+		// eslint-disable-next-line no-console
+		console.log( '[whisper-worker] transcribing', {
+			lang: resolvedLang,
+			durationSec: ( audioData.length / ( sampleRate ?? 16000 ) ).toFixed(
+				1
+			),
+			maxAmplitude: Math.max(
+				...Array.from( audioData.slice( 0, 4000 ) ).map( Math.abs )
+			).toFixed( 4 ),
+		} );
+
+		const result = await model( audioData, {
+			sampling_rate: sampleRate ?? 16000,
+			// Force transcription (not translation) in the target language.
+			task: 'transcribe',
+			language: resolvedLang,
+		} );
+
+		// eslint-disable-next-line no-console
+		console.log( '[whisper-worker] raw result:', JSON.stringify( result ) );
+
+		const outType =
+			type === 'transcribe-partial' ? 'partial-result' : 'result';
+
+		self.postMessage( {
+			type: outType,
+			text: result.text?.trim() ?? '',
+			id,
+		} );
+	} catch ( err ) {
+		self.postMessage( {
+			type: 'error',
+			message: err.message,
+			id,
+		} );
+	}
+} );

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -318,6 +318,19 @@
 		opacity: 0.6;
 	}
 
+	// Recording state — pulsing glow signals the mic is active
+	&--recording {
+		border-color: rgba(214, 54, 56, 0.4);
+		background: rgba(214, 54, 56, 0.025);
+		animation: wp-agentic-input-recording-glow 1.8s ease-in-out infinite;
+
+		// Keep the red glow even when the textarea has focus
+		&:focus-within {
+			border-color: rgba(214, 54, 56, 0.5);
+			box-shadow: none; // animation handles the shadow
+		}
+	}
+
 	.wp-agentic-admin-input {
 		display: block;
 		width: 100%;
@@ -676,6 +689,17 @@
 	line-height: 1;
 	color: inherit;
 	pointer-events: none;
+}
+
+@keyframes wp-agentic-input-recording-glow {
+	0%,
+	100% {
+		box-shadow: 0 0 0 2px rgba(214, 54, 56, 0.3);
+	}
+
+	50% {
+		box-shadow: 0 0 0 2px rgba(214, 54, 56, 0.08);
+	}
 }
 
 @keyframes wp-agentic-voice-pulse {

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -375,6 +375,93 @@
 	}
 }
 
+// Textarea container — needed to anchor the transcribing overlay
+.wp-agentic-admin-textarea-container {
+	position: relative;
+}
+
+// Transcribing overlay — appears over textarea while Whisper runs
+.wp-agentic-admin-transcribing-overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	background: rgba(255, 255, 255, 0.93);
+	backdrop-filter: blur(3px);
+	border-radius: 8px 8px 0 0;
+	animation: wp-agentic-overlay-in 0.18s ease;
+	z-index: 1;
+}
+
+@keyframes wp-agentic-overlay-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+// Equaliser-style wave bars
+.wp-agentic-admin-transcribing-wave {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	height: 28px;
+
+	span {
+		display: block;
+		width: 4px;
+		height: 6px;
+		background: #2271b1;
+		border-radius: 2px;
+		animation: wp-agentic-wave-bar 1.1s ease-in-out infinite;
+
+		&:nth-child(1) {
+			animation-delay: 0s;
+		}
+
+		&:nth-child(2) {
+			animation-delay: 0.15s;
+		}
+
+		&:nth-child(3) {
+			animation-delay: 0.3s;
+		}
+
+		&:nth-child(4) {
+			animation-delay: 0.45s;
+		}
+
+		&:nth-child(5) {
+			animation-delay: 0.6s;
+		}
+	}
+}
+
+@keyframes wp-agentic-wave-bar {
+	0%,
+	100% {
+		height: 4px;
+		opacity: 0.45;
+	}
+
+	50% {
+		height: 22px;
+		opacity: 1;
+	}
+}
+
+.wp-agentic-admin-transcribing-label {
+	font-size: 12px;
+	color: #50575e;
+	letter-spacing: 0.02em;
+}
+
 // Web search toggle
 .wp-agentic-admin-websearch-toggle {
 	display: flex;
@@ -512,6 +599,130 @@
 		opacity: 0;
 		transform: scale(0.8);
 		pointer-events: none;
+	}
+}
+
+// Voice button (microphone) — speech-to-text input
+.wp-agentic-admin-voice-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	position: relative; // Anchor for recording tooltip
+	width: 36px;
+	height: 36px;
+	border: none;
+	background: none;
+	color: #50575e;
+	cursor: pointer;
+	border-radius: 50%; // Circular like Gemini
+	padding: 0;
+	transition:
+		color 0.15s ease,
+		background 0.15s ease;
+
+	&:hover {
+		background: #f0f0f1;
+		color: #1d2327;
+	}
+
+	// ── Recording state ──────────────────────────────────────────────
+	&--recording {
+		flex-direction: column;
+		gap: 2px;
+		color: #d63638;
+		background: #fce8e8;
+		animation: wp-agentic-voice-pulse 2s ease-in-out infinite;
+
+		// Shrink the stop icon slightly to leave room for the timer
+		svg {
+			width: 16px;
+			height: 16px;
+		}
+
+		&:hover {
+			background: #f5c0c1;
+			animation-play-state: paused;
+		}
+	}
+
+	// ── Warning state (≤ 10 s remaining) ─────────────────────────────
+	&--warning {
+		background: #f5c0c1;
+		animation-duration: 0.7s;
+
+		.wp-agentic-admin-voice-timer {
+			color: #7f1d1d;
+		}
+	}
+
+	// ── Transcribing state ───────────────────────────────────────────
+	&--transcribing {
+		color: #8c8f94;
+		cursor: default;
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		pointer-events: none;
+	}
+}
+
+// ── Countdown timer shown inline inside the recording button ─────────
+.wp-agentic-admin-voice-timer {
+	font-size: 9px;
+	font-weight: 700;
+	line-height: 1;
+	color: inherit;
+	pointer-events: none;
+}
+
+@keyframes wp-agentic-voice-pulse {
+	0%,
+	100% {
+		background: #fce8e8;
+	}
+
+	50% {
+		background: #f8d5d5;
+	}
+}
+
+// ── Thinking dots (CSS-animated, shown during transcription) ─────────
+.wp-agentic-admin-voice-dots {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+
+	span {
+		width: 5px;
+		height: 5px;
+		border-radius: 50%;
+		background: currentColor;
+		animation: wp-agentic-voice-dot 1.4s ease-in-out infinite;
+
+		&:nth-child(2) {
+			animation-delay: 0.2s;
+		}
+
+		&:nth-child(3) {
+			animation-delay: 0.4s;
+		}
+	}
+}
+
+@keyframes wp-agentic-voice-dot {
+	0%,
+	80%,
+	100% {
+		transform: scale(0.4);
+		opacity: 0.4;
+	}
+
+	40% {
+		transform: scale(1);
+		opacity: 1;
 	}
 }
 

--- a/tests/abilities/e2e-runner.js
+++ b/tests/abilities/e2e-runner.js
@@ -38,22 +38,35 @@ const dumpMessages = args.includes( '--dump-messages' );
 const noThink = ! args.includes( '--think' );
 
 if ( fileIndex === -1 || ! args[ fileIndex + 1 ] ) {
-	console.error( 'Usage: node e2e-runner.js --file <test-file.js> [options]' );
+	console.error(
+		'Usage: node e2e-runner.js --file <test-file.js> [options]'
+	);
 	console.error( '' );
 	console.error( 'Options:' );
 	console.error( '  --file <path>       Path to test file (required)' );
 	console.error( '  --model <id>        Ollama model (default: qwen3:1.7b)' );
 	console.error( '  --think             Enable thinking (default: off)' );
-	console.error( '  --wp-url <url>      WordPress URL (default: https://wp-agentic-admin.local)' );
+	console.error(
+		'  --wp-url <url>      WordPress URL (default: https://wp-agentic-admin.local)'
+	);
 	console.error( '  --wp-user <user>    WP application password username' );
 	console.error( '  --wp-pass <pass>    WP application password' );
-	console.error( '  --verbose           Show full LLM responses and API results' );
+	console.error(
+		'  --verbose           Show full LLM responses and API results'
+	);
 	process.exit( 1 );
 }
 
 const testFilePath = path.resolve( args[ fileIndex + 1 ] );
-const modelId = modelIndex !== -1 && args[ modelIndex + 1 ] ? args[ modelIndex + 1 ] : 'qwen3:1.7b';
-const wpUrl = ( wpUrlIndex !== -1 && args[ wpUrlIndex + 1 ] ? args[ wpUrlIndex + 1 ] : 'https://wp-agentic-admin.local' ).replace( /\/$/, '' );
+const modelId =
+	modelIndex !== -1 && args[ modelIndex + 1 ]
+		? args[ modelIndex + 1 ]
+		: 'qwen3:1.7b';
+const wpUrl = (
+	wpUrlIndex !== -1 && args[ wpUrlIndex + 1 ]
+		? args[ wpUrlIndex + 1 ]
+		: 'https://wp-agentic-admin.local'
+).replace( /\/$/, '' );
 const wpUser = wpUserIndex !== -1 ? args[ wpUserIndex + 1 ] : '';
 // Application passwords have spaces — collect all args until the next flag
 let wpPass = '';
@@ -103,7 +116,9 @@ function isOllamaInstalled() {
 
 function installOllama() {
 	if ( process.platform !== 'darwin' ) {
-		console.error( 'Auto-install only supported on macOS. Install Ollama manually.' );
+		console.error(
+			'Auto-install only supported on macOS. Install Ollama manually.'
+		);
 		process.exit( 1 );
 	}
 	try {
@@ -126,7 +141,10 @@ async function isOllamaRunning() {
 
 function startOllamaServe() {
 	console.log( '  Starting Ollama server...' );
-	const child = spawn( 'ollama', [ 'serve' ], { stdio: 'ignore', detached: true } );
+	const child = spawn( 'ollama', [ 'serve' ], {
+		stdio: 'ignore',
+		detached: true,
+	} );
 	child.unref();
 }
 
@@ -143,8 +161,15 @@ async function waitForOllama( maxWaitMs = 15000 ) {
 
 async function isModelPulled( model ) {
 	try {
-		const data = await ( await fetch( `${ OLLAMA_BASE }/api/tags` ) ).json();
-		return ( data.models || [] ).some( ( m ) => m.name === model || m.name === `${ model }:latest` || m.name.startsWith( model ) );
+		const data = await (
+			await fetch( `${ OLLAMA_BASE }/api/tags` )
+		).json();
+		return ( data.models || [] ).some(
+			( m ) =>
+				m.name === model ||
+				m.name === `${ model }:latest` ||
+				m.name.startsWith( model )
+		);
 	} catch {
 		return false;
 	}
@@ -153,8 +178,12 @@ async function isModelPulled( model ) {
 async function pullModel( model ) {
 	console.log( `  Pulling model ${ model }...` );
 	return new Promise( ( resolve, reject ) => {
-		const child = spawn( 'ollama', [ 'pull', model ], { stdio: 'inherit' } );
-		child.on( 'close', ( code ) => code === 0 ? resolve() : reject( new Error( `exit ${ code }` ) ) );
+		const child = spawn( 'ollama', [ 'pull', model ], {
+			stdio: 'inherit',
+		} );
+		child.on( 'close', ( code ) =>
+			code === 0 ? resolve() : reject( new Error( `exit ${ code }` ) )
+		);
 	} );
 }
 
@@ -185,15 +214,22 @@ async function chatCompletion( messages ) {
 // ---------------------------------------------------------------------------
 
 async function wpExecuteTool( toolId, toolArgs = {} ) {
-	const parts = toolId.includes( '/' ) ? toolId.split( '/' ) : [ 'wp-agentic-admin', toolId ];
+	const parts = toolId.includes( '/' )
+		? toolId.split( '/' )
+		: [ 'wp-agentic-admin', toolId ];
 	const baseEndpoint = `${ wpUrl }/wp-json/wp-abilities/v1/abilities/${ parts[ 0 ] }/${ parts[ 1 ] }/run`;
 	const headers = {};
 
 	if ( wpUser && wpPass ) {
-		headers.Authorization = 'Basic ' + Buffer.from( `${ wpUser }:${ wpPass }` ).toString( 'base64' );
+		headers.Authorization =
+			'Basic ' +
+			Buffer.from( `${ wpUser }:${ wpPass }` ).toString( 'base64' );
 	}
 
-	const hasArgs = toolArgs && typeof toolArgs === 'object' && Object.keys( toolArgs ).length > 0;
+	const hasArgs =
+		toolArgs &&
+		typeof toolArgs === 'object' &&
+		Object.keys( toolArgs ).length > 0;
 
 	// Build query string for GET requests (mirrors abilities-api.js buildInputQueryString)
 	function buildQueryString( input ) {
@@ -206,7 +242,9 @@ async function wpExecuteTool( toolId, toolArgs = {} ) {
 
 	// Try GET first (with args as query params), fall back to POST.
 	// This mirrors the browser's logic: read-only abilities use GET.
-	const getEndpoint = hasArgs ? baseEndpoint + buildQueryString( toolArgs ) : baseEndpoint;
+	const getEndpoint = hasArgs
+		? baseEndpoint + buildQueryString( toolArgs )
+		: baseEndpoint;
 
 	let res = await fetch( getEndpoint, { method: 'GET', headers } );
 
@@ -222,7 +260,9 @@ async function wpExecuteTool( toolId, toolArgs = {} ) {
 
 	if ( ! res.ok ) {
 		const text = await res.text();
-		throw new Error( `WP API ${ res.status }: ${ text.substring( 0, 200 ) }` );
+		throw new Error(
+			`WP API ${ res.status }: ${ text.substring( 0, 200 ) }`
+		);
 	}
 	return await res.json();
 }
@@ -265,11 +305,13 @@ User: "what environment is this?"
 {"action": "tool_call", "tool": "core/get-environment-info", "args": {}}
 
 User: "what is a transient?"
-{"action": "final_answer", "content": "A transient is temporary cached data in WordPress..."}${ REACT_CONFIG.disableThinking ? '\n\n/nothink' : '' }`;
+{"action": "final_answer", "content": "A transient is temporary cached data in WordPress..."}${
+		REACT_CONFIG.disableThinking ? '\n\n/nothink' : ''
+	}`;
 }
 
 function buildConversationalPrompt() {
-	return 'You are a helpful WordPress assistant embedded in the wp-admin dashboard. Answer questions about WordPress clearly and concisely. If you don\'t know something, say so honestly.';
+	return "You are a helpful WordPress assistant embedded in the wp-admin dashboard. Answer questions about WordPress clearly and concisely. If you don't know something, say so honestly.";
 }
 
 // ---------------------------------------------------------------------------
@@ -362,7 +404,9 @@ function parseActionFromResponse( content ) {
 				braceCount--;
 				if ( braceCount === 0 ) {
 					try {
-						const action = JSON.parse( jsonText.substring( firstBrace, i + 1 ) );
+						const action = JSON.parse(
+							jsonText.substring( firstBrace, i + 1 )
+						);
 						if ( action.action ) {
 							return action;
 						}
@@ -392,7 +436,8 @@ function buildToolResultMessage( toolResult, truncatedResult ) {
 	} else {
 		message = `Tool result: ${ truncatedResult }`;
 	}
-	const suffix = '\n\nRemember: Respond with ONLY a JSON object. Either call another tool or provide final_answer.';
+	const suffix =
+		'\n\nRemember: Respond with ONLY a JSON object. Either call another tool or provide final_answer.';
 	const nothink = REACT_CONFIG.disableThinkingAfterTool ? '\n\n/nothink' : '';
 	return message + suffix + nothink;
 }
@@ -402,15 +447,39 @@ function buildToolResultMessage( toolResult, truncatedResult ) {
 // ---------------------------------------------------------------------------
 
 const ACTION_WORDS = [
-	'list', 'show', 'check', 'flush', 'clear', 'purge', 'optimize',
-	'activate', 'deactivate', 'enable', 'disable', 'turn on', 'turn off',
-	'read', 'run', 'delete', 'clean', 'fix', 'refresh', 'regenerate',
-	'reset', 'view',
+	'list',
+	'show',
+	'check',
+	'flush',
+	'clear',
+	'purge',
+	'optimize',
+	'activate',
+	'deactivate',
+	'enable',
+	'disable',
+	'turn on',
+	'turn off',
+	'read',
+	'run',
+	'delete',
+	'clean',
+	'fix',
+	'refresh',
+	'regenerate',
+	'reset',
+	'view',
 ];
 
 const QUESTION_WORDS = [
-	'what is', 'what are', 'what does', 'explain', 'define',
-	'difference between', 'tell me about', 'meaning of',
+	'what is',
+	'what are',
+	'what does',
+	'explain',
+	'define',
+	'difference between',
+	'tell me about',
+	'meaning of',
 ];
 
 function routeMessage( message, abilities ) {
@@ -456,7 +525,11 @@ function routeMessage( message, abilities ) {
 // ReAct loop — copied from react-agent.js executeWithPromptBased()
 // ---------------------------------------------------------------------------
 
-async function executeReactLoop( userMessage, conversationHistory, systemPrompt ) {
+async function executeReactLoop(
+	userMessage,
+	conversationHistory,
+	systemPrompt
+) {
 	const toolsUsed = [];
 	const observations = [];
 	let iteration = 0;
@@ -476,12 +549,16 @@ async function executeReactLoop( userMessage, conversationHistory, systemPrompt 
 
 		// Dump full messages array for debugging
 		if ( dumpMessages ) {
-			console.log( `\n      ── Messages sent to LLM (iteration ${ iteration }) ──` );
+			console.log(
+				`\n      ── Messages sent to LLM (iteration ${ iteration }) ──`
+			);
 			for ( let mi = 0; mi < messages.length; mi++ ) {
 				const m = messages[ mi ];
-				const preview = m.content.length > 200
-					? m.content.substring( 0, 200 ) + `... (${ m.content.length } chars)`
-					: m.content;
+				const preview =
+					m.content.length > 200
+						? m.content.substring( 0, 200 ) +
+						  `... (${ m.content.length } chars)`
+						: m.content;
 				console.log( `      [${ mi }] ${ m.role }: ${ preview }` );
 			}
 			console.log( `      ── End messages ──\n` );
@@ -490,25 +567,54 @@ async function executeReactLoop( userMessage, conversationHistory, systemPrompt 
 		const response = await chatCompletion( messages );
 
 		if ( verbose ) {
-			const clean = response.replace( /<think>[\s\S]*?<\/think>\s*/g, '' ).trim();
-			console.log( `      LLM: ${ clean.length > 120 ? clean.substring( 0, 120 ) + '...' : clean }` );
+			const clean = response
+				.replace( /<think>[\s\S]*?<\/think>\s*/g, '' )
+				.trim();
+			console.log(
+				`      LLM: ${
+					clean.length > 120
+						? clean.substring( 0, 120 ) + '...'
+						: clean
+				}`
+			);
 		}
 
 		// Strip think blocks for parsing
-		const content = response.replace( /<think>[\s\S]*?<\/think>\s*/g, '' ).trim();
+		const content = response
+			.replace( /<think>[\s\S]*?<\/think>\s*/g, '' )
+			.trim();
 		const action = parseActionFromResponse( content );
 
 		// No valid JSON → treat as final answer
 		if ( ! action ) {
 			if ( toolsUsed.length > 0 ) {
-				return { success: true, finalAnswer: content, iterations: iteration, toolsUsed, observations };
+				return {
+					success: true,
+					finalAnswer: content,
+					iterations: iteration,
+					toolsUsed,
+					observations,
+				};
 			}
-			return { success: false, finalAnswer: content || 'Failed to parse response', iterations: iteration, toolsUsed, observations };
+			return {
+				success: false,
+				finalAnswer: content || 'Failed to parse response',
+				iterations: iteration,
+				toolsUsed,
+				observations,
+			};
 		}
 
 		// Final answer
 		if ( action.action === 'final_answer' ) {
-			return { success: true, finalAnswer: action.content || action.answer || 'Task completed.', iterations: iteration, toolsUsed, observations };
+			return {
+				success: true,
+				finalAnswer:
+					action.content || action.answer || 'Task completed.',
+				iterations: iteration,
+				toolsUsed,
+				observations,
+			};
 		}
 
 		// Tool call
@@ -517,8 +623,18 @@ async function executeReactLoop( userMessage, conversationHistory, systemPrompt 
 			const toolArgs = action.args || {};
 
 			// Detect repeated tool call
-			if ( toolsUsed.length > 0 && toolsUsed[ toolsUsed.length - 1 ] === toolName ) {
-				return { success: true, finalAnswer: 'Data gathered but stopped due to repeated tool call.', iterations: iteration, toolsUsed, observations };
+			if (
+				toolsUsed.length > 0 &&
+				toolsUsed[ toolsUsed.length - 1 ] === toolName
+			) {
+				return {
+					success: true,
+					finalAnswer:
+						'Data gathered but stopped due to repeated tool call.',
+					iterations: iteration,
+					toolsUsed,
+					observations,
+				};
 			}
 
 			// Execute via WP REST API
@@ -527,35 +643,66 @@ async function executeReactLoop( userMessage, conversationHistory, systemPrompt 
 				toolResult = await wpExecuteTool( toolName, toolArgs );
 				if ( verbose ) {
 					const preview = JSON.stringify( toolResult );
-					console.log( `      Tool ${ toolName }: ${ preview.length > 100 ? preview.substring( 0, 100 ) + '...' : preview }` );
+					console.log(
+						`      Tool ${ toolName }: ${
+							preview.length > 100
+								? preview.substring( 0, 100 ) + '...'
+								: preview
+						}`
+					);
 				}
 			} catch ( err ) {
 				toolResult = { success: false, error: err.message };
 				if ( verbose ) {
-					console.log( `      Tool ${ toolName } ERROR: ${ err.message }` );
+					console.log(
+						`      Tool ${ toolName } ERROR: ${ err.message }`
+					);
 				}
 			}
 
 			toolsUsed.push( toolName );
-			observations.push( { tool: toolName, args: toolArgs, result: toolResult } );
+			observations.push( {
+				tool: toolName,
+				args: toolArgs,
+				result: toolResult,
+			} );
 
 			// Truncate and feed result back to LLM
 			const resultStr = JSON.stringify( toolResult );
-			const truncated = resultStr.length > REACT_CONFIG.maxToolResultLength
-				? resultStr.substring( 0, REACT_CONFIG.maxToolResultLength ) + '...[truncated]'
-				: resultStr;
+			const truncated =
+				resultStr.length > REACT_CONFIG.maxToolResultLength
+					? resultStr.substring(
+							0,
+							REACT_CONFIG.maxToolResultLength
+					  ) + '...[truncated]'
+					: resultStr;
 
 			messages.push( { role: 'assistant', content } );
-			messages.push( { role: 'user', content: buildToolResultMessage( toolResult, truncated ) } );
+			messages.push( {
+				role: 'user',
+				content: buildToolResultMessage( toolResult, truncated ),
+			} );
 
 			continue;
 		}
 
 		// Unknown action
-		return { success: false, finalAnswer: 'Unknown action type', iterations: iteration, toolsUsed, observations };
+		return {
+			success: false,
+			finalAnswer: 'Unknown action type',
+			iterations: iteration,
+			toolsUsed,
+			observations,
+		};
 	}
 
-	return { success: false, finalAnswer: 'Max iterations reached', iterations: iteration, toolsUsed, observations };
+	return {
+		success: false,
+		finalAnswer: 'Max iterations reached',
+		iterations: iteration,
+		toolsUsed,
+		observations,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -573,10 +720,20 @@ async function executeConversational( userMessage, conversationHistory ) {
 	const clean = response.replace( /<think>[\s\S]*?<\/think>\s*/g, '' ).trim();
 
 	if ( verbose ) {
-		console.log( `      LLM (conv): ${ clean.length > 120 ? clean.substring( 0, 120 ) + '...' : clean }` );
+		console.log(
+			`      LLM (conv): ${
+				clean.length > 120 ? clean.substring( 0, 120 ) + '...' : clean
+			}`
+		);
 	}
 
-	return { success: true, finalAnswer: clean, iterations: 1, toolsUsed: [], observations: [] };
+	return {
+		success: true,
+		finalAnswer: clean,
+		iterations: 1,
+		toolsUsed: [],
+		observations: [],
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -585,7 +742,8 @@ async function executeConversational( userMessage, conversationHistory ) {
 
 function formatToolResultForHistory( toolId, result ) {
 	const str = JSON.stringify( result, null, 2 );
-	const truncated = str.length > 1000 ? str.substring( 0, 1000 ) + '...(truncated)' : str;
+	const truncated =
+		str.length > 1000 ? str.substring( 0, 1000 ) + '...(truncated)' : str;
 	return `[Tool Result from ${ toolId }]:\n${ truncated }`;
 }
 
@@ -595,30 +753,51 @@ function formatToolResultForHistory( toolId, result ) {
 
 function evaluateTurn( turn, result ) {
 	// Normalize tool names
-	const toolsUsed = result.toolsUsed.map( ( t ) => t.includes( '/' ) ? t : `wp-agentic-admin/${ t }` );
+	const toolsUsed = result.toolsUsed.map( ( t ) =>
+		t.includes( '/' ) ? t : `wp-agentic-admin/${ t }`
+	);
 	const firstTool = toolsUsed[ 0 ] || null;
 
 	// Check tool expectation
 	if ( turn.expectTool !== undefined ) {
 		if ( turn.expectTool === null ) {
 			if ( firstTool !== null ) {
-				return { passed: false, reason: `Expected no tool, got: ${ firstTool }` };
+				return {
+					passed: false,
+					reason: `Expected no tool, got: ${ firstTool }`,
+				};
 			}
 		} else if ( Array.isArray( turn.expectTool ) ) {
 			if ( ! turn.expectTool.includes( firstTool ) ) {
-				return { passed: false, reason: `Expected [${ turn.expectTool.join( '|' ) }], got: ${ firstTool || '(none)' }` };
+				return {
+					passed: false,
+					reason: `Expected [${ turn.expectTool.join(
+						'|'
+					) }], got: ${ firstTool || '(none)' }`,
+				};
 			}
 		} else if ( firstTool !== turn.expectTool ) {
-			return { passed: false, reason: `Expected ${ turn.expectTool }, got: ${ firstTool || '(none)' }` };
+			return {
+				passed: false,
+				reason: `Expected ${ turn.expectTool }, got: ${
+					firstTool || '(none)'
+				}`,
+			};
 		}
 	}
 
 	// Check answer pattern
 	if ( turn.expectAnswer ) {
-		const pattern = turn.expectAnswer instanceof RegExp ? turn.expectAnswer : new RegExp( turn.expectAnswer, 'i' );
+		const pattern =
+			turn.expectAnswer instanceof RegExp
+				? turn.expectAnswer
+				: new RegExp( turn.expectAnswer, 'i' );
 		if ( ! pattern.test( result.finalAnswer || '' ) ) {
 			const preview = ( result.finalAnswer || '' ).substring( 0, 80 );
-			return { passed: false, reason: `Answer didn't match ${ pattern }: "${ preview }..."` };
+			return {
+				passed: false,
+				reason: `Answer didn't match ${ pattern }: "${ preview }..."`,
+			};
 		}
 	}
 
@@ -660,13 +839,20 @@ function evaluateTurn( turn, result ) {
 	try {
 		const headers = {};
 		if ( wpUser && wpPass ) {
-			headers.Authorization = 'Basic ' + Buffer.from( `${ wpUser }:${ wpPass }` ).toString( 'base64' );
+			headers.Authorization =
+				'Basic ' +
+				Buffer.from( `${ wpUser }:${ wpPass }` ).toString( 'base64' );
 		}
-		const wpTest = await fetch( `${ wpUrl }/wp-json/wp-abilities/v1/abilities`, { headers } );
+		const wpTest = await fetch(
+			`${ wpUrl }/wp-json/wp-abilities/v1/abilities`,
+			{ headers }
+		);
 		if ( wpTest.ok ) {
 			console.log( `  ✓ WP API connected (${ wpUrl })` );
 		} else {
-			console.error( `  ✗ WP API returned ${ wpTest.status }. Check --wp-url, --wp-user, --wp-pass` );
+			console.error(
+				`  ✗ WP API returned ${ wpTest.status }. Check --wp-url, --wp-user, --wp-pass`
+			);
 			process.exit( 1 );
 		}
 	} catch ( err ) {
@@ -688,9 +874,16 @@ function evaluateTurn( turn, result ) {
 	console.log( `  Model:          ${ modelId }` );
 	console.log( `  Thinking:       ${ noThink ? 'DISABLED' : 'enabled' }` );
 	console.log( `  WP URL:         ${ wpUrl }` );
-	console.log( `  Test file:      ${ path.relative( process.cwd(), testFilePath ) }` );
+	console.log(
+		`  Test file:      ${ path.relative( process.cwd(), testFilePath ) }`
+	);
 	console.log( `  Conversations:  ${ conversations.length }` );
-	console.log( `  Total turns:    ${ conversations.reduce( ( s, c ) => s + c.turns.length, 0 ) }` );
+	console.log(
+		`  Total turns:    ${ conversations.reduce(
+			( s, c ) => s + c.turns.length,
+			0
+		) }`
+	);
 
 	const reactPrompt = buildReactSystemPrompt( abilities );
 
@@ -709,13 +902,19 @@ function evaluateTurn( turn, result ) {
 
 		for ( let ti = 0; ti < convo.turns.length; ti++ ) {
 			const turn = convo.turns[ ti ];
-			process.stdout.write( `    [${ ci + 1 }.${ ti + 1 }] "${ turn.input }" ... ` );
+			process.stdout.write(
+				`    [${ ci + 1 }.${ ti + 1 }] "${ turn.input }" ... `
+			);
 
 			try {
 				// Always use ReAct prompt — the LLM decides tool_call vs final_answer.
 				// This mirrors the browser's most common path and lets us test both
 				// tool selection AND conversational answers in the same loop.
-				const result = await executeReactLoop( turn.input, history, reactPrompt );
+				const result = await executeReactLoop(
+					turn.input,
+					history,
+					reactPrompt
+				);
 
 				// Evaluate
 				const evalResult = evaluateTurn( turn, result );
@@ -731,8 +930,13 @@ function evaluateTurn( turn, result ) {
 				} );
 
 				if ( evalResult.passed ) {
-					const toolInfo = result.toolsUsed.length > 0 ? ` [${result.toolsUsed.join(', ')}]` : '';
-					console.log( `✓${ toolInfo } (${ result.iterations } iter)` );
+					const toolInfo =
+						result.toolsUsed.length > 0
+							? ` [${ result.toolsUsed.join( ', ' ) }]`
+							: '';
+					console.log(
+						`✓${ toolInfo } (${ result.iterations } iter)`
+					);
 				} else {
 					console.log( `✗ (${ evalResult.reason })` );
 				}
@@ -744,9 +948,11 @@ function evaluateTurn( turn, result ) {
 				// causes back-to-back assistant messages + cached data reuse.
 				history.push( { role: 'user', content: turn.input } );
 				if ( result.finalAnswer ) {
-					history.push( { role: 'assistant', content: result.finalAnswer } );
+					history.push( {
+						role: 'assistant',
+						content: result.finalAnswer,
+					} );
 				}
-
 			} catch ( err ) {
 				allResults.push( {
 					conversation: label,
@@ -771,7 +977,9 @@ function evaluateTurn( turn, result ) {
 		console.log( '' );
 		console.log( '  Failures:' );
 		for ( const f of failures ) {
-			console.log( `    ✗ [${ f.conversation } T${ f.turn }] "${ f.input }"` );
+			console.log(
+				`    ✗ [${ f.conversation } T${ f.turn }] "${ f.input }"`
+			);
 			console.log( `      ${ f.reason }` );
 		}
 	}
@@ -781,7 +989,11 @@ function evaluateTurn( turn, result ) {
 	const pct = total > 0 ? Math.round( ( passed / total ) * 100 ) : 0;
 
 	console.log( '' );
-	console.log( `  ${ passed }/${ total } turns passed (${ pct }%) in ${ ( totalTime / 1000 ).toFixed( 1 ) }s` );
+	console.log(
+		`  ${ passed }/${ total } turns passed (${ pct }%) in ${ (
+			totalTime / 1000
+		).toFixed( 1 ) }s`
+	);
 	console.log( '' );
 
 	process.exit( passed === total ? 0 : 1 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,15 @@ module.exports = {
 			import: path.resolve( __dirname, 'src/extensions/sw.js' ),
 			filename: 'sw.js', // Output as sw.js directly, not sw.index.js
 		},
+
+		// Whisper Web Worker - self-contained bundle for speech-to-text
+		'whisper-worker': {
+			import: path.resolve(
+				__dirname,
+				'src/extensions/services/whisper-worker.js'
+			),
+			filename: 'whisper-worker.js',
+		},
 	},
 
 	output: {
@@ -64,8 +73,9 @@ module.exports = {
 			...defaultConfig.optimization?.splitChunks,
 			cacheGroups: {
 				...defaultConfig.optimization?.splitChunks?.cacheGroups,
-				// Don't split the service worker
+				// Don't split the service worker or whisper worker
 				sw: false,
+				'whisper-worker': false,
 			},
 		},
 		runtimeChunk: false, // SW needs runtime included


### PR DESCRIPTION
## Summary
- Adds on-device speech-to-text via Whisper Tiny (Xenova/whisper-tiny, ~40 MB ONNX) running entirely in a Web Worker — no audio ever leaves the browser
- Space bar hold-to-record (push-to-talk) with a 200 ms threshold to distinguish a quick tap (inserts space) from a deliberate hold (starts recording); OS key-repeat events suppressed during recording to prevent ghost spaces
- Pulsing red border glow on the input wrapper during recording, transcribing wave overlay centred over the textarea while Whisper runs
- Fixes ReAct agent crash when the LLM returns a `tool_call` action without a `tool` field (`toolId.includes` TypeError)

## Changes
- `src/extensions/services/whisper-worker.js` — new Web Worker: Whisper pipeline (WASM/q8), ISO→Whisper language map, warmup message, debug logging
- `src/extensions/components/VoiceButton.jsx` — new component: forwardRef + useImperativeHandle exposing start/stop, 30 s countdown with auto-stop, warning state ≤10 s, transcribing dots
- `src/extensions/components/ChatInput.jsx` — VoiceButton integration, voiceState tracking, Space push-to-talk with 200 ms timer, Enter-to-send, transcribing overlay, recording glow modifier
- `src/extensions/components/ChatContainer.jsx` — placeholder updated to hint at Space shortcut; incorporates upstream Thinking… state from fix/issue-147
- `src/extensions/styles/main.scss` — voice button styles, recording/transcribing animations, input wrapper `--recording` glow keyframe
- `src/extensions/services/react-agent.js` — guard against undefined toolId at call site and in executeTool
- `webpack.config.js` — whisper-worker entry as self-contained bundle (no code splitting)
- `package.json` / `package-lock.json` — adds `@huggingface/transformers`

## Testing
- [ ] Unit tests pass (`npm test`)
- [ ] Ability tests pass (`npm run test:abilities -- --file tests/abilities/core-abilities.test.js`)
- [ ] JS lint clean (`npm run lint:js`)
- [ ] PHP lint clean (`composer lint`)
- [ ] Manually tested in browser (if UI changes)

## Notes
- First use downloads the ~40 MB Whisper ONNX model from HuggingFace Hub and caches it in Cache Storage — subsequent uses are instant
- Model is pre-warmed on component mount (warmup message to worker) so first recording is fast
- iOS Safari falls back to `audio/mp4` (no WebM support) and WASM backend (no WebGPU)
- Debug `console.log` statements remain in whisper-worker.js intentionally for now to aid diagnosing transcription issues in the field