### PR TITLE
fix: bypass ReAct for knowledge-base intent (book button) — #209 Fix 1

### DIFF
--- a/includes/class-admin-bar.php
+++ b/includes/class-admin-bar.php
@@ -88,7 +88,7 @@ class Admin_Bar {
 		}
 
 		// Skip on the plugin's own settings page — the full app is already loaded.
-		if ( 'toplevel_page_wp-agentic-admin' === $hook ) {
+		if ( 'toplevel_page_agentic-admin' === $hook ) {
 			return;
 		}
 
@@ -145,7 +145,7 @@ class Admin_Bar {
 
 		// Don't render on the plugin page — the full app handles it.
 		$screen = get_current_screen();
-		if ( $screen && 'toplevel_page_wp-agentic-admin' === $screen->id ) {
+		if ( $screen && 'toplevel_page_agentic-admin' === $screen->id ) {
 			return;
 		}
 		?>

--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -72,7 +72,7 @@ class Admin_Page {
 	 */
 	public function enqueue_scripts( string $hook ): void {
 		// Only load on our admin page.
-		if ( 'toplevel_page_wp-agentic-admin' !== $hook ) {
+		if ( 'toplevel_page_agentic-admin' !== $hook ) {
 			return;
 		}
 

--- a/src/extensions/App.jsx
+++ b/src/extensions/App.jsx
@@ -103,7 +103,9 @@ const App = () => {
 				// Check if local model is cached
 				setInitMessage( 'Checking cache...' );
 				setInitProgress( 30 );
-				const isCached = await modelLoader.isModelCached();
+				const savedModel =
+					localStorage.getItem( 'agentic_admin_model' ) || undefined;
+				const isCached = await modelLoader.isModelCached( savedModel );
 
 				if ( isCached ) {
 					log.info( 'Model is cached, auto-loading...' );
@@ -111,7 +113,7 @@ const App = () => {
 					setInitMessage( 'Loading from cache...' );
 					setInitProgress( 35 );
 					try {
-						await modelLoader.load();
+						await modelLoader.load( savedModel );
 						setModelReady( true );
 					} catch ( loadErr ) {
 						log.error( 'Auto-load failed:', loadErr );

--- a/src/extensions/components/AdminSidebar.jsx
+++ b/src/extensions/components/AdminSidebar.jsx
@@ -141,7 +141,9 @@ const AdminSidebar = () => {
 				// Check if local model is cached
 				setInitMessage( 'Checking cache...' );
 				setInitProgress( 30 );
-				const isCached = await modelLoader.isModelCached();
+				const savedModel =
+					localStorage.getItem( 'agentic_admin_model' ) || undefined;
+				const isCached = await modelLoader.isModelCached( savedModel );
 
 				if ( isCached ) {
 					log.info( 'Model is cached, auto-loading...' );
@@ -149,7 +151,7 @@ const AdminSidebar = () => {
 					setInitMessage( 'Loading from cache...' );
 					setInitProgress( 35 );
 					try {
-						await modelLoader.load();
+						await modelLoader.load( savedModel );
 						setModelReady( true );
 					} catch ( loadErr ) {
 						log.error( 'Auto-load failed:', loadErr );

--- a/src/extensions/components/EditorSidebar.jsx
+++ b/src/extensions/components/EditorSidebar.jsx
@@ -69,7 +69,9 @@ const EditorSidebar = () => {
 
 				setInitMessage( 'Checking cache...' );
 				setInitProgress( 30 );
-				const isCached = await modelLoader.isModelCached();
+				const savedModel =
+					localStorage.getItem( 'agentic_admin_model' ) || undefined;
+				const isCached = await modelLoader.isModelCached( savedModel );
 
 				if ( isCached ) {
 					log.info( 'Model is cached, auto-loading...' );
@@ -77,7 +79,7 @@ const EditorSidebar = () => {
 					setInitMessage( 'Loading from cache...' );
 					setInitProgress( 35 );
 					try {
-						await modelLoader.load();
+						await modelLoader.load( savedModel );
 						setModelReady( true );
 					} catch ( loadErr ) {
 						log.error( 'Auto-load failed:', loadErr );

--- a/src/extensions/services/chat-orchestrator.js
+++ b/src/extensions/services/chat-orchestrator.js
@@ -18,6 +18,7 @@ import workflowRegistry from './workflow-registry';
 import workflowOrchestrator from './workflow-orchestrator';
 import ReactAgent from './react-agent';
 import messageRouter from './message-router';
+import vectorStore from './vector-store';
 import { executeAbility } from './agentic-abilities-api';
 import { createLogger } from '../utils/logger';
 
@@ -289,6 +290,14 @@ class ChatOrchestrator {
 					userMessage,
 					route.workflow
 				);
+			}
+
+			// Knowledge-base intent (book button) bypasses ReAct entirely.
+			// The user explicitly asked for a docs answer — fishing for tools
+			// produces hallucinated tool calls on small models (issue #209).
+			if ( options.docSearch ) {
+				log.info( 'Routing to doc-search (RAG, no tools)' );
+				return await this.processWithDocSearch( userMessage );
 			}
 
 			// All non-workflow messages go through ReAct.
@@ -743,6 +752,174 @@ Explain what went wrong and suggest what the user might try next.`;
 			const messageWithContext = `• ${ toolName }\n${ fallbackSummary }`;
 			this.session.addAssistantMessage( messageWithContext );
 			this.callbacks.onStreamEnd( fallbackSummary );
+		}
+	}
+
+	/**
+	 * Process message via knowledge-base RAG (no tools).
+	 *
+	 * Invoked when the user enabled the docs/book button. Skips ReAct
+	 * entirely, runs a vector search over the indexed knowledge base, and
+	 * streams an LLM answer grounded in the retrieved snippets. If the
+	 * index is empty, falls back to a conversational LLM answer without
+	 * RAG context — but still no tools.
+	 *
+	 * @param {string} userMessage - User's message
+	 * @return {Promise<Object>} Result with success status.
+	 */
+	async processWithDocSearch( userMessage ) {
+		if ( ! this.isLLMReady() ) {
+			this.session.addAssistantMessage(
+				'The AI model is not loaded yet. Please load the model first.'
+			);
+			return { success: false, error: 'Model not loaded' };
+		}
+
+		// Retrieve RAG context (best-effort; failure falls through to a
+		// context-less conversational answer).
+		let ragContext = '';
+		let ragHits = 0;
+		try {
+			await vectorStore.init();
+			if ( vectorStore.isReady() ) {
+				const results = await vectorStore.search( userMessage, 3 );
+				if ( results.length > 0 ) {
+					ragHits = results.length;
+					const CHAR_BUDGET = 2500;
+					let budget = CHAR_BUDGET;
+					const parts = [ '[Knowledge base context]' ];
+					for ( const r of results ) {
+						const snippet = r.content.slice(
+							0,
+							Math.min( r.content.length, budget )
+						);
+						parts.push( `${ r.path }:\n${ snippet }` );
+						budget -= snippet.length + r.path.length + 3;
+						if ( budget <= 0 ) {
+							break;
+						}
+					}
+					parts.push( '[End context]' );
+					ragContext = parts.join( '\n\n' );
+				}
+			}
+		} catch ( err ) {
+			log.warn( 'Doc-search vector lookup failed:', err.message );
+		}
+
+		log.info(
+			`Doc-search: ${ ragHits } hit(s), context ${ ragContext.length } chars`
+		);
+
+		const systemPrompt = ragContext
+			? "You are a WordPress assistant answering from the user's indexed knowledge base. Use the provided context to answer accurately. If the context doesn't cover the question, say so plainly — do not invent details."
+			: 'You are a helpful WordPress assistant. The user has the knowledge-base mode on, but no indexed content matched their question. Answer from general WordPress knowledge and tell them no local docs were found.';
+
+		// Honor the user's thinking-mode setting. Qwen 3 occasionally ignores
+		// /nothink and emits <think> anyway, so we also strip blocks below.
+		const thinkingPrefs = ChatOrchestrator.getThinkingPreferences();
+		const suppressThinking = !! thinkingPrefs.disableThinkingBeforeTool;
+		const nothinkSuffix = suppressThinking ? '\n\n/nothink' : '';
+
+		const userPrompt =
+			( ragContext
+				? `${ ragContext }\n\nQuestion: ${ userMessage }`
+				: userMessage ) + nothinkSuffix;
+
+		const engine = modelLoader.getEngine();
+		const messages = [
+			{ role: 'system', content: systemPrompt },
+			{ role: 'user', content: userPrompt },
+		];
+
+		this.callbacks.onStreamStart();
+		let fullResponse = '';
+		let visibleResponse = '';
+		let inThinkBlock = false;
+		let thinkAnnounced = false;
+
+		const stripThink = ( text ) =>
+			text.replace( /<think>[\s\S]*?<\/think>\s*/g, '' );
+
+		try {
+			const stream = await engine.chat.completions.create( {
+				messages,
+				temperature: 0.3,
+				max_tokens: this.llmOptions.maxTokens,
+				stream: true,
+				stream_options: { include_usage: true },
+				stop: [ 'User:', 'USER:', '\n\nUser' ],
+			} );
+
+			for await ( const chunk of stream ) {
+				if ( this.currentAbortController?.signal.aborted ) {
+					break;
+				}
+				const delta = chunk.choices[ 0 ]?.delta?.content || '';
+				fullResponse += delta;
+
+				// Detect and route <think> tokens.
+				const hasOpen = fullResponse.includes( '<think>' );
+				const hasClose = fullResponse.includes( '</think>' );
+
+				if ( hasOpen && ! hasClose ) {
+					if ( ! inThinkBlock ) {
+						inThinkBlock = true;
+						if ( ! suppressThinking ) {
+							thinkAnnounced = true;
+							this.callbacks.onThinkingStart?.();
+						}
+					}
+					if ( ! suppressThinking ) {
+						const thinkStart =
+							fullResponse.indexOf( '<think>' ) + 7;
+						const thinkContent = fullResponse
+							.substring( thinkStart )
+							.trim();
+						this.callbacks.onThinkingChunk?.( delta, thinkContent );
+					}
+					// Skip onStreamChunk while inside a think block.
+					continue;
+				}
+
+				if ( inThinkBlock && hasClose ) {
+					inThinkBlock = false;
+					const match = fullResponse.match(
+						/<think>([\s\S]*?)<\/think>/
+					);
+					const thinkContent = match ? match[ 1 ].trim() : '';
+					if ( ! suppressThinking ) {
+						this.callbacks.onThinkingEnd?.( thinkContent || null );
+					}
+				}
+
+				visibleResponse = stripThink( fullResponse ).trimStart();
+				this.callbacks.onStreamChunk( delta, visibleResponse );
+
+				if ( chunk.usage ) {
+					modelLoader.updateUsageStats( chunk.usage );
+				}
+			}
+
+			// Edge case: model produced <think> without closing tag.
+			if ( inThinkBlock && thinkAnnounced ) {
+				this.callbacks.onThinkingEnd?.( null );
+			}
+
+			const finalText = stripThink( fullResponse ).trim();
+			this.session.addAssistantMessage(
+				finalText,
+				this.getUsageStatsMeta()
+			);
+			this.callbacks.onStreamEnd( finalText );
+			return { success: true };
+		} catch ( error ) {
+			log.error( 'Doc-search LLM stream failed:', error );
+			const fallback =
+				"I couldn't complete the knowledge-base answer. Try again, or toggle the knowledge-base button off to use tools.";
+			this.session.addAssistantMessage( fallback );
+			this.callbacks.onStreamEnd( fallback );
+			return { success: false, error: error.message };
 		}
 	}
 


### PR DESCRIPTION
## Summary

- New \`processWithDocSearch\` path: when the user has the docs/book toggle on, skip the ReAct tool-selection loop entirely. Runs a vector-store lookup, builds a context-augmented prompt, and streams a direct LLM answer with no tool calls.
- Honors the user's \"disable thinking before tool\" setting (\`/nothink\` flag); defensively strips any \`<think>\` blocks Qwen emits anyway.
- Falls back to a context-less conversational answer (still no tools) when the index is empty or the vector lookup fails — never silently re-routes into ReAct.

## Why

Qwen 3 1.7B (the default model, prompt-based JSON mode) hallucinates tool calls when no tool clearly matches. With the book button on, the user has stated their intent — fishing for tools is wrong.

**Repro (before):** book button on + \"Whats the hook that allows me to inject content in the footer?\" → invokes \`role-capabilities-check\` or \`rewrite-list\`.

**After:** routes to doc-search, no tool call, clean conversational answer.

Partially addresses #209 (Fix 1 of 3). Fix 2 (post-hoc tool validation) and Fix 3 (soften read-file priming) tracked in the same umbrella.

## Notes

- The commit list shows the v0.11 admin-page-hook fix (\`2672eef\`) because \`dev\` is currently missing the v0.11 release commits. That commit will resolve as a no-op once \`release/v0-11-prep\` merges back into \`dev\`.

## Test plan

- [x] Build clean (\`npm run build\`)
- [x] Lint clean (\`npx wp-scripts lint-js\`)
- [x] Unit tests pass (96/99, 3 skipped — unchanged from main)
- [x] Manual: book button on + knowledge question → no tool call, clean answer
- [x] Manual: thinking-mode toggle respected (no leaked \`<think>\` content with it off)
- [ ] Manual: book button on + workflow-keyword query → workflow still wins (\"flush cache\", etc.)
- [ ] Manual: book button off → existing ReAct path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)