### PR TITLE
fix: harden query-database — block sensitive columns + length cap (closes #166, #129)

### DIFF
--- a/includes/abilities/query-database.php
+++ b/includes/abilities/query-database.php
@@ -76,28 +76,95 @@ function wp_agentic_admin_register_query_database(): void {
 }
 
 /**
- * Check if a SQL query is safe (SELECT only).
+ * Maximum length (in characters) for a query string. Prevents pathological
+ * queries that try to bypass the keyword blocklist via obfuscation.
+ *
+ * @var int
+ */
+const WP_AGENTIC_ADMIN_QUERY_MAX_LENGTH = 2000;
+
+/**
+ * Column names that must never appear in a query — neither in SELECT lists
+ * nor in WHERE clauses.
+ *
+ * Blocking them in WHERE clauses prevents email/password reconnaissance
+ * attacks (e.g. SELECT * FROM wp_users WHERE user_email='target@x.com'),
+ * where an empty vs. non-empty result set itself leaks whether the value
+ * exists in the database. See issue #166.
+ *
+ * @return string[]
+ */
+function wp_agentic_admin_sensitive_columns(): array {
+	return array(
+		'user_pass',
+		'user_email',
+		'user_activation_key',
+		'session_tokens',
+	);
+}
+
+/**
+ * Check if a SQL query is safe (SELECT-family only, no sensitive columns).
  *
  * @param string $query SQL query string.
- * @return bool True if safe.
+ * @return string|true True if safe, otherwise an error message.
  */
-function wp_agentic_admin_is_safe_query( string $query ): bool {
-	$forbidden = array( 'INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE', 'REPLACE', 'GRANT', 'REVOKE' );
-	$upper     = strtoupper( trim( $query ) );
-
-	// Must start with SELECT or SHOW or DESCRIBE.
-	if ( ! preg_match( '/^\s*(SELECT|SHOW|DESCRIBE|EXPLAIN)\b/i', $upper ) ) {
-		return false;
+function wp_agentic_admin_check_query_safety( string $query ) {
+	if ( strlen( $query ) > WP_AGENTIC_ADMIN_QUERY_MAX_LENGTH ) {
+		return sprintf(
+			/* translators: %d: maximum query length in characters */
+			__( 'Query exceeds the maximum length of %d characters.', 'wp-agentic-admin' ),
+			WP_AGENTIC_ADMIN_QUERY_MAX_LENGTH
+		);
 	}
 
+	$upper = strtoupper( trim( $query ) );
+
+	// Must start with SELECT, SHOW, DESCRIBE, or EXPLAIN.
+	if ( ! preg_match( '/^\s*(SELECT|SHOW|DESCRIBE|EXPLAIN)\b/i', $upper ) ) {
+		return __( 'Only SELECT, SHOW, DESCRIBE, and EXPLAIN queries are allowed.', 'wp-agentic-admin' );
+	}
+
+	$forbidden = array( 'INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE', 'REPLACE', 'GRANT', 'REVOKE' );
 	foreach ( $forbidden as $keyword ) {
-		// Check for forbidden keywords as separate words.
 		if ( preg_match( '/\b' . $keyword . '\b/', $upper ) ) {
-			return false;
+			return __( 'Only SELECT, SHOW, DESCRIBE, and EXPLAIN queries are allowed.', 'wp-agentic-admin' );
+		}
+	}
+
+	// Block any reference to sensitive columns (in SELECT lists, WHERE
+	// clauses, JOIN conditions — anywhere). Even read access via WHERE
+	// leaks information by row-count side-channel. See issue #166.
+	foreach ( wp_agentic_admin_sensitive_columns() as $col ) {
+		if ( preg_match( '/\b' . preg_quote( $col, '/' ) . '\b/i', $query ) ) {
+			return sprintf(
+				/* translators: %s: sensitive column name */
+				__( 'Queries that reference the sensitive column "%s" are blocked.', 'wp-agentic-admin' ),
+				$col
+			);
 		}
 	}
 
 	return true;
+}
+
+/**
+ * Redact sensitive column values in a row of results.
+ *
+ * Belt-and-suspenders defense: even when the query itself doesn't name
+ * a sensitive column (e.g. SELECT *), the result rows must not leak
+ * password hashes or activation keys.
+ *
+ * @param array $row Associative array of column => value.
+ * @return array Row with sensitive columns replaced by [REDACTED].
+ */
+function wp_agentic_admin_redact_sensitive_row( array $row ): array {
+	foreach ( wp_agentic_admin_sensitive_columns() as $col ) {
+		if ( array_key_exists( $col, $row ) ) {
+			$row[ $col ] = '[REDACTED]';
+		}
+	}
+	return $row;
 }
 
 /**
@@ -114,16 +181,17 @@ function wp_agentic_admin_execute_query_database( array $input = array() ): arra
 	if ( empty( $query ) ) {
 		return array(
 			'success' => false,
-			'message' => 'No query provided.',
+			'message' => __( 'No query provided.', 'wp-agentic-admin' ),
 			'results' => array(),
 			'rows'    => 0,
 		);
 	}
 
-	if ( ! wp_agentic_admin_is_safe_query( $query ) ) {
+	$safety = wp_agentic_admin_check_query_safety( $query );
+	if ( true !== $safety ) {
 		return array(
 			'success' => false,
-			'message' => 'Only SELECT, SHOW, DESCRIBE, and EXPLAIN queries are allowed.',
+			'message' => $safety,
 			'results' => array(),
 			'rows'    => 0,
 		);
@@ -132,20 +200,35 @@ function wp_agentic_admin_execute_query_database( array $input = array() ): arra
 	// Replace {prefix} placeholder with actual prefix.
 	$query = str_replace( '{prefix}', $wpdb->prefix, $query );
 
-	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is validated as SELECT-only above.
+	// The query is fully built by the LLM (the whole point of the ability),
+	// so $wpdb->prepare() can't be used here — there are no separable
+	// placeholders. Safety is enforced upstream by:
+	// - read-only verb gate (SELECT/SHOW/DESCRIBE/EXPLAIN only)
+	// - forbidden-keyword blocklist (INSERT/UPDATE/DELETE/DROP/…)
+	// - sensitive-column blocklist (user_pass/user_email/…)
+	// - 2000-char length cap
+	// - manage_options capability check in permission_callback
+	// - per-row redaction of sensitive columns as belt-and-suspenders.
+	// Caching is intentionally skipped: each LLM-generated query is unique,
+	// so a cache would never hit while doubling our database call surface.
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 	$results = $wpdb->get_results( $query, ARRAY_A );
 
 	if ( null === $results ) {
 		return array(
 			'success' => false,
-			'message' => ! empty( $wpdb->last_error ) ? $wpdb->last_error : 'Query failed.',
+			'message' => ! empty( $wpdb->last_error ) ? $wpdb->last_error : __( 'Query failed.', 'wp-agentic-admin' ),
 			'results' => array(),
 			'rows'    => 0,
 		);
 	}
 
-	// Limit to 50 rows.
-	$results = array_slice( $results, 0, 50 );
+	// Limit to 50 rows, then redact any sensitive columns that snuck
+	// through (e.g. via SELECT *).
+	$results = array_map(
+		'wp_agentic_admin_redact_sensitive_row',
+		array_slice( $results, 0, 50 )
+	);
 
 	return array(
 		'success' => true,


### PR DESCRIPTION
## Summary

First of three security PRs for v0.11. Two real-world attack vectors closed.

**Net: +99 / -16 lines, 1 file touched.**

## Closes

### #166 — Email/password reconnaissance via WHERE clauses

The query-database ability runs LLM-authored SQL. Previously, sensitive column values like \`user_pass\` and \`user_email\` were redacted *in the response display*, but a user could still send:

\`\`\`sql
SELECT * FROM wp_users WHERE user_email = 'target@example.com'
\`\`\`

An empty result vs. one-row result leaks whether that email exists — confirming users one address at a time.

**Fix:** Reject any query that *mentions* a sensitive column anywhere in the string, before execution. The blocklist lives in a shared \`wp_agentic_admin_sensitive_columns()\` helper:

\`\`\`php
function wp_agentic_admin_sensitive_columns(): array {
    return [ 'user_pass', 'user_email', 'user_activation_key', 'session_tokens' ];
}
\`\`\`

Plus a belt-and-suspenders \`wp_agentic_admin_redact_sensitive_row()\` that scrubs those columns from result rows, so \`SELECT *\` doesn't smuggle them out.

### #129 — Unescaped parameter + missing safety rationale

\`$wpdb->prepare()\` can't be used here because the LLM authors the whole query (no separable placeholders to bind). The phpcs warnings (\`PreparedSQL.NotPrepared\`, \`DirectDatabaseQuery.DirectQuery\`, \`DirectDatabaseQuery.NoCaching\`) are intentional, but were inadequately documented. Now a single \`phpcs:ignore\` covers all three with a rationale comment listing every defense layer.

Also added a **2000-char length cap** to prevent pathological queries that try to bypass the keyword blocklist via obfuscation.

## What changed

| Change | Why |
|---|---|
| Rename \`is_safe_query()\` → \`check_query_safety()\` | Returns \`string\|true\` instead of \`bool\` so the caller can surface the *reason* a query was rejected. Helps the LLM self-correct on next turn. |
| New \`wp_agentic_admin_sensitive_columns()\` helper | Single source of truth for the column blocklist. |
| New \`wp_agentic_admin_redact_sensitive_row()\` helper | Result-row redactor. |
| New \`WP_AGENTIC_ADMIN_QUERY_MAX_LENGTH = 2000\` constant | Length cap. |
| Consolidated phpcs:ignore with rationale comment | Documents all defense layers in one place. |

## Verification

Manual smoke test via \`wp_cli eval\` in the running Playground:

| Query | Expected | Got |
|---|---|---|
| \`SELECT * FROM wp_users WHERE user_email = '…'\` | blocked | ✅ blocked |
| \`SELECT user_pass FROM wp_users\` | blocked | ✅ blocked |
| \`SELECT ID, user_login FROM wp_users\` | passed | ✅ passed |
| \`DELETE FROM wp_users\` | blocked | ✅ blocked |
| 2500-char query | blocked | ✅ blocked |
| \`INSERT INTO wp_users VALUES (1)\` | blocked | ✅ blocked |

- \`composer lint\` — clean
- \`npm test\` — **96 passing**, no JS changed

## What's next

Two more security PRs to land before WP.org submission:
- PR B: #122 (SQL injection in \`database-check.php\`)
- PR C: #128, #121, #123 (smaller fixes)

## Test plan
- [ ] Build check passes
- [ ] PHP lint passes
- [ ] JS lint passes
- [ ] Unit tests pass
- [ ] Manual: try a recon query (\`SELECT * FROM wp_users WHERE user_email = 'admin@…'\`) from chat → agent gets a blocked-column error, doesn't reveal whether the email exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)