### PR TITLE
fix: small security cleanups (closes #121, #123, #128)

### DIFF
--- a/includes/functions-abilities.php
+++ b/includes/functions-abilities.php
@@ -47,11 +47,12 @@ function wp_agentic_admin_register_ability( string $id, array $php_args, array $
 	if ( empty( $id ) || ! preg_match( '/^[a-z0-9-]+\/[a-z0-9-]+$/', $id ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- __() is a translation function, output is escaped by _doing_it_wrong()
-			sprintf(
-				/* translators: %s: ability ID */
-				__( 'Invalid ability ID format: %s. Must be in format "namespace/ability-name".', 'wp-agentic-admin' ),
-				$id
+			esc_html(
+				sprintf(
+					/* translators: %s: ability ID */
+					__( 'Invalid ability ID format: %s. Must be in format "namespace/ability-name".', 'wp-agentic-admin' ),
+					$id
+				)
 			),
 			'1.0.0'
 		);

--- a/sw-loader.php
+++ b/sw-loader.php
@@ -6,6 +6,13 @@
  * browser permits registering the SW with scope '/wp-admin/' even though
  * the script lives under '/wp-content/plugins/...'.
  *
+ * This file is intentionally loaded directly by the browser (the Service
+ * Worker registration HTTP request), NOT through WordPress's normal
+ * bootstrap. ABSPATH is never defined here, so the usual `if ( ! defined(
+ * 'ABSPATH' ) ) exit;` guard cannot apply — and the file has no logic
+ * beyond setting three headers and streaming a static built asset, so
+ * direct access is the supported invocation path.
+ *
  * @license GPL-2.0-or-later
  * @package WPAgenticAdmin
  * @since   0.4.1
@@ -18,5 +25,10 @@ header( 'Content-Type: application/javascript' );
 // Prevent caching so SW updates propagate immediately.
 header( 'Cache-Control: no-cache, no-store, must-revalidate' );
 
+// WP_Filesystem is unavailable here (WordPress isn't loaded — see header).
+// We need to stream a single built asset to stdout with a precise content
+// type, which readfile() does in one syscall. The path is a hard-coded
+// __DIR__-rooted constant, so there's no traversal vector.
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
 readfile( __DIR__ . '/build-extensions/sw.js' );
 exit;


### PR DESCRIPTION
## Summary

Third of three security PRs. Three small Plugin Checker items — two real edits and one already-done close-out.

**Net: +18 / -5 lines, 2 files touched.**

## Closes

### #121 — Escape output in \`functions-abilities.php\`

Previous code passed \`sprintf()\` output directly to \`_doing_it_wrong()\` with a misleading phpcs:ignore claiming \"output is escaped by _doing_it_wrong()\". That's not actually true — \`_doing_it_wrong\` forwards the message to \`trigger_error()\`, which in WP_DEBUG mode can reach an admin notice / error log without HTML escaping.

In practice the ability ID is developer-controlled (third-party plugins choose their own namespace), but Plugin Checker (rightly) wants defense in depth here.

**Fix:** wrap the \`sprintf\` in \`esc_html()\` and drop the misleading ignore comment. No behavior change in the common path (the format string has no HTML), but the safety contract is now explicit.

### #123 — \`sw-loader.php\` direct access + \`readfile()\`

This file is **intentionally** browser-accessible — it's the URL the browser fetches when registering the Service Worker, *before* WordPress is loaded. \`ABSPATH\` is never defined here, and \`WP_Filesystem\` is unavailable.

**Fix:** kept the existing structure (it's correct), added a docblock explaining *why* no ABSPATH guard is possible, and a single \`phpcs:ignore\` on the \`readfile()\` call with rationale (single asset, hard-coded \`__DIR__\` path, no traversal vector).

### #128 — \`db-optimize.php\` uncached query

Already resolved by the existing \`phpcs:ignore\` on line 81 (covers both \`DirectQuery\` and \`NoCaching\`). No changes needed — closing as already-fixed.

## Verification

- \`composer lint\` — **0 errors, 0 warnings** (was 1 warning on sw-loader.php)
- \`npm test\` — 96 passing, unchanged

## Where this leaves v0.11

| Bucket | Status |
|---|---|
| Housekeeping (#198) | Open, Ivelina reviewing |
| Security PR A (#199) | Open, Ivelina reviewing |
| Security PR B (#200) | Open, Ivelina reviewing |
| **Security PR C (this)** | Open, Ivelina reviewing |
| Compliance — trademark rename (#125) | Not started |
| Compliance — readme.txt headers (#124) | Not started |
| Critical bug — role-capabilities-check sync (#188) | Not started |
| Critical bug — Activate/Deactivate buttons (#179) | Not started |
| Critical bug — Actions filtered post-tool (#181) | Not started |
| Critical bug — Don't preload model when sidebar hidden (#116) | Not started |

## Test plan
- [ ] Build check passes
- [ ] PHP lint passes (specifically: 0 warnings repo-wide)
- [ ] JS lint passes
- [ ] Unit tests pass
- [ ] Manual: register an invalid ability ID (\`'BAD ID'\`) via PHP and confirm the resulting \`_doing_it_wrong\` notice renders escaped HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)