### PR TITLE
Focus role-capabilities-check on privilege escalation

### DIFF
--- a/includes/abilities/security/role-capabilities-check.php
+++ b/includes/abilities/security/role-capabilities-check.php
@@ -25,7 +25,7 @@ function wp_agentic_admin_register_role_capabilities_check(): void {
 		// PHP configuration for WordPress Abilities API.
 		array(
 			'label'               => __( 'Check Role Capabilities', 'wp-agentic-admin' ),
-			'description'         => __( 'Compare site role capabilities against WordPress defaults to detect privilege escalation or tampering.', 'wp-agentic-admin' ),
+			'description'         => __( 'Check default WordPress roles for added capabilities that indicate privilege escalation.', 'wp-agentic-admin' ),
 			'category'            => 'sre-tools',
 			'input_schema'        => array(
 				'type'                 => 'object',
@@ -50,11 +50,7 @@ function wp_agentic_admin_register_role_capabilities_check(): void {
 					),
 					'roles'        => array(
 						'type'        => 'array',
-						'description' => __( 'Per-role comparison results.', 'wp-agentic-admin' ),
-					),
-					'extra_roles'  => array(
-						'type'        => 'array',
-						'description' => __( 'Roles that do not exist in default WordPress.', 'wp-agentic-admin' ),
+						'description' => __( 'Per-role escalation results.', 'wp-agentic-admin' ),
 					),
 				),
 			),
@@ -91,92 +87,53 @@ function wp_agentic_admin_execute_role_capabilities_check( array $input = array(
 	$current      = wp_roles()->roles;
 	$roles_result = array();
 	$total_issues = 0;
-	$extra_roles  = array();
 
-	// Check each default role against the current site.
+	// Check each default role for added capabilities (privilege escalation).
 	foreach ( $defaults as $role_slug => $default_caps ) {
 		if ( ! isset( $current[ $role_slug ] ) ) {
-			// Default role was removed — this is legitimate hardening, skip it.
 			continue;
 		}
 
 		$current_caps = array_keys( array_filter( $current[ $role_slug ]['capabilities'] ?? array() ) );
 		$default_list = array_keys( $default_caps );
 
-		$added   = array_values( array_diff( $current_caps, $default_list ) );
-		$removed = array_values( array_diff( $default_list, $current_caps ) );
+		$added = array_values( array_diff( $current_caps, $default_list ) );
 
-		if ( empty( $added ) && empty( $removed ) ) {
+		if ( empty( $added ) ) {
 			$roles_result[] = array(
 				'role'      => $role_slug,
 				'role_name' => $current[ $role_slug ]['name'],
 				'status'    => 'default',
 				'added'     => array(),
-				'removed'   => array(),
 			);
 			continue;
 		}
 
 		++$total_issues;
 
-		// Risk depends on which role gained capabilities.
-		$risk = wp_agentic_admin_calculate_role_risk( $role_slug, $added, $removed );
+		$risk = wp_agentic_admin_calculate_role_risk( $role_slug, $added );
 
 		$roles_result[] = array(
 			'role'       => $role_slug,
 			'role_name'  => $current[ $role_slug ]['name'],
-			'status'     => 'modified',
+			'status'     => 'escalated',
 			'added'      => $added,
-			'removed'    => $removed,
 			'risk_score' => $risk,
 		);
 	}
 
-	// Detect non-default roles (from plugins, or attacker-created).
-	$default_slugs = array_keys( $defaults );
-	foreach ( $current as $role_slug => $role_data ) {
-		if ( in_array( $role_slug, $default_slugs, true ) ) {
-			continue;
-		}
-
-		$caps = array_keys( array_filter( $role_data['capabilities'] ?? array() ) );
-
-		// Dangerous capabilities that indicate admin-level access.
-		$dangerous_caps  = array( 'manage_options', 'edit_users', 'install_plugins', 'edit_plugins', 'delete_users', 'create_users', 'update_core', 'activate_plugins' );
-		$has_admin_caps  = ! empty( array_intersect( $caps, $dangerous_caps ) );
-
-		$extra_roles[] = array(
-			'role'         => $role_slug,
-			'role_name'    => $role_data['name'],
-			'capabilities' => $caps,
-			'cap_count'    => count( $caps ),
-			'has_admin'    => $has_admin_caps,
-			'risk_score'   => $has_admin_caps ? 8.0 : 3.0,
-		);
-	}
-
-	if ( 0 === $total_issues && empty( $extra_roles ) ) {
-		$message = __( 'All default WordPress roles match their expected capabilities. No modifications detected.', 'wp-agentic-admin' );
+	if ( 0 === $total_issues ) {
+		$message = __( 'No privilege escalation detected. All default roles have their expected capabilities.', 'wp-agentic-admin' );
 	} else {
-		$parts = array();
-		if ( $total_issues > 0 ) {
-			$parts[] = sprintf(
-				/* translators: %d: number of modified roles */
-				_n( '%d default role modified', '%d default roles modified', $total_issues, 'wp-agentic-admin' ),
-				$total_issues
-			);
-		}
-		if ( ! empty( $extra_roles ) ) {
-			$parts[] = sprintf(
-				/* translators: %d: number of extra roles */
-				_n( '%d non-default role found', '%d non-default roles found', count( $extra_roles ), 'wp-agentic-admin' ),
-				count( $extra_roles )
-			);
-		}
 		$message = sprintf(
-			/* translators: %s: details */
-			__( 'Role capabilities check: %s.', 'wp-agentic-admin' ),
-			implode( ', ', $parts )
+			/* translators: %d: number of escalated roles */
+			_n(
+				'Privilege escalation detected: %d default role has added capabilities.',
+				'Privilege escalation detected: %d default roles have added capabilities.',
+				$total_issues,
+				'wp-agentic-admin'
+			),
+			$total_issues
 		);
 	}
 
@@ -185,28 +142,20 @@ function wp_agentic_admin_execute_role_capabilities_check( array $input = array(
 		'message'      => $message,
 		'total_issues' => $total_issues,
 		'roles'        => $roles_result,
-		'extra_roles'  => $extra_roles,
 	);
 }
 
 /**
- * Calculate risk score for a modified default role.
+ * Calculate risk score for a role with added capabilities.
  *
  * Subscribers and contributors gaining capabilities is high risk.
  * Editors gaining admin-level capabilities is medium-high risk.
- * Removed capabilities are low risk (usually intentional hardening).
  *
  * @param string $role_slug Role slug.
  * @param array  $added     Capabilities added beyond defaults.
- * @param array  $removed   Capabilities removed from defaults.
  * @return float Risk score 1.0–10.0.
  */
-function wp_agentic_admin_calculate_role_risk( string $role_slug, array $added, array $removed ): float {
-	if ( empty( $added ) ) {
-		// Only removals — likely intentional hardening.
-		return 3.0;
-	}
-
+function wp_agentic_admin_calculate_role_risk( string $role_slug, array $added ): float {
 	// Dangerous capabilities that should never appear on low-privilege roles.
 	$dangerous = array( 'manage_options', 'edit_users', 'install_plugins', 'edit_plugins', 'delete_users', 'create_users', 'update_core', 'activate_plugins', 'edit_themes', 'switch_themes' );
 
@@ -214,10 +163,10 @@ function wp_agentic_admin_calculate_role_risk( string $role_slug, array $added, 
 
 	// Risk by role — lower-privilege roles are higher risk when escalated.
 	$role_risk_base = array(
-		'subscriber'  => 9.0,
-		'contributor' => 8.5,
-		'author'      => 7.0,
-		'editor'      => 6.5,
+		'subscriber'    => 9.0,
+		'contributor'   => 8.5,
+		'author'        => 7.0,
+		'editor'        => 6.5,
 		'administrator' => 4.0,
 	);
 

--- a/simulate-hack.sh
+++ b/simulate-hack.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# Simulate a hacked WordPress site for security scanner testing.
+#
+# This script:
+# 1. Plants suspicious options in wp_options (eval, base64, inline script)
+# 2. Creates a rogue administrator account
+# 3. Escalates subscriber role with manage_options capability
+# 4. Creates a fake malicious PHP file in wp-content/plugins/
+# 5. Modifies wp-login.php to trigger a core checksum mismatch
+#
+# Usage: bash simulate-hack.sh
+# Run from Local's site shell (Open Site Shell in Local app).
+
+set -e
+
+# Navigate to the WordPress root (ABSPATH).
+# Detect it via WP-CLI, fall back to walking up from the script directory.
+if command -v wp &>/dev/null; then
+    WP_ROOT="$(wp eval 'echo ABSPATH;' 2>/dev/null)" || true
+fi
+
+if [ -z "$WP_ROOT" ] || [ ! -f "$WP_ROOT/wp-login.php" ]; then
+    # Walk up from the script's location until we find wp-login.php.
+    WP_ROOT="$(cd "$(dirname "$0")" && pwd)"
+    while [ "$WP_ROOT" != "/" ] && [ ! -f "$WP_ROOT/wp-login.php" ]; do
+        WP_ROOT="$(dirname "$WP_ROOT")"
+    done
+fi
+
+if [ ! -f "$WP_ROOT/wp-login.php" ]; then
+    echo "[!] Could not locate WordPress root. Run this script from within your WP install."
+    exit 1
+fi
+
+cd "$WP_ROOT"
+echo "WordPress root: $WP_ROOT"
+echo ""
+
+echo "============================================"
+echo "  Simulating hacked WordPress site"
+echo "  (for wp-agentic-admin scanner testing)"
+echo "============================================"
+echo ""
+
+# --- Step 1: Plant suspicious options ---
+echo "--- Step 1: Planting suspicious options ---"
+echo ""
+
+wp option update wp_session_manager_x 'eval(base64_decode("ZWNobyAiaGFja2VkIjs="));'
+echo "[+] Created option 'wp_session_manager_x' with eval() payload"
+
+wp option update wp_cache_config_bak '$code = base64_decode("ZnVuY3Rpb24gZ2V0X3NoZWxsKCkgeyByZXR1cm4gImZha2UiOyB9"); include($code);'
+echo "[+] Created option 'wp_cache_config_bak' with base64_decode payload"
+
+wp option update widget_display_override '<script>document.write(String.fromCharCode(60,115,99,114,105,112,116))</script>'
+echo "[+] Created option 'widget_display_override' with inline script"
+echo ""
+
+# --- Step 2: Create rogue admin account ---
+echo "--- Step 2: Creating rogue admin account ---"
+echo ""
+
+if wp user get eviluser@leet.com --field=ID 2>/dev/null; then
+    echo "[*] Evil user 'eviluser@leet.com' already exists"
+else
+    wp user create eviluser eviluser@leet.com --role=administrator --user_pass=h4ck3d123
+    echo "[+] Created administrator account 'eviluser' (eviluser@leet.com)"
+fi
+echo ""
+
+# --- Step 3: Escalate subscriber privileges ---
+echo "--- Step 3: Escalating subscriber role ---"
+echo ""
+
+# Find any subscriber user, or create one for testing.
+SUBSCRIBER_ID=$(wp user list --role=subscriber --field=ID --number=1 2>/dev/null)
+if [ -z "$SUBSCRIBER_ID" ]; then
+    wp user create testsubscriber testsubscriber@example.com --role=subscriber --user_pass=sub123
+    echo "[+] Created subscriber account 'testsubscriber'"
+    SUBSCRIBER_ID=$(wp user get testsubscriber --field=ID)
+fi
+
+# Add manage_options capability to the subscriber role.
+wp cap add subscriber manage_options 2>/dev/null
+echo "[+] Added 'manage_options' capability to subscriber role (privilege escalation)"
+echo ""
+
+# --- Step 4: Create a fake malicious PHP file ---
+echo "--- Step 4: Creating fake backdoor file ---"
+echo ""
+
+BACKDOOR_DIR="wp-content/plugins/totally-legit-seo"
+mkdir -p "$BACKDOOR_DIR"
+
+cat > "$BACKDOOR_DIR/helper.php" << 'EOPHP'
+<?php
+/**
+ * Plugin Name: Totally Legit SEO Helper
+ * Description: Just an ordinary SEO helper. Nothing to see here.
+ * Version: 1.0.0
+ */
+
+// Definitely not suspicious at all.
+$encoded = "ZWNobyAiVGhpcyBpcyBhIGZha2UgbWFsd2FyZSBwYXlsb2FkIGZvciB0ZXN0aW5nIHB1cnBvc2VzIG9ubHkuIjs=";
+$decoded = base64_decode( $encoded );
+eval( $decoded );
+
+// The decoded string is just: echo "This is a fake malware payload for testing purposes only.";
+EOPHP
+
+echo "[+] Created $BACKDOOR_DIR/helper.php (fake eval+base64 backdoor)"
+echo ""
+
+# --- Step 5: Modify wp-login.php to fail core checksum ---
+echo "--- Step 5: Modifying wp-login.php (checksum mismatch) ---"
+echo ""
+
+if [ -f "wp-login.php" ]; then
+    if [ ! -f "wp-login.php.bak" ]; then
+        cp wp-login.php wp-login.php.bak
+        echo "[+] Backed up wp-login.php to wp-login.php.bak"
+    fi
+
+    if ! grep -q 'SIMULATED_HACK_MARKER' wp-login.php; then
+        echo '' >> wp-login.php
+        echo '// SIMULATED_HACK_MARKER' >> wp-login.php
+        echo '$_simulated_hack_gibberish = "aGFja2VkX2J5X3NjcmlwdF9raWRkaWVz";' >> wp-login.php
+        echo "[+] Modified wp-login.php (appended gibberish variable)"
+    else
+        echo "[*] wp-login.php already modified"
+    fi
+else
+    echo "[!] wp-login.php not found — skipping"
+fi
+
+echo ""
+echo "============================================"
+echo "  Hack simulation complete!"
+echo ""
+echo "  What was planted:"
+echo "  - 3 suspicious options in wp_options"
+echo "    (eval, base64_decode, inline script)"
+echo "  - Admin account: eviluser@leet.com"
+echo "  - Subscriber escalation: manage_options added"
+echo "  - Backdoor: $BACKDOOR_DIR/helper.php"
+echo "  - Modified: wp-login.php (checksum fail)"
+echo "============================================"


### PR DESCRIPTION
## Summary
- Simplify role-capabilities-check to only detect **added capabilities** on default WordPress roles (privilege escalation)
- Remove detection of removed capabilities and extra/non-default roles
- Add subscriber privilege escalation step (`manage_options`) to `simulate-hack.sh`

## Changes

### `includes/abilities/security/role-capabilities-check.php`
- **Removed** tracking of removed capabilities and `extra_roles` (non-default roles) detection
- **Simplified** `wp_agentic_admin_execute_role_capabilities_check()` to only flag roles with added capabilities beyond WordPress defaults
- **Updated** role status from `modified` to `escalated` for flagged roles
- **Simplified** `wp_agentic_admin_calculate_role_risk()` — removed `$removed` parameter and the early-return for removal-only cases
- **Updated** output schema — removed `extra_roles` field, updated descriptions to reflect escalation focus
- **Updated** messages to clearly communicate privilege escalation detection

### `simulate-hack.sh`
- **Added** Step 3: escalate the subscriber role by adding `manage_options` capability via `wp cap add`
- Creates a test subscriber user if none exists
- Renumbered Steps 4–5 and updated the summary output

## Test plan
- [ ] Run `bash simulate-hack.sh` to plant the subscriber escalation
- [ ] Trigger the role-capabilities-check ability and verify it flags the subscriber role with risk score 9.0
- [ ] Verify roles with only removed capabilities show as `default` (not flagged)
- [ ] Run `composer lint` to confirm PHP passes WPCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)