### PR TITLE
fix: suppress phpcs false-positives in database-check (closes #122)

### DIFF
--- a/includes/abilities/security/database-check.php
+++ b/includes/abilities/security/database-check.php
@@ -297,7 +297,11 @@ function wp_agentic_admin_check_options_suspicious_urls(): array {
 		$values[]        = $pattern;
 	}
 
-	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic number of LIKE patterns; WHERE clause is built from safe literal strings.
+	// The WHERE clause is built from literal "option_value LIKE %s" fragments
+	// in a fixed-size loop over $suspicious_patterns — no user input touches
+	// the SQL string. The %s count always matches ...$values, but phpcs can't
+	// see through the implode + spread to verify that statically.
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 	$rows = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT option_name, LEFT(option_value, 200) AS option_value_preview
@@ -307,7 +311,7 @@ function wp_agentic_admin_check_options_suspicious_urls(): array {
 			...$values
 		)
 	);
-	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 	$findings = array();
 	foreach ( $rows as $row ) {
@@ -500,7 +504,12 @@ function wp_agentic_admin_check_posts_hidden_links(): array {
 function wp_agentic_admin_check_usermeta_injections(): array {
 	global $wpdb;
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+	// Slow meta_key scan is intentional — this is a security audit that
+	// looks for injected payloads anywhere in usermeta. The LIMIT 50 and
+	// admin-only permission_callback (in the parent ability registration)
+	// keep the blast radius small. Caching is skipped: stale results would
+	// hide a fresh injection.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 	$rows = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT user_id, meta_key, LEFT(meta_value, 200) AS meta_value_preview
@@ -519,6 +528,7 @@ function wp_agentic_admin_check_usermeta_injections(): array {
 	foreach ( $rows as $row ) {
 		$findings[] = array(
 			'user_id'    => (int) $row->user_id,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- this is a PHP array key in our response, not a WP_Query argument.
 			'meta_key'   => $row->meta_key,
 			'preview'    => $row->meta_value_preview,
 			'risk_score' => 9.0, // Code injection in user meta is almost always malicious.


### PR DESCRIPTION
## Summary

Closes the SQL injection issue in \`database-check.php\` — but as a documentation/suppression PR rather than a behavior change. **Net: +13 / -3 lines, 1 file touched.**

## Context

When #122 was filed, the file had real exposure: \`\$where_clauses\` was concatenated unescaped into a query. The file has since been refactored — all dynamic SQL now goes through \`\$wpdb->prepare()\` with \`%s\` placeholders, and the values passed are either literal pattern strings or \`\$wpdb->esc_like()\`'d constants. No user input ever touches the query string directly.

What remained were 3 phpcs false-positives.

## Suppressions added (with rationale comments)

| Rule | Line | Why it's a false positive |
|---|---|---|
| \`WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare\` | 306 (existing \`prepare()\` block) | The WHERE clause is built from literal \`"option_value LIKE %s"\` fragments in a fixed-size loop over \`\$suspicious_patterns\`. The \`%s\` count always matches \`...\$values\`, but phpcs can't trace through \`implode\` + variadic spread to verify that. |
| \`WordPress.DB.SlowDBQuery.slow_db_query_meta_key\` | 515 (SELECT) | Security audit that intentionally scans usermeta for injected payloads. \`LIMIT 50\` + admin-only \`permission_callback\` keep the blast radius small. Caching skipped on purpose — stale results would hide a fresh injection. |
| \`WordPress.DB.SlowDBQuery.slow_db_query_meta_key\` | 531 (PHP array key) | phpcs flags the literal string \`'meta_key'\` used as a PHP array key, as if it were a WP_Query argument. |

## What I did NOT change

The SQL itself. All three queries in this file already use \`\$wpdb->prepare()\` with safe placeholder patterns. The phpcs warnings were noise, not findings.

## Verification

- \`composer lint\` — clean (was 0 errors / 2 warnings, now 0 / 0)
- \`npm test\` — 96 passing, unchanged
- All queries still go through \`\$wpdb->prepare()\` with proper \`%s\` placeholders

## What's still queued for v0.11

After this lands, the remaining WP.org blockers are:
- **PR C (next):** #128, #121, #123 — smaller security fixes
- **Compliance:** #125 (trademark rename), #124 (readme.txt headers)
- **Critical bug:** #188 (role-capabilities-check JS/PHP sync)

## Test plan
- [ ] Build check passes
- [ ] PHP lint passes (specifically: 0 warnings for database-check.php)
- [ ] JS lint passes
- [ ] Unit tests pass
- [ ] Manual: run the database-check security ability from chat → completes without errors and surfaces any findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)