### PR TITLE
fix: defer 1.2 GB model preload until sidebar opens (closes #116)

### DIFF
--- a/src/extensions/admin-sidebar.js
+++ b/src/extensions/admin-sidebar.js
@@ -43,6 +43,15 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			const isOpen = container.classList.toggle( 'is-open' );
 			toggleBtn.classList.toggle( 'is-active', isOpen );
 			toggleLink.setAttribute( 'aria-expanded', String( isOpen ) );
+			// First open kicks the AdminSidebar React component out of
+			// its "wait" state so it can run the WebGPU check and start
+			// auto-loading the model. Subsequent opens are no-ops on
+			// React's side. See AdminSidebar.jsx.
+			if ( isOpen ) {
+				window.dispatchEvent(
+					new CustomEvent( 'wp-agentic-admin/sidebar-opened' )
+				);
+			}
 		} );
 	}
 

--- a/src/extensions/components/AdminSidebar.jsx
+++ b/src/extensions/components/AdminSidebar.jsx
@@ -50,10 +50,39 @@ const AdminSidebar = () => {
 	);
 	const [ initProgress, setInitProgress ] = useState( 5 );
 
+	// Most wp-admin page loads never open the sidebar. Defer the WebGPU
+	// check + 1.2 GB model load until the user actually opens it.
+	// Toggle in admin-sidebar.js dispatches 'wp-agentic-admin/sidebar-opened'
+	// on first open. Issue #116.
+	const [ hasOpened, setHasOpened ] = useState( () =>
+		typeof document !== 'undefined'
+			? document
+					.getElementById( 'wp-agentic-admin-sidebar' )
+					?.classList.contains( 'is-open' ) || false
+			: false
+	);
+
+	useEffect( () => {
+		if ( hasOpened ) {
+			return undefined;
+		}
+		const handler = () => setHasOpened( true );
+		window.addEventListener( 'wp-agentic-admin/sidebar-opened', handler );
+		return () =>
+			window.removeEventListener(
+				'wp-agentic-admin/sidebar-opened',
+				handler
+			);
+	}, [ hasOpened ] );
+
 	/**
-	 * Background WebGPU check and auto-load cached model on mount
+	 * Background WebGPU check and auto-load cached model — runs only
+	 * after the user opens the sidebar for the first time.
 	 */
 	useEffect( () => {
+		if ( ! hasOpened ) {
+			return;
+		}
 		const initializeApp = async () => {
 			try {
 				setInitMessage( 'Checking WebGPU support...' );
@@ -134,7 +163,7 @@ const AdminSidebar = () => {
 		};
 
 		initializeApp();
-	}, [] );
+	}, [ hasOpened ] );
 
 	const handleModelReady = useCallback( () => {
 		setModelReady( true );


### PR DESCRIPTION
## Summary

The admin-sidebar bundle loads on every wp-admin page (intentional — the toggle lives in the admin bar). But mounting \`AdminSidebar.jsx\` immediately ran \`initializeApp()\`, which fired the WebGPU check, looked up saved provider preferences, and started downloading / loading the ~1.2 GB Qwen 3 1.7B model into GPU memory.

For users who rarely open the sidebar (most page loads), that's a huge unwanted cost — both memory and the visible download progress bar in the admin bar.

**Net: +40 / -2 lines, 2 files touched.**

## Fix

React tree still mounts on every admin page (cheap — just a few KB of components), but the WebGPU/model initialization is gated on a \`hasOpened\` state that flips when the user clicks the toggle for the first time.

### Wiring

- \`admin-sidebar.js\` dispatches a custom \`wp-agentic-admin/sidebar-opened\` event when the toggle adds the \`is-open\` class. Subsequent toggles still fire the event (harmless — \`hasOpened\` is already true).
- \`AdminSidebar.jsx\` subscribes to the event, sets \`hasOpened\`, and a second useEffect that depends on \`hasOpened\` runs \`initializeApp\` when the flag flips.
- Initial \`hasOpened\` reads \`is-open\` from the DOM, so if some upstream change makes the sidebar start open, we still initialize on first render.
- Listener is removed once \`hasOpened\` becomes true (no leak).

## Memory impact

| Phase | Before | After |
|---|---|---|
| Page load (sidebar closed) | WebGPU check + ~1.2 GB model auto-load if cached | Just React mount (few KB) |
| First sidebar open | already done | WebGPU check + auto-load (same flow, deferred) |
| Subsequent opens | n/a | No-op on init path |

## Verification

- \`npm test\` — 96 passing, unchanged
- \`npm run build\` — clean
- \`composer lint\` — clean
- \`npx wp-scripts lint-js\` — clean

## Manual test plan
- [ ] Open Playground at \`/wp-admin\` (any page that's NOT the plugin's own admin page)
- [ ] Confirm: no model loading happens — ModelStatus widget on the admin bar should be idle / not progress
- [ ] Click the superhero icon to open the sidebar
- [ ] Confirm: WebGPU check fires, model loads (you'll see the progress bar / status)
- [ ] Close + reopen sidebar — no second load triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)