### PR TITLE
fix: keep post-tool final_answer brief — don't re-list tool output (closes #181)

### DIFF
--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -964,8 +964,13 @@ class ReactAgent {
 		} else {
 			message = `Tool result: ${ truncatedResult }`;
 		}
+		// Remind the model that the user already sees the tool result
+		// rendered as a structured UI block (the ability_result message).
+		// Without this, small models tend to re-list every plugin/user/etc.
+		// in their final_answer prose, duplicating what's already on screen.
+		// Issue #181.
 		const suffix =
-			'\n\nRemember: Respond with ONLY a JSON object. Either call another tool or provide final_answer.';
+			"\n\nRemember: Respond with ONLY a JSON object. Either call another tool or provide a final_answer. The user already sees the tool result above — keep final_answer brief (one or two sentences). Don't re-list items the tool already returned.";
 		const nothink = this.config.disableThinkingAfterTool
 			? '\n\n/nothink'
 			: '';
@@ -1003,7 +1008,7 @@ Final answer: {"action": "final_answer", "content": "Your answer here"}
 
 RULES:
 - One JSON object per response. No text before or after.
-- Summarize tool results for humans. Never copy raw JSON into final_answer.
+- The tool result is shown to the user as its own UI block — your final_answer should NOT re-list what the tool already returned. Keep final_answer brief (1–2 sentences of context or interpretation, never a full restatement).
 - If a tool fails, explain the failure in a final_answer.
 - Never retry a failed tool. Never invent tool names.
 - If no tool is needed, answer directly via final_answer.
@@ -1013,8 +1018,8 @@ EXAMPLE:
 User: "list plugins"
 {"action": "tool_call", "tool": "wp-agentic-admin/plugin-list", "args": {}}
 
-[Tool returns data]
-{"action": "final_answer", "content": "You have 2 plugins: Akismet (active) and Hello Dolly (inactive)."}
+[Tool returns the list — the user sees it rendered above]
+{"action": "final_answer", "content": "You have 2 plugins installed. One is active."}
 
 User: "what environment is this?"
 {"action": "tool_call", "tool": "core/get-environment-info", "args": {}}


### PR DESCRIPTION
## Summary

The original report: ask "list plugins", get the structured plugin list rendered as an \`ability_result\` UI block in the chat — but the LLM's \`final_answer\` text *also* lists every plugin again. With 20+ plugins it's pure duplication.

Two prompt nudges fix this for Qwen 3 1.7B (no new code, just better instructions to the model).

**Net: +9 / -4 lines, 1 file touched.**

## What changed

### 1. \`buildToolResultMessage\` suffix

The message we send to the LLM right after a tool returns now ends with:

> *"The user already sees the tool result above — keep final_answer brief (one or two sentences). Don't re-list items the tool already returned."*

(Previously just told it to call another tool or provide a final_answer, without the brevity nudge.)

### 2. System prompt RULES + EXAMPLE

The RULES section gained an explicit no-re-listing rule. The worked example was updated to show the desired brief style:

**Before:**
\`\`\`json
{"action": "final_answer", "content": "You have 2 plugins: Akismet (active) and Hello Dolly (inactive)."}
\`\`\`

**After:**
\`\`\`json
{"action": "final_answer", "content": "You have 2 plugins installed. One is active."}
\`\`\`

## Why this is prompt-engineering, not code

The LLM can still produce a verbose answer if it wants to — these are *nudges*, not guarantees. Small models like Qwen 3 1.7B respond well to:
- Explicit "don't do X" rules
- Worked examples that model the desired behavior

If a user explicitly asks "list each plugin one by one and tell me what each does," the LLM should still comply — we don't want to suppress legitimate verbose responses, just the redundant restatement that happens by default.

## Verification

- \`npm test\` — 96 passing (mock-LLM tests don't exercise prompt content directly, so no test changes)
- \`composer lint\` — clean
- \`npx wp-scripts lint-js\` — clean

This is the kind of fix that's best validated with the actual model. To test in Playground:
1. Load Qwen 3 1.7B
2. Send "list plugins" → \`ability_result\` renders the list
3. The text response should now be one sentence ("You have N plugins, M active") instead of a bulleted restatement

## Test plan
- [ ] Build check passes
- [ ] PHP lint passes
- [ ] JS lint passes
- [ ] Unit tests pass
- [ ] Manual: "list plugins" → final_answer is brief; "list users" → same; "show me the error log" → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)