### PR TITLE
refactor: remove voice input from default build (v0.11 PR 2/4)

### DIFF
--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -877,7 +877,7 @@ const ChatContainer = ( {
 						? 'Load the AI model to start chatting...'
 						: isLoading || isStreaming
 						? 'Thinking...'
-						: 'Describe your issue or what you want to do… (hold Space to speak)'
+						: 'Describe your issue or what you want to do…'
 				}
 				defaultBundle={ defaultBundle }
 			/>

--- a/src/extensions/components/ChatInput.jsx
+++ b/src/extensions/components/ChatInput.jsx
@@ -23,7 +23,6 @@ import {
 } from '@wordpress/icons';
 import ABILITY_BUNDLES from '../data/ability-bundles';
 import pluginAbilitiesManager from '../services/plugin-abilities-manager';
-import VoiceButton from './VoiceButton';
 
 /**
  * Map of bundle icon names to @wordpress/icons components.
@@ -52,7 +51,7 @@ const BUNDLE_ICONS = {
 const ChatInput = ( {
 	onSend,
 	disabled = false,
-	placeholder = 'Describe your issue or what you want to do… (hold Space to speak)',
+	placeholder = 'Describe your issue or what you want to do…',
 	isLoading = false,
 	defaultBundle = null,
 } ) => {
@@ -62,11 +61,7 @@ const ChatInput = ( {
 	const [ docSearchEnabled, setDocSearchEnabled ] = useState( false );
 	const [ kbIndexReady, setKbIndexReady ] = useState( false );
 	const [ pluginBundles, setPluginBundles ] = useState( [] );
-	const [ voiceState, setVoiceState ] = useState( 'idle' );
 	const textareaRef = useRef( null );
-	const voiceButtonRef = useRef( null );
-	const isSpaceDownRef = useRef( false );
-	const spacePressTimerRef = useRef( null );
 
 	// Check if the knowledge base index is available.
 	useEffect( () => {
@@ -79,11 +74,6 @@ const ChatInput = ( {
 			}
 		};
 		checkIndex();
-	}, [] );
-
-	// Cancel pending push-to-talk timer on unmount.
-	useEffect( () => {
-		return () => clearTimeout( spacePressTimerRef.current );
 	}, [] );
 
 	// Subscribe to plugin abilities manager for dynamic bundles
@@ -119,11 +109,6 @@ const ChatInput = ( {
 			e.preventDefault();
 		}
 
-		// Prevent accidental submit while recording or transcribing.
-		if ( isVoiceActive ) {
-			return;
-		}
-
 		const trimmedMessage = message.trim();
 		if ( ! trimmedMessage || disabled || isLoading ) {
 			return;
@@ -140,12 +125,7 @@ const ChatInput = ( {
 	};
 
 	/**
-	 * Handle keydown: Enter sends, Space on empty input starts recording.
-	 *
-	 * A 200 ms threshold distinguishes a quick tap (insert space) from a
-	 * deliberate hold (push-to-talk). The OS key-repeat delay is ~500 ms,
-	 * so we also suppress repeat events once recording is active to prevent
-	 * spaces from being inserted while the user holds the key.
+	 * Handle keydown: Enter sends.
 	 *
 	 * @param {KeyboardEvent} e - Keyboard event
 	 */
@@ -153,55 +133,6 @@ const ChatInput = ( {
 		if ( e.key === 'Enter' && ! e.shiftKey ) {
 			e.preventDefault();
 			handleSubmit( e );
-			return;
-		}
-
-		if ( e.key === ' ' ) {
-			// Suppress OS key-repeat events while push-to-talk or its timer is active.
-			if (
-				isSpaceDownRef.current ||
-				spacePressTimerRef.current !== null
-			) {
-				e.preventDefault();
-				return;
-			}
-
-			// Empty input + idle: arm the 200 ms push-to-talk timer.
-			if (
-				message === '' &&
-				voiceState === 'idle' &&
-				! e.repeat &&
-				! isDisabled
-			) {
-				e.preventDefault();
-				spacePressTimerRef.current = setTimeout( () => {
-					spacePressTimerRef.current = null;
-					isSpaceDownRef.current = true;
-					voiceButtonRef.current?.start();
-				}, 200 );
-			}
-		}
-	};
-
-	/**
-	 * Handle keyup: Space release either inserts a space (quick tap) or stops recording.
-	 *
-	 * @param {KeyboardEvent} e - Keyboard event
-	 */
-	const handleKeyUp = ( e ) => {
-		if ( e.key !== ' ' ) {
-			return;
-		}
-
-		if ( spacePressTimerRef.current !== null ) {
-			// Released before the 200 ms threshold — treat as a normal space character.
-			clearTimeout( spacePressTimerRef.current );
-			spacePressTimerRef.current = null;
-			setMessage( ( prev ) => prev + ' ' );
-		} else if ( isSpaceDownRef.current ) {
-			// Released after recording started — stop push-to-talk.
-			isSpaceDownRef.current = false;
-			voiceButtonRef.current?.stop();
 		}
 	};
 
@@ -214,24 +145,8 @@ const ChatInput = ( {
 		setMessage( e.target.value );
 	};
 
-	/**
-	 * Set the final transcription result and focus the textarea for editing.
-	 *
-	 * @param {string} text - Final transcribed text from Whisper.
-	 */
-	const handleTranscript = ( text ) => {
-		setMessage( text );
-		// Give focus back so the user can immediately edit or send.
-		requestAnimationFrame( () => textareaRef.current?.focus() );
-	};
-
 	const isDisabled = disabled || isLoading;
-	const isVoiceActive = voiceState !== 'idle';
-	const isTranscribing = voiceState === 'transcribing';
 	const canSend = message.trim().length > 0 && ! isDisabled;
-	// Mic is visible on an empty input, or while voice is active (recording /
-	// transcribing) so the component stays mounted through the full cycle.
-	const showMic = message === '' || isVoiceActive;
 
 	return (
 		<div className="wp-agentic-admin-input-area">
@@ -239,10 +154,6 @@ const ChatInput = ( {
 				className={ `wp-agentic-admin-input-wrapper${
 					isDisabled
 						? ' wp-agentic-admin-input-wrapper--disabled'
-						: ''
-				}${
-					voiceState === 'recording'
-						? ' wp-agentic-admin-input-wrapper--recording'
 						: ''
 				}` }
 			>
@@ -253,29 +164,10 @@ const ChatInput = ( {
 						value={ message }
 						onChange={ handleChange }
 						onKeyDown={ handleKeyDown }
-						onKeyUp={ handleKeyUp }
 						placeholder={ placeholder }
 						rows="3"
 						disabled={ isDisabled }
 					/>
-					{ isTranscribing && (
-						<div
-							className="wp-agentic-admin-transcribing-overlay"
-							aria-live="polite"
-							aria-label="Transcribing audio"
-						>
-							<div className="wp-agentic-admin-transcribing-wave">
-								<span />
-								<span />
-								<span />
-								<span />
-								<span />
-							</div>
-							<span className="wp-agentic-admin-transcribing-label">
-								Transcribing…
-							</span>
-						</div>
-					) }
 				</div>
 				<div className="wp-agentic-admin-input-toolbar">
 					<div className="wp-agentic-admin-input-toolbar__left">
@@ -457,24 +349,15 @@ const ChatInput = ( {
 						) }
 					</div>
 					<div className="wp-agentic-admin-input-toolbar__right">
-						{ showMic ? (
-							<VoiceButton
-								ref={ voiceButtonRef }
-								onTranscript={ handleTranscript }
-								onStateChange={ setVoiceState }
-								disabled={ isDisabled }
-							/>
-						) : (
-							<button
-								type="button"
-								className="wp-agentic-admin-send-button"
-								onClick={ handleSubmit }
-								disabled={ ! canSend }
-								aria-label="Send message"
-							>
-								<Icon icon={ send } size={ 20 } />
-							</button>
-						) }
+						<button
+							type="button"
+							className="wp-agentic-admin-send-button"
+							onClick={ handleSubmit }
+							disabled={ ! canSend }
+							aria-label="Send message"
+						>
+							<Icon icon={ send } size={ 20 } />
+						</button>
 					</div>
 				</div>
 			</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,14 +39,9 @@ module.exports = {
 			filename: 'sw.js', // Output as sw.js directly, not sw.index.js
 		},
 
-		// Whisper Web Worker - self-contained bundle for speech-to-text
-		'whisper-worker': {
-			import: path.resolve(
-				__dirname,
-				'src/extensions/services/whisper-worker.js'
-			),
-			filename: 'whisper-worker.js',
-		},
+		// Whisper Web Worker — source preserved in src/extensions/services/
+		// and src/extensions/components/VoiceButton.jsx for v1.4 (per roadmap).
+		// Re-add this entry to ship voice input again.
 
 		// Indexing Web Worker - background embedding + Voy indexing
 		'indexing-worker': {
@@ -84,7 +79,6 @@ module.exports = {
 				...defaultConfig.optimization?.splitChunks?.cacheGroups,
 				// Don't split the service worker or web workers
 				sw: false,
-				'whisper-worker': false,
 				'indexing-worker': false,
 			},
 		},


### PR DESCRIPTION
## Summary

Second of four PRs implementing the v0.11 strip-down strategy from the [v1 Roadmap doc](https://docs.google.com/document/d/1gKohp3AvWEbsNFBSYYBu99F8m53gjDpPZKYL0q2zgJY/edit). Drops the **819 KB Whisper Web Worker bundle** from the default build by removing the webpack entry, and removes the VoiceButton + push-to-talk integration from \`ChatInput\` so the bundle drop is real (no orphaned imports).

Independent of PR #191 — can be reviewed/merged in either order.

## What's removed

- \`whisper-worker\` entry in \`webpack.config.js\` (and the split-chunks exception)
- \`VoiceButton\` import + ref + state in \`ChatInput.jsx\`
- Space-to-record push-to-talk keyboard handlers
- Transcribing overlay UI
- \`isVoiceActive\` / \`isTranscribing\` / \`showMic\` derived state
- "hold Space to speak" hint in the placeholder (both ChatInput default and ChatContainer call site)

## What's preserved (per the doc's "park, don't delete" intent)

Voice returns in v1.4 as an opt-in Labs feature:

- \`src/extensions/components/VoiceButton.jsx\` (400 lines)
- \`src/extensions/services/whisper-worker.js\` (162 lines)
- Voice-related SCSS in \`main.scss\` (~18 lines — kept so reintroduction is straightforward; the CSS bytes are negligible relative to the 819 KB bundle win)

To re-enable: restore the \`whisper-worker\` webpack entry + restore the VoiceButton import / state in \`ChatInput.jsx\`. A breadcrumb comment in \`webpack.config.js\` points future devs at the relevant paths.

## Verification

- \`npm run build\` succeeds; \`build-extensions/whisper-worker.js\` no longer exists
- \`build-extensions/\` contents: index, admin-sidebar, editor, sw, indexing-worker (no whisper)
- Unit tests: **117 passing, 0 changed** — voice removal is structural
- JS lint clean on all three changed files (2 pre-existing warnings in ChatContainer.jsx, not introduced here)

## Roadmap context

| PR | Status |
|---|---|
| #191 | PR 1: manifest pattern, no behavior change |
| **This PR** | PR 2: voice out of default build |
| TBD | PR 3: delete 6 dead features (backup-check, opcode-cache-status, disk-usage, webmcp-bridge, feedback, core-editor-blocks) |
| TBD | PR 4: flip default to core+local-only; labs requires \`WP_AGENTIC_ADMIN_ENABLE_LABS\` |

## Test plan
- [ ] PHP lint passes
- [ ] JS lint passes (existing warnings only)
- [ ] Unit tests pass
- [ ] Build check passes
- [ ] Manual: load plugin in playground; chat input has no mic button, Space inserts a space, Enter sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)