### PR TITLE
fix: Remove the redaction from the query ability

### DIFF
--- a/includes/abilities/query-database.php
+++ b/includes/abilities/query-database.php
@@ -101,27 +101,6 @@ function wp_agentic_admin_is_safe_query( string $query ): bool {
 }
 
 /**
- * Redact sensitive columns from query results.
- *
- * @param array $results Query results.
- * @return array Redacted results.
- */
-function wp_agentic_admin_redact_query_results( array $results ): array {
-	$sensitive_columns = array( 'user_pass', 'user_email' );
-
-	foreach ( $results as &$row ) {
-		$row = (array) $row;
-		foreach ( $sensitive_columns as $col ) {
-			if ( isset( $row[ $col ] ) ) {
-				$row[ $col ] = '[REDACTED]';
-			}
-		}
-	}
-
-	return $results;
-}
-
-/**
  * Execute the query-database ability.
  *
  * @param array $input Input parameters.
@@ -167,9 +146,6 @@ function wp_agentic_admin_execute_query_database( array $input = array() ): arra
 
 	// Limit to 50 rows.
 	$results = array_slice( $results, 0, 50 );
-
-	// Redact sensitive data.
-	$results = wp_agentic_admin_redact_query_results( $results );
 
 	return array(
 		'success' => true,


### PR DESCRIPTION
This pull request removes the redaction of sensitive columns from database query results in the `query-database` ability. The function responsible for redacting sensitive information has been deleted, and sensitive fields such as `user_pass` and `user_email` will now be returned as-is in query results.

**Security and data handling changes:**

* Removed the `wp_agentic_admin_redact_query_results` function, which previously redacted sensitive columns (like `user_pass` and `user_email`) from query results. (`includes/abilities/query-database.php`)
* Stopped calling the redaction function in `wp_agentic_admin_execute_query_database`, so sensitive data is no longer redacted from returned results. (`includes/abilities/query-database.php`)