### PR TITLE
fix: reactive Activate/Deactivate buttons in plugin-list (closes #179)

### DIFF
--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -568,7 +568,7 @@ const ChatContainer = ( {
 				} );
 			} );
 			if ( ! confirmed ) {
-				return;
+				return { success: false, cancelled: true };
 			}
 		}
 
@@ -589,11 +589,13 @@ const ChatContainer = ( {
 					? 'Action completed successfully.'
 					: 'Action failed.' );
 			sessionRef.current?.addAssistantMessage( msg );
+			return result;
 		} catch ( error ) {
 			log.error( 'Action execution error:', error );
 			sessionRef.current?.addAssistantMessage(
 				`Action failed: ${ error.message || 'Unknown error' }`
 			);
+			return { success: false, error: error.message };
 		}
 	}, [] );
 

--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -26,6 +26,70 @@ const MessageType = {
 };
 
 /**
+ * Pairs of abilities that are mutual inverses. After a successful click,
+ * the button flips to the inverse so its label reflects the new plugin
+ * state without needing a fresh plugin-list call.
+ */
+const INVERSE_ACTIONS = {
+	'wp-agentic-admin/plugin-activate': {
+		action: 'wp-agentic-admin/plugin-deactivate',
+		button_label: 'Deactivate',
+	},
+	'wp-agentic-admin/plugin-deactivate': {
+		action: 'wp-agentic-admin/plugin-activate',
+		button_label: 'Activate',
+	},
+};
+
+/**
+ * A single action button inside an ability_result message. Tracks its
+ * own loading state and, for known reversible pairs (plugin-activate ↔
+ * plugin-deactivate), flips after a successful click so the label and
+ * target action match the new state.
+ *
+ * @param {Object}   props          - Component props
+ * @param {Object}   props.action   - Action descriptor from the ability result
+ * @param {Function} props.onAction - Async (abilityId, args) → result
+ * @return {JSX.Element} The rendered button row
+ */
+const ActionButton = ( { action, onAction } ) => {
+	const [ override, setOverride ] = useState( null );
+	const [ loading, setLoading ] = useState( false );
+	const current = override ? { ...action, ...override } : action;
+
+	const handleClick = async () => {
+		setLoading( true );
+		try {
+			const result = await onAction( current.action, current.args );
+			if ( result && result.success !== false && ! result.error ) {
+				const inverse = INVERSE_ACTIONS[ current.action ];
+				if ( inverse ) {
+					setOverride( inverse );
+				}
+			}
+		} finally {
+			setLoading( false );
+		}
+	};
+
+	return (
+		<li className="agentic-action-list__item">
+			<span className="agentic-action-list__label">
+				{ current.label }
+			</span>
+			<button
+				className="agentic-action-list__button"
+				type="button"
+				onClick={ handleClick }
+				disabled={ loading }
+			>
+				{ loading ? '…' : current.button_label }
+			</button>
+		</li>
+	);
+};
+
+/**
  * Format timestamp for display
  *
  * @param {string} timestamp - ISO timestamp
@@ -492,28 +556,13 @@ const MessageItem = ( { message, onAction } ) => {
 						<div className="agentic-message__actions">
 							<ol className="agentic-action-list">
 								{ messageActions.map( ( action ) => (
-									<li
+									<ActionButton
 										key={ `${
 											action.action
 										}-${ JSON.stringify( action.args ) }` }
-										className="agentic-action-list__item"
-									>
-										<span className="agentic-action-list__label">
-											{ action.label }
-										</span>
-										<button
-											className="agentic-action-list__button"
-											type="button"
-											onClick={ () =>
-												onAction(
-													action.action,
-													action.args
-												)
-											}
-										>
-											{ action.button_label }
-										</button>
-									</li>
+										action={ action }
+										onAction={ onAction }
+									/>
 								) ) }
 							</ol>
 						</div>


### PR DESCRIPTION
## Summary

After clicking the Activate (or Deactivate) button on a plugin row in an \`ability_result\` message, the button label and its target action would stay frozen at the original state. So an Activate click left an "Activate" button on a now-active plugin — clicking it again hit "plugin is already active" instead of deactivating it.

**Net: +71 / -20 lines, 2 files touched.**

## What changed

### \`MessageItem.jsx\`

- Extracted the inline button JSX into a small \`<ActionButton>\` component
- Tracks its own \`loading\` (shows \`…\`, button disabled) and \`override\` state
- After a successful click, looks up the action in a new \`INVERSE_ACTIONS\` map:
  \`\`\`js
  const INVERSE_ACTIONS = {
      'wp-agentic-admin/plugin-activate':   { action: 'plugin-deactivate', button_label: 'Deactivate' },
      'wp-agentic-admin/plugin-deactivate': { action: 'plugin-activate',   button_label: 'Activate'   },
  };
  \`\`\`
- If the action has an inverse, the button flips to it (same plugin slug in \`args\`, just opposite ability id + label). Adding another reversible pair only needs a new entry in the map.

### \`ChatContainer.jsx\`

- \`handleAction\` now \`return\`s the action result (was \`return undefined\`). ActionButton reads \`result.success\` and only flips on real successes — a failed activation doesn't lie about the state.
- Cancelled confirmations now return \`{ success: false, cancelled: true }\` instead of undefined.

## Behavior matrix

| Initial button | Click outcome | After |
|---|---|---|
| Activate (plugin inactive) | success | Button becomes Deactivate |
| Deactivate (plugin active) | success | Button becomes Activate |
| Activate | failure (e.g. plugin not found) | Stays Activate |
| Any | user cancels confirmation | Stays as it was |
| Any | during run | Shows \`…\`, disabled |

## Verification

- \`npm test\` — 96 passing, unchanged
- \`npm run build\` — clean
- \`composer lint\` — clean
- \`npx wp-scripts lint-js\` — clean (2 pre-existing ChatContainer warnings are not introduced here)

## Manual test plan
- [ ] In the running Playground, send "list plugins"
- [ ] Click Activate on Akismet → label flips to Deactivate, click it → flips back to Activate
- [ ] Click Activate on a non-existent plugin (force-edit the action args) → label does NOT flip (error path)
- [ ] During click, see \`…\` placeholder on the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)