### PR TITLE
feat: structured FileView component for read-file output

### DIFF
--- a/src/extensions/abilities/read-file.js
+++ b/src/extensions/abilities/read-file.js
@@ -225,6 +225,32 @@ export function registerReadFile() {
 		},
 
 		/**
+		 * Structured payload for the FileView component.
+		 *
+		 * Returned when the chat should render a dedicated <FileView> instead
+		 * of markdown (cleaner UX, avoids paragraph-only renderer collapsing
+		 * the file into a wall of <p> tags). Falls back to summarize() for
+		 * the error branch and for Copy All serialization.
+		 *
+		 * @param {Object} result - Result from PHP.
+		 * @return {Object|null} Structured payload or null when not applicable.
+		 */
+		renderDisplay: ( result ) => {
+			if ( ! result?.success ) {
+				return null;
+			}
+			return {
+				component: 'file',
+				filePath: result.file_path,
+				content: result.content,
+				language: detectLanguage( result.file_path || '' ),
+				totalLines: result.total_lines || 0,
+				linesReturned: result.lines_returned || 0,
+				wasRedacted: !! result.was_redacted,
+			};
+		},
+
+		/**
 		 * Plain-English interpretation for the LLM.
 		 *
 		 * @param {Object} result      - Result from PHP.

--- a/src/extensions/components/ChatContainer.jsx
+++ b/src/extensions/components/ChatContainer.jsx
@@ -335,6 +335,15 @@ const ChatContainer = ( {
 						error: msg.meta?.error,
 						timestamp: msg.timestamp,
 					};
+				case MessageType.FILE_VIEW:
+					return {
+						id: msg.id,
+						type: 'file_view',
+						content: msg.content,
+						file: msg.meta?.file,
+						meta: msg.meta,
+						timestamp: msg.timestamp,
+					};
 				case MessageType.SYSTEM:
 				default:
 					return {
@@ -521,6 +530,26 @@ const ChatContainer = ( {
 								: msg.result
 						}`;
 						break;
+					case 'file_view': {
+						prefix = 'Assistant:';
+						const f = msg.file || {};
+						const fence = '```';
+						const range =
+							f.totalLines > 0 &&
+							f.linesReturned > 0 &&
+							f.totalLines !== f.linesReturned
+								? ` (showing ${ f.linesReturned } of ${ f.totalLines } lines)`
+								: '';
+						const redacted = f.wasRedacted
+							? '\n\n> Sensitive values (credentials, keys, salts) have been redacted.'
+							: '';
+						content = `**\`${
+							f.filePath || ''
+						}\`**${ range }\n\n${ fence }${ f.language || '' }\n${
+							f.content || ''
+						}\n${ fence }${ redacted }`;
+						break;
+					}
 					case 'error':
 						prefix = 'Error:';
 						content = msg.content || msg.error;

--- a/src/extensions/components/FileView.jsx
+++ b/src/extensions/components/FileView.jsx
@@ -1,0 +1,80 @@
+/**
+ * FileView component
+ *
+ * Renders file contents from abilities like read-file as a structured block
+ * (header pill with path, line range, redacted badge, copy-raw button) +
+ * a monospace code body. Bypasses the chat's paragraph-only markdown renderer.
+ */
+
+import { useState } from '@wordpress/element';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger( 'FileView' );
+
+const FileView = ( { file } ) => {
+	const [ copied, setCopied ] = useState( false );
+
+	if ( ! file || typeof file.content !== 'string' ) {
+		return null;
+	}
+
+	const {
+		filePath = '',
+		content = '',
+		language = '',
+		totalLines = 0,
+		linesReturned = 0,
+		wasRedacted = false,
+	} = file;
+
+	const showRange =
+		totalLines > 0 && linesReturned > 0 && totalLines !== linesReturned;
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText( content );
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 1500 );
+		} catch ( err ) {
+			log.error( 'Failed to copy file content:', err );
+		}
+	};
+
+	return (
+		<div className="agentic-file-view">
+			<div className="agentic-file-view__header">
+				<code className="agentic-file-view__path">{ filePath }</code>
+				{ showRange && (
+					<span className="agentic-file-view__meta">
+						{ linesReturned } / { totalLines } lines
+					</span>
+				) }
+				{ wasRedacted && (
+					<span
+						className="agentic-file-view__badge"
+						title="Sensitive values (credentials, keys, salts) were replaced server-side."
+					>
+						redacted
+					</span>
+				) }
+				<button
+					type="button"
+					className={ `agentic-file-view__copy${
+						copied ? ' agentic-file-view__copy--copied' : ''
+					}` }
+					onClick={ handleCopy }
+					title={ copied ? 'Copied!' : 'Copy file content' }
+				>
+					{ copied ? 'Copied' : 'Copy' }
+				</button>
+			</div>
+			<pre className="agentic-file-view__body">
+				<code className={ language ? `language-${ language }` : '' }>
+					{ content }
+				</code>
+			</pre>
+		</div>
+	);
+};
+
+export default FileView;

--- a/src/extensions/components/MessageItem.jsx
+++ b/src/extensions/components/MessageItem.jsx
@@ -8,6 +8,7 @@
 
 import { useState } from '@wordpress/element';
 import AbilityPicker from './AbilityPicker';
+import FileView from './FileView';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger( 'MessageItem' );
@@ -23,6 +24,7 @@ const MessageType = {
 	ABILITY_REQUEST: 'ability_request',
 	ABILITY_RESULT: 'ability_result',
 	ERROR: 'error',
+	FILE_VIEW: 'file_view',
 };
 
 /**
@@ -765,6 +767,27 @@ const MessageItem = ( { message, onAction } ) => {
 							<pre>{ formatAbilityResult( meta?.result ) }</pre>
 						</div>
 					) }
+				</div>
+			</div>
+		);
+	}
+
+	// File view — structured file content (read-file and similar)
+	if ( type === MessageType.FILE_VIEW ) {
+		const file = message.meta?.file || message.file;
+		return (
+			<div className="agentic-message agentic-message--assistant">
+				<div className="agentic-timeline" aria-hidden="true">
+					<div className="agentic-timeline__line" />
+					<div className="agentic-timeline__dot" />
+				</div>
+				<div className="agentic-message__content">
+					<FileView file={ file } />
+					<div className="agentic-message__footer">
+						<div className="agentic-message__time">
+							{ formatTime( timestamp ) }
+						</div>
+					</div>
 				</div>
 			</div>
 		);

--- a/src/extensions/services/agentic-abilities-api.js
+++ b/src/extensions/services/agentic-abilities-api.js
@@ -42,6 +42,10 @@ const log = createLogger( 'AgenticAbilitiesAPI' );
  * @param {string[]} [config.keywords]                   - Keywords that trigger this ability in workflow detection.
  * @param {string}   [config.initialMessage]             - Message shown while ability executes.
  * @param {Function} [config.summarize]                  - Function to generate human-readable summary from result (for users).
+ * @param {Function} [config.renderDisplay]              - Optional. Returns a structured payload `{ component, ...props }`
+ *                                                       that the chat renders via a dedicated React component instead of markdown.
+ *                                                       Only consulted when `preferSummarize` is also true.
+ *                                                       Currently supported component: `'file'` (see read-file ability).
  * @param {Function} [config.interpretResult]            - Function to generate plain-English interpretation from result (for LLM).
  *                                                       Receives (result, userMessage). Helps small models correctly understand
  *                                                       tool output, especially empty or negative results.

--- a/src/extensions/services/chat-orchestrator.js
+++ b/src/extensions/services/chat-orchestrator.js
@@ -451,19 +451,48 @@ class ChatOrchestrator {
 
 		// For tools that prefer to display their own summary (e.g. read-file),
 		// use tool.summarize() directly instead of the LLM's final_answer.
+		// If the tool also provides renderDisplay(), push a structured message
+		// (e.g. file_view) and short-circuit — the dedicated component handles
+		// the UI, no streaming or assistant message needed.
 		let displayAnswer = result.finalAnswer;
+		let lastTool = null;
+		let lastObservation = null;
 		if ( result.toolsUsed.length === 1 ) {
 			const lastToolId = result.toolsUsed[ 0 ];
 			// Apply namespace fallback: LLM sometimes drops the "wp-agentic-admin/" prefix.
-			const lastTool =
+			lastTool =
 				toolRegistry.get( lastToolId ) ||
 				toolRegistry.get( `wp-agentic-admin/${ lastToolId }` );
-			const lastObservation = result.observations[ 0 ];
+			lastObservation = result.observations[ 0 ];
 			if ( lastTool?.preferSummarize && lastObservation?.result?.data ) {
 				displayAnswer = lastTool.summarize(
 					lastObservation.result.data,
 					userMessage
 				);
+			}
+		}
+
+		// Structured display path (e.g. FileView).
+		if (
+			lastTool?.preferSummarize &&
+			typeof lastTool.renderDisplay === 'function' &&
+			lastObservation?.result?.data
+		) {
+			const payload = lastTool.renderDisplay(
+				lastObservation.result.data,
+				userMessage
+			);
+			if ( payload?.component === 'file' ) {
+				this.callbacks.onStreamStart();
+				this.session.addFileViewMessage(
+					{ ...payload, fallbackMarkdown: displayAnswer },
+					this.getUsageStatsMeta()
+				);
+				this.callbacks.onStreamEnd( '' );
+				log.info(
+					`ReAct completed (file_view): ${ result.iterations } iterations, ${ result.toolsUsed.length } tools used`
+				);
+				return { success: result.success, result };
 			}
 		}
 

--- a/src/extensions/services/chat-session.js
+++ b/src/extensions/services/chat-session.js
@@ -21,6 +21,7 @@ export const MessageType = {
 	TOOL_RESULT: 'tool_result',
 	THINKING: 'thinking',
 	ERROR: 'error',
+	FILE_VIEW: 'file_view',
 };
 
 /**
@@ -172,6 +173,24 @@ class ChatSession {
 	addThinkingMessage( content ) {
 		return this.addMessage(
 			this.createMessage( MessageType.THINKING, content )
+		);
+	}
+
+	/**
+	 * Add a file view message (structured file display)
+	 *
+	 * @param {Object} payload - File payload (filePath, content, language,
+	 *                         totalLines, linesReturned, wasRedacted,
+	 *                         fallbackMarkdown).
+	 * @param {Object} [meta]  - Extra metadata (e.g. tps stats).
+	 * @return {Object} The added message
+	 */
+	addFileViewMessage( payload, meta = {} ) {
+		return this.addMessage(
+			this.createMessage( MessageType.FILE_VIEW, payload.filePath, {
+				...meta,
+				file: payload,
+			} )
 		);
 	}
 

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -3506,3 +3506,94 @@
 		margin-top: 8px;
 	}
 }
+
+// Structured file view (read-file ability)
+.agentic-file-view {
+	border: 1px solid #e2e4e7;
+	border-radius: 6px;
+	background: #fff;
+	overflow: hidden;
+	margin: 0;
+
+	&__header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 10px;
+		background: #f6f7f7;
+		border-bottom: 1px solid #e2e4e7;
+		flex-wrap: wrap;
+	}
+
+	&__path {
+		font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+		font-size: 12px;
+		color: #1d2327;
+		background: rgba(0, 0, 0, 0.06);
+		border: 1px solid rgba(0, 0, 0, 0.08);
+		border-radius: 3px;
+		padding: 2px 6px;
+		word-break: break-all;
+	}
+
+	&__meta {
+		font-size: 12px;
+		color: #646970;
+	}
+
+	&__badge {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: #8a4b00;
+		background: #fcf0d4;
+		border: 1px solid #f0c674;
+		border-radius: 3px;
+		padding: 1px 6px;
+		cursor: help;
+	}
+
+	&__copy {
+		margin-left: auto;
+		font-size: 12px;
+		padding: 3px 10px;
+		border: 1px solid #c3c4c7;
+		background: #fff;
+		border-radius: 3px;
+		cursor: pointer;
+		color: #1d2327;
+
+		&:hover {
+			background: #f0f0f1;
+		}
+
+		&--copied {
+			color: #007017;
+			border-color: #00a32a;
+		}
+	}
+
+	&__body {
+		margin: 0;
+		padding: 12px 14px;
+		font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+		font-size: 12.5px;
+		line-height: 1.55;
+		color: #1d2327;
+		background: #fff;
+		overflow-x: auto;
+		max-height: 480px;
+		white-space: pre;
+		tab-size: 4;
+
+		code {
+			background: transparent;
+			border: none;
+			padding: 0;
+			font: inherit;
+			color: inherit;
+			white-space: pre;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- New `<FileView>` component renders file content in a framed block (path pill, line range, redacted badge, copy-raw button) + monospace body — replacing markdown-fenced output that was breaking on the paragraph-only renderer.
- New opt-in `renderDisplay(result)` callback on the abilities API. When a `preferSummarize` tool returns `{ component: 'file', ... }`, the orchestrator pushes a `FILE_VIEW` message and short-circuits streaming.
- Copy All transcript serializes `file_view` back to fenced markdown, so copied output stays portable.

Closes the read-file display bug surfaced during v0.11 testing (file content rendered as a wall of `<p>` tags with literal backticks visible).

## Test plan

- [x] `npm run build` — clean
- [x] `npx wp-scripts lint-js` — no new errors
- [x] Unit tests (96 pass, 3 skipped)
- [ ] Manual: \`show me wp-content/themes/twentytwentyfive/functions.php\` → confirm structured block renders, copy-raw works, redacted badge shows for \`wp-config.php\`
- [ ] Manual: copy full conversation → confirm \`file_view\` round-trips through Copy All as fenced markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)