### PR TITLE
fix: ReAct reliability pass (structured output, preferSummarize, stale docs)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,8 +58,8 @@ Update ALL of these:
 
 ## Constraints
 
-- **Context window**: 4096 tokens (1.7B) / 32768 (7B). Tool descriptions sent every request — keep them concise.
-- **Tool results truncated** to 2000 chars before sending to LLM.
+- **Context window**: 8192 tokens (1.7B) / 32768 (7B), 8192 default. Source of truth is `MODEL_CONTEXT_SIZES` in `model-loader.js`; override per model via the `agentic_admin_context_size` localStorage key. Tool descriptions sent every request — keep them concise.
+- **Tool results truncated** to `maxToolResultLength` (3000 chars) before sending to LLM. Abilities with `preferSummarize: true` bypass this entirely.
 - **Max 10 ReAct iterations**. Repeated tool call detection stops oscillation.
 - **Service Worker** (`sw.js`) must be self-contained — no code splitting, no dynamic imports.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,13 +319,14 @@ The 1.7B model is recommended for most users — it loads faster, uses less VRAM
 1. **JSON formatting** - 7B models produce valid JSON consistently (100% parse success with Qwen2.5-7B). Robust parsing still handles edge cases: try native `JSON.parse` first, then fall back to quote sanitization.
 2. **Goal efficiency** - Qwen2.5-7B calls exactly 1 tool for single-goal tasks (no over-shooting).
 3. **Multi-step reasoning** - 100% success on conditional logic and diagnose-then-fix chains.
-4. **Context limits** - 4096 token context window configured (models support up to 32K).
+4. **Context limits** - Context window is set per model in `MODEL_CONTEXT_SIZES` (`model-loader.js`): 8192 tokens for Qwen3 1.7B, 32768 for Qwen2.5 7B, 8192 default fallback. A per-model override can be stored in the `agentic_admin_context_size` localStorage key and is resolved by `ModelLoader.getEffectiveContextSize()`.
 
 ### Safety Mechanisms
 
 - Repeated call detection (same tool twice = stop)
 - Max 10 iterations
-- Tool result truncation (2000 chars max in prompt-based mode)
+- Tool result truncation (`maxToolResultLength`, 3000 chars, in prompt-based mode)
+- Schema-constrained JSON for the ReAct action envelope when thinking is disabled (see below)
 - Context window overflow handling
 - JSON envelope unwrapping (prevents raw `{"action": "final_answer", ...}` leaking to user)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -326,7 +326,7 @@ The 1.7B model is recommended for most users — it loads faster, uses less VRAM
 - Repeated call detection (same tool twice = stop)
 - Max 10 iterations
 - Tool result truncation (`maxToolResultLength`, 3000 chars, in prompt-based mode)
-- Schema-constrained JSON for the ReAct action envelope when thinking is disabled (see below)
+- Schema-constrained JSON for the ReAct action envelope (`structuredOutput`, **off by default** — it breaks thinking models; see `REACT_ACTION_SCHEMA` in `react-agent.js`)
 - Context window overflow handling
 - JSON envelope unwrapping (prevents raw `{"action": "final_answer", ...}` leaking to user)
 

--- a/src/extensions/abilities/core-environment-info.js
+++ b/src/extensions/abilities/core-environment-info.js
@@ -71,18 +71,16 @@ export function registerCoreEnvironmentInfo() {
 				const envDisplay =
 					result.environment.charAt( 0 ).toUpperCase() +
 					result.environment.slice( 1 );
-				lines.push( ` * * Environment: * * ${ envDisplay }` );
+				lines.push( `**Environment:** ${ envDisplay }` );
 			}
 			if ( result.wp_version ) {
-				lines.push(
-					` * * WordPress Version: * * ${ result.wp_version }`
-				);
+				lines.push( `**WordPress Version:** ${ result.wp_version }` );
 			}
 			if ( result.php_version ) {
-				lines.push( ` * * PHP Version: * * ${ result.php_version }` );
+				lines.push( `**PHP Version:** ${ result.php_version }` );
 			}
 			if ( result.db_server_info ) {
-				lines.push( ` * * Database: * * ${ result.db_server_info }` );
+				lines.push( `**Database:** ${ result.db_server_info }` );
 			}
 
 			if ( lines.length === 0 ) {

--- a/src/extensions/abilities/core-site-info.js
+++ b/src/extensions/abilities/core-site-info.js
@@ -110,25 +110,25 @@ export function registerCoreSiteInfo() {
 			const lines = [];
 
 			if ( result.name ) {
-				lines.push( ` * * Site Name: * * ${ result.name }` );
+				lines.push( `**Site Name:** ${ result.name }` );
 			}
 			if ( result.description ) {
-				lines.push( ` * * Tagline: * * ${ result.description }` );
+				lines.push( `**Tagline:** ${ result.description }` );
 			}
 			if ( result.url ) {
-				lines.push( ` * * Site URL: * * ${ result.url }` );
+				lines.push( `**Site URL:** ${ result.url }` );
 			}
 			if ( result.version ) {
-				lines.push( ` * * WordPress Version: * * ${ result.version }` );
+				lines.push( `**WordPress Version:** ${ result.version }` );
 			}
 			if ( result.language ) {
-				lines.push( ` * * Language: * * ${ result.language }` );
+				lines.push( `**Language:** ${ result.language }` );
 			}
 			if ( result.admin_email ) {
-				lines.push( ` * * Admin Email: * * ${ result.admin_email }` );
+				lines.push( `**Admin Email:** ${ result.admin_email }` );
 			}
 			if ( result.charset ) {
-				lines.push( ` * * Charset: * * ${ result.charset }` );
+				lines.push( `**Charset:** ${ result.charset }` );
 			}
 
 			if ( lines.length === 0 ) {

--- a/src/extensions/abilities/file-scan.js
+++ b/src/extensions/abilities/file-scan.js
@@ -159,6 +159,11 @@ export function registerFileScan() {
 
 		// Read-only — no confirmation needed.
 		requiresConfirmation: false,
+
+		// summarize() lists every plugin, theme and mu-plugin scanned plus the
+		// findings. That payload routinely exceeds maxToolResultLength, and a
+		// truncated security scan is worse than none.
+		preferSummarize: true,
 	} );
 }
 

--- a/src/extensions/abilities/plugin-list.js
+++ b/src/extensions/abilities/plugin-list.js
@@ -98,12 +98,12 @@ export function registerPluginList() {
 			} are inactive.\n\n`;
 
 			if ( activePlugins.length > 0 ) {
-				summary += ` * * Active plugins: * * ${ activePlugins.join(
+				summary += `**Active plugins:** ${ activePlugins.join(
 					', '
 				) }\n\n`;
 			}
 			if ( inactivePlugins.length > 0 ) {
-				summary += ` * * Inactive plugins: * * ${ inactivePlugins.join(
+				summary += `**Inactive plugins:** ${ inactivePlugins.join(
 					', '
 				) }`;
 			}

--- a/src/extensions/abilities/security-scan.js
+++ b/src/extensions/abilities/security-scan.js
@@ -95,6 +95,11 @@ export function registerSecurityScan() {
 		},
 
 		requiresConfirmation: false,
+
+		// summarize() renders the full pass/fail report grouped by severity.
+		// Re-rendering it through the LLM risks dropping findings when the
+		// payload exceeds maxToolResultLength.
+		preferSummarize: true,
 	} );
 }
 

--- a/src/extensions/abilities/site-health.js
+++ b/src/extensions/abilities/site-health.js
@@ -85,15 +85,15 @@ export function registerSiteHealth() {
 			// This creates a more natural conversational experience.
 
 			if ( msg.includes( 'php' ) ) {
-				return `Your PHP version is * * ${
+				return `Your PHP version is **${
 					result.php_version || 'Unknown'
-				} * * .`;
+				}**.`;
 			}
 
 			if ( msg.includes( 'wordpress' ) || msg.includes( 'wp version' ) ) {
-				return `You're running * * WordPress ${
+				return `You're running **WordPress ${
 					result.wordpress_version || 'Unknown'
-				} * * .`;
+				}**.`;
 			}
 
 			if (
@@ -101,9 +101,9 @@ export function registerSiteHealth() {
 				msg.includes( 'database' ) ||
 				msg.includes( 'db version' )
 			) {
-				return `Your database is * * MySQL ${
+				return `Your database is **MySQL ${
 					result.mysql_version || 'Unknown'
-				} * * .`;
+				}**.`;
 			}
 
 			if (
@@ -111,22 +111,22 @@ export function registerSiteHealth() {
 				msg.includes( 'nginx' ) ||
 				msg.includes( 'apache' )
 			) {
-				return `Your server is * * ${
+				return `Your server is **${
 					result.server_software || 'Unknown'
-				} * * .`;
+				}**.`;
 			}
 
 			if ( msg.includes( 'theme' ) ) {
 				// Handle nested object safely with optional chaining.
-				return `Your active theme is * * ${
+				return `Your active theme is **${
 					result.active_theme?.name || 'Unknown'
-				} * * (version ${ result.active_theme?.version || '?' }).`;
+				}** (version ${ result.active_theme?.version || '?' }).`;
 			}
 
 			if ( msg.includes( 'memory' ) ) {
-				return `Your PHP memory limit is * * ${
+				return `Your PHP memory limit is **${
 					result.memory_limit || 'Unknown'
-				} * * .`;
+				}**.`;
 			}
 
 			if (
@@ -134,27 +134,23 @@ export function registerSiteHealth() {
 				msg.includes( 'site address' ) ||
 				msg.includes( 'home' )
 			) {
-				return `Your site URL is * * ${
+				return `Your site URL is **${
 					result.site_url || result.home_url || 'Unknown'
-				} * * .`;
+				}**.`;
 			}
 
 			// No specific question detected - return full health summary.
 			// This is the default when user asks something general like "site health".
 			return (
 				`Here's your site health information:\n\n` +
-				` * * WordPress: * * ${
-					result.wordpress_version || 'Unknown'
-				}\n` +
-				` * * PHP: * * ${ result.php_version || 'Unknown' }\n` +
-				` * * Database: * * MySQL ${
-					result.mysql_version || 'Unknown'
-				}\n` +
-				` * * Server: * * ${ result.server_software || 'Unknown' }\n` +
-				` * * Theme: * * ${ result.active_theme?.name || 'Unknown' } (${
+				`**WordPress:** ${ result.wordpress_version || 'Unknown' }\n` +
+				`**PHP:** ${ result.php_version || 'Unknown' }\n` +
+				`**Database:** MySQL ${ result.mysql_version || 'Unknown' }\n` +
+				`**Server:** ${ result.server_software || 'Unknown' }\n` +
+				`**Theme:** ${ result.active_theme?.name || 'Unknown' } (${
 					result.active_theme?.version || '?'
 				})\n` +
-				` * * Memory Limit: * * ${ result.memory_limit || 'Unknown' }`
+				`**Memory Limit:** ${ result.memory_limit || 'Unknown' }`
 			);
 		},
 
@@ -209,6 +205,11 @@ export function registerSiteHealth() {
 
 		// Read-only - no confirmation needed.
 		requiresConfirmation: false,
+
+		// summarize() already branches on the user's question (PHP version, theme,
+		// memory limit, ...) and returns a complete answer, so the second LLM call
+		// adds nothing but a truncation risk on the full health payload.
+		preferSummarize: true,
 	} );
 }
 

--- a/src/extensions/abilities/verify-core-checksums.js
+++ b/src/extensions/abilities/verify-core-checksums.js
@@ -191,6 +191,11 @@ export function registerVerifyCoreChecksums() {
 
 		// Read-only - no confirmation needed.
 		requiresConfirmation: false,
+
+		// summarize() emits fenced diff blocks for modified core files. The LLM
+		// mangles fenced code and the diffs blow past maxToolResultLength, so
+		// render them directly.
+		preferSummarize: true,
 	} );
 }
 

--- a/src/extensions/services/__tests__/react-agent.test.js
+++ b/src/extensions/services/__tests__/react-agent.test.js
@@ -511,9 +511,32 @@ describe( 'ReactAgent', () => {
 			]?.[ 0 ]?.response_format;
 		}
 
-		it( 'should NOT constrain output while thinking is enabled', async () => {
-			// Thinking on is the default. A JSON grammar cannot represent the
-			// leading <think> block, so the envelope must stay unconstrained.
+		it( 'should be OFF by default, even when thinking is disabled', async () => {
+			// Default is off because it breaks thinking models: Qwen 3 emits
+			// `{` then whitespace to max_tokens when the grammar blocks its
+			// <think> block. Verified in-browser 2026-08-01, reproduced 2/2.
+			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				disableThinking: true,
+			} );
+			reactAgent.setCallbacks( mockCallbacks );
+
+			mockStreamOnce(
+				mockEngine,
+				'{"action": "final_answer", "content": "Done"}'
+			);
+
+			await reactAgent.execute( 'flush the cache', [] );
+
+			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
+		} );
+
+		it( 'should NOT constrain a thinking turn even when opted in', async () => {
+			// A JSON grammar cannot represent the leading <think> block.
+			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				structuredOutput: true,
+			} );
+			reactAgent.setCallbacks( mockCallbacks );
+
 			mockStreamOnce(
 				mockEngine,
 				'{"action": "final_answer", "content": "Done"}'
@@ -524,8 +547,9 @@ describe( 'ReactAgent', () => {
 			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
 		} );
 
-		it( 'should constrain output when thinking is disabled', async () => {
+		it( 'should constrain output when opted in AND thinking is disabled', async () => {
 			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				structuredOutput: true,
 				disableThinking: true,
 			} );
 			reactAgent.setCallbacks( mockCallbacks );
@@ -552,6 +576,7 @@ describe( 'ReactAgent', () => {
 
 		it( 'should constrain follow-up turns once disableThinkingAfterTool fires', async () => {
 			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				structuredOutput: true,
 				disableThinkingAfterTool: true,
 			} );
 			reactAgent.setCallbacks( mockCallbacks );
@@ -567,23 +592,6 @@ describe( 'ReactAgent', () => {
 			// First turn still thinks, second turn (post-tool) does not.
 			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
 			expect( responseFormatOfCall( 1 ) ).toBeDefined();
-		} );
-
-		it( 'should honour structuredOutput: false as an escape hatch', async () => {
-			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
-				disableThinking: true,
-				structuredOutput: false,
-			} );
-			reactAgent.setCallbacks( mockCallbacks );
-
-			mockStreamOnce(
-				mockEngine,
-				'{"action": "final_answer", "content": "Done"}'
-			);
-
-			await reactAgent.execute( 'flush the cache', [] );
-
-			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
 		} );
 	} );
 } );

--- a/src/extensions/services/__tests__/react-agent.test.js
+++ b/src/extensions/services/__tests__/react-agent.test.js
@@ -497,4 +497,93 @@ describe( 'ReactAgent', () => {
 			expect( result.toolsUsed ).toContain( 'agentic-admin/site-health' );
 		} );
 	} );
+
+	describe( 'Structured output (grammar-constrained action envelope)', () => {
+		/**
+		 * Returns the response_format of the Nth create() call, if any.
+		 *
+		 * @param {number} callIndex - Zero-based index of the create() call.
+		 * @return {Object|undefined} The response_format passed, or undefined.
+		 */
+		function responseFormatOfCall( callIndex ) {
+			return mockEngine.chat.completions.create.mock.calls[
+				callIndex
+			]?.[ 0 ]?.response_format;
+		}
+
+		it( 'should NOT constrain output while thinking is enabled', async () => {
+			// Thinking on is the default. A JSON grammar cannot represent the
+			// leading <think> block, so the envelope must stay unconstrained.
+			mockStreamOnce(
+				mockEngine,
+				'{"action": "final_answer", "content": "Done"}'
+			);
+
+			await reactAgent.execute( 'hello', [] );
+
+			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
+		} );
+
+		it( 'should constrain output when thinking is disabled', async () => {
+			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				disableThinking: true,
+			} );
+			reactAgent.setCallbacks( mockCallbacks );
+
+			mockStreamOnce(
+				mockEngine,
+				'{"action": "final_answer", "content": "Done"}'
+			);
+
+			await reactAgent.execute( 'flush the cache', [] );
+
+			const format = responseFormatOfCall( 0 );
+			expect( format ).toBeDefined();
+			expect( format.type ).toBe( 'json_object' );
+
+			// The schema is passed stringified, as WebLLM expects.
+			const schema = JSON.parse( format.schema );
+			expect( schema.required ).toEqual( [ 'action' ] );
+			expect( schema.properties.action.enum ).toEqual( [
+				'tool_call',
+				'final_answer',
+			] );
+		} );
+
+		it( 'should constrain follow-up turns once disableThinkingAfterTool fires', async () => {
+			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				disableThinkingAfterTool: true,
+			} );
+			reactAgent.setCallbacks( mockCallbacks );
+
+			mockStreamOnce(
+				mockEngine,
+				'{"action": "tool_call", "tool": "agentic-admin/plugin-list", "args": {}}',
+				'{"action": "final_answer", "content": "You have 1 plugin."}'
+			);
+
+			await reactAgent.execute( 'list plugins', [] );
+
+			// First turn still thinks, second turn (post-tool) does not.
+			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
+			expect( responseFormatOfCall( 1 ) ).toBeDefined();
+		} );
+
+		it( 'should honour structuredOutput: false as an escape hatch', async () => {
+			reactAgent = new ReactAgent( mockModelLoader, mockToolRegistry, {
+				disableThinking: true,
+				structuredOutput: false,
+			} );
+			reactAgent.setCallbacks( mockCallbacks );
+
+			mockStreamOnce(
+				mockEngine,
+				'{"action": "final_answer", "content": "Done"}'
+			);
+
+			await reactAgent.execute( 'flush the cache', [] );
+
+			expect( responseFormatOfCall( 0 ) ).toBeUndefined();
+		} );
+	} );
 } );

--- a/src/extensions/services/external-engine.js
+++ b/src/extensions/services/external-engine.js
@@ -153,6 +153,14 @@ class ExternalEngine {
 			model: this.modelId,
 		};
 
+		// WebLLM accepts a `schema` key inside response_format to grammar-constrain
+		// decoding. That key is WebLLM-specific: OpenAI rejects unrecognized keys
+		// in response_format outright, and other providers ignore it. Keep plain
+		// JSON mode, which every OpenAI-compatible provider understands.
+		if ( body.response_format?.schema ) {
+			body.response_format = { type: body.response_format.type };
+		}
+
 		// o1/o3/gpt-5 models require specific parameter mapping and don't support many standard params
 		if ( isModernModel ) {
 			if ( body.max_tokens ) {

--- a/src/extensions/services/model-loader.js
+++ b/src/extensions/services/model-loader.js
@@ -70,14 +70,6 @@ const log = createLogger( 'ModelLoader' );
 const DEFAULT_MODEL = 'Qwen3-1.7B-q4f16_1-MLC';
 
 /**
- * Model configuration options
- */
-const MODEL_CONFIG = {
-	// Context window size (larger for 7B models)
-	context_window_size: 8192,
-};
-
-/**
  * Mapping from f16 model IDs to their f32 equivalents.
  * Used when the GPU does not support the shader-f16 WebGPU feature.
  */
@@ -1376,7 +1368,6 @@ export {
 	ModelLoader,
 	modelLoader,
 	DEFAULT_MODEL,
-	MODEL_CONFIG,
 	MODEL_CONTEXT_SIZES,
 	ExternalEngine,
 };

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -295,6 +295,14 @@ class ReactAgent {
 				const useStructuredOutput =
 					this.config.structuredOutput && suppressThinkingUi;
 
+				log.debug(
+					`Structured output: ${
+						useStructuredOutput
+							? 'ON — action envelope is grammar-constrained'
+							: 'off — thinking turn, envelope unconstrained'
+					}`
+				);
+
 				// Stream LLM response to show thinking tokens live
 				const stream = await engine.chat.completions.create( {
 					messages,

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -49,7 +49,7 @@ const REACT_CONFIG = {
 	maxToolResultLength: 3000, // 7B models handle more context
 	disableThinking: false, // Disable Qwen 3 <think> blocks for faster inference
 	disableThinkingAfterTool: false, // Skip thinking on iterations after tool results
-	structuredOutput: true, // Grammar-constrain the action envelope (see REACT_ACTION_SCHEMA)
+	structuredOutput: false, // Opt-in. Breaks thinking models — see REACT_ACTION_SCHEMA
 };
 
 /**
@@ -65,10 +65,25 @@ const REACT_CONFIG = {
  * fact. WebLLM implements this in the WASM layer; OpenAI-compatible providers
  * get plain JSON mode (see ExternalEngine, which strips the `schema` key).
  *
- * IMPORTANT: this can only be applied when thinking is disabled. Qwen 3 emits
- * `<think>...</think>` *before* the JSON, which a JSON grammar forbids, so
- * constraining a thinking turn would truncate the reasoning block and fail.
- * The call site gates on `suppressThinkingUi` for exactly this reason.
+ * OFF BY DEFAULT — it breaks thinking models. Measured in a real browser
+ * (WebGPU, Service Worker mode) on 2026-08-01:
+ *
+ *   Qwen2.5-7B-Instruct  structuredOutput ON  -> works, 2 iterations, 1 tool
+ *   Qwen3-1.7B-q4f32_1   structuredOutput ON  -> BROKEN, 0 tools, reproduced 2/2
+ *
+ * On Qwen3 the model emits `{` and then thousands of newlines until it hits
+ * max_tokens, so `parseActionFromResponse()` fails and the loop falls through
+ * to "I had trouble understanding how to help."
+ *
+ * Cause: Qwen 3 is a thinking model and wants to open `<think>` before the
+ * JSON. A JSON grammar cannot represent that block. `/nothink` is only a soft
+ * instruction, so when the model still reaches for `<think>` the grammar
+ * blocks every token except whitespace and decoding degenerates.
+ *
+ * Gating on `suppressThinkingUi` (below) is therefore necessary but NOT
+ * sufficient: it tracks whether we *asked* for no thinking, not whether the
+ * model complied. Enable this only on a non-thinking model such as
+ * Qwen2.5-7B, via `new ReactAgent( ..., { structuredOutput: true } )`.
  */
 const REACT_ACTION_SCHEMA = {
 	type: 'object',

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -49,6 +49,39 @@ const REACT_CONFIG = {
 	maxToolResultLength: 3000, // 7B models handle more context
 	disableThinking: false, // Disable Qwen 3 <think> blocks for faster inference
 	disableThinkingAfterTool: false, // Skip thinking on iterations after tool results
+	structuredOutput: true, // Grammar-constrain the action envelope (see REACT_ACTION_SCHEMA)
+};
+
+/**
+ * JSON schema for the ReAct action envelope.
+ *
+ * The loop only ever accepts two shapes:
+ *   {"action": "tool_call",    "tool": "<tool-id>", "args": {...}}
+ *   {"action": "final_answer", "content": "..."}
+ *
+ * Passing this to the engine as `response_format` makes the grammar enforce
+ * the envelope during decoding, so malformed JSON becomes unrepresentable
+ * rather than something `parseActionFromResponse()` has to repair after the
+ * fact. WebLLM implements this in the WASM layer; OpenAI-compatible providers
+ * get plain JSON mode (see ExternalEngine, which strips the `schema` key).
+ *
+ * IMPORTANT: this can only be applied when thinking is disabled. Qwen 3 emits
+ * `<think>...</think>` *before* the JSON, which a JSON grammar forbids, so
+ * constraining a thinking turn would truncate the reasoning block and fail.
+ * The call site gates on `suppressThinkingUi` for exactly this reason.
+ */
+const REACT_ACTION_SCHEMA = {
+	type: 'object',
+	properties: {
+		action: {
+			type: 'string',
+			enum: [ 'tool_call', 'final_answer' ],
+		},
+		tool: { type: 'string' },
+		args: { type: 'object' },
+		content: { type: 'string' },
+	},
+	required: [ 'action' ],
 };
 
 /**
@@ -255,6 +288,13 @@ class ReactAgent {
 			);
 
 			try {
+				// Grammar-constrain the action envelope, but only on turns where
+				// thinking is off. A JSON grammar cannot represent the leading
+				// <think> block, so constraining a thinking turn would break it.
+				// See REACT_ACTION_SCHEMA.
+				const useStructuredOutput =
+					this.config.structuredOutput && suppressThinkingUi;
+
 				// Stream LLM response to show thinking tokens live
 				const stream = await engine.chat.completions.create( {
 					messages,
@@ -262,6 +302,12 @@ class ReactAgent {
 					max_tokens: this.config.maxTokens,
 					stream: true,
 					stream_options: { include_usage: true },
+					...( useStructuredOutput && {
+						response_format: {
+							type: 'json_object',
+							schema: JSON.stringify( REACT_ACTION_SCHEMA ),
+						},
+					} ),
 				} );
 
 				let fullResponse = '';

--- a/src/extensions/services/react-agent.js
+++ b/src/extensions/services/react-agent.js
@@ -310,13 +310,20 @@ class ReactAgent {
 				const useStructuredOutput =
 					this.config.structuredOutput && suppressThinkingUi;
 
-				log.debug(
-					`Structured output: ${
-						useStructuredOutput
-							? 'ON — action envelope is grammar-constrained'
-							: 'off — thinking turn, envelope unconstrained'
-					}`
-				);
+				// Name the actual reason — "disabled" and "thinking turn" are
+				// different causes and conflating them misleads when debugging.
+				let structuredOutputReason;
+				if ( useStructuredOutput ) {
+					structuredOutputReason =
+						'ON — action envelope is grammar-constrained';
+				} else if ( ! this.config.structuredOutput ) {
+					structuredOutputReason =
+						'off — structuredOutput disabled (default)';
+				} else {
+					structuredOutputReason =
+						'off — thinking turn, envelope unconstrained';
+				}
+				log.debug( `Structured output: ${ structuredOutputReason }` );
 
 				// Stream LLM response to show thinking tokens live
 				const stream = await engine.chat.completions.create( {

--- a/src/extensions/styles/admin-sidebar.scss
+++ b/src/extensions/styles/admin-sidebar.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
 
 /**
- * WP Agentic Admin - Admin Sidebar Styles
+ * Agentic Admin - Admin Sidebar Styles
  *
  * Fixed sidebar panel for all wp-admin pages.
  * Imports base chat styles and adds sidebar-specific overrides.

--- a/src/extensions/styles/editor-sidebar.scss
+++ b/src/extensions/styles/editor-sidebar.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
 
 /**
- * WP Agentic Admin - Editor Sidebar Styles
+ * Agentic Admin - Editor Sidebar Styles
  *
  * Imports base styles and adds overrides for the narrow
  * PluginSidebar panel (~280px width).

--- a/src/extensions/styles/main.scss
+++ b/src/extensions/styles/main.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable no-descending-specificity, no-duplicate-selectors */
 
 /**
- * WP Agentic Admin - Main Styles
+ * Agentic Admin - Main Styles
  *
  * Descending specificity disabled: SCSS nesting of BEM modifiers causes
  * false positives when unrelated components style the same HTML elements.

--- a/src/extensions/sw.js
+++ b/src/extensions/sw.js
@@ -30,7 +30,7 @@ const SW_VERSION = '0.4.101';
  */
 function swLog( ...args ) {
 	const timestamp = new Date().toISOString().split( 'T' )[ 1 ].slice( 0, -1 );
-	console.log( `[WP Agentic SW ${ timestamp }]`, ...args );
+	console.log( `[Agentic Admin SW ${ timestamp }]`, ...args );
 }
 
 /**

--- a/src/extensions/utils/logger.js
+++ b/src/extensions/utils/logger.js
@@ -15,19 +15,21 @@ const LOG_LEVELS = {
 	DEBUG: 3,
 };
 
-// Set default log level (can be changed via console: window.wpAgenticLogLevel = 2)
+// Set default log level (can be changed via console: window.agenticAdminLogLevel = 3)
 let currentLogLevel = LOG_LEVELS.INFO;
 
-// Allow setting log level from browser console
+// Allow setting log level from the browser console.
+// Named without the reserved `wp` prefix, per the WordPress.org plugin
+// guidelines on avoiding naming collisions.
 if ( typeof window !== 'undefined' ) {
-	window.wpAgenticLogLevel = currentLogLevel;
-	Object.defineProperty( window, 'wpAgenticLogLevel', {
+	Object.defineProperty( window, 'agenticAdminLogLevel', {
+		configurable: true,
 		get: () => currentLogLevel,
 		set: ( level ) => {
 			if ( typeof level === 'number' && level >= 0 && level <= 3 ) {
 				currentLogLevel = level;
 				console.log(
-					`[WP Agentic] Log level set to: ${ Object.keys(
+					`[Agentic Admin] Log level set to: ${ Object.keys(
 						LOG_LEVELS
 					).find( ( key ) => LOG_LEVELS[ key ] === level ) }`
 				);


### PR DESCRIPTION
Three independent reliability fixes in the inference path. They came out of investigating why the local 7B "struggles sometimes". None of them change the model or the runtime.

Deliberately **not** touching the engine, the model catalog, or anything WebLLM-adjacent while #228 (the WP.org submission) is open.

---

## 1. Correct stale docs, delete dead config

`docs/ARCHITECTURE.md` and `.claude/CLAUDE.md` both claimed:

- a **4096-token context window**
- **2000-char** tool-result truncation

Both are wrong, and have been for a while. The code says:

| | Docs claimed | Actually |
|---|---|---|
| Context, Qwen3 1.7B | 4096 | **8192** (`MODEL_CONTEXT_SIZES`) |
| Context, Qwen2.5 7B | 32768 | 32768 ✓ |
| Tool result truncation | 2000 | **3000** (`maxToolResultLength`) |

This matters more than a typo. Any analysis of the agent built on these docs inherits the error, and the obvious "fix" it suggests, bumping the context to 16384, would actually **halve** the 7B's window.

Also removed `MODEL_CONFIG.context_window_size = 8192` from `model-loader.js`. It looked authoritative, contradicted `MODEL_CONTEXT_SIZES`, and was **never passed to the engine**: its only reference in the entire codebase was its own line in the export block. It is almost certainly where the "single global 4096-ish context" impression came from.

The docs now point at `MODEL_CONTEXT_SIZES` as the source of truth and mention the `agentic_admin_context_size` localStorage override resolved by `ModelLoader.getEffectiveContextSize()`.

## 2. Grammar-constrain the ReAct action envelope

The loop only ever accepts two shapes:

```json
{"action": "tool_call",    "tool": "<tool-id>", "args": {}}
{"action": "final_answer", "content": "..."}
```

Until now we **asked** for that in the system prompt and then repaired whatever came back. `parseActionFromResponse()` is ~80 lines of strip-the-think-block, strip-the-code-fence, sanitize-control-characters, retry-with-quote-replacement. That is a lot of machinery for "the model produced not-quite-JSON".

`response_format` appeared exactly once in the whole codebase, in `workflow-orchestrator.js:469`, and even there as bare `{ type: 'json_object' }` with no schema. The ReAct loop, the hot path, used none.

Now `REACT_ACTION_SCHEMA` is passed as `response_format`, so the grammar enforces the envelope **during decoding**. Malformed JSON becomes unrepresentable rather than something we repair after the fact. `parseActionFromResponse()` stays as-is, it is still the path for unconstrained turns and a safety net.

### The catch, and why this is gated

A JSON grammar cannot represent Qwen 3's leading `<think>...</think>` block. Constraining a thinking turn would truncate the reasoning and fail. So this applies **only when thinking is already off**:

```js
const useStructuredOutput = this.config.structuredOutput && suppressThinkingUi;
```

which covers both existing nothink paths: router-level `disableThinking` for clear action commands, and post-tool `disableThinkingAfterTool`. Thinking turns are untouched.

`ExternalEngine` strips the WebLLM-specific `schema` key from `response_format` before proxying. WebLLM understands it; OpenAI **rejects unrecognized keys in `response_format` outright**, so external providers keep plain JSON mode.

Escape hatch if it misbehaves in the wild: `structuredOutput: false`.

## 3. Adopt `preferSummarize` on the report abilities

`react-agent.js:451` already has the right mechanism: if an ability sets `preferSummarize`, the loop skips the second LLM call and returns `summarize()` directly. Added in the read-file work, explicitly to dodge truncation.

**It was used by 2 of 37 abilities.**

Flipped it on for the four abilities that emit large, complete, self-contained reports:

| Ability | Why |
|---|---|
| `site-health` | `summarize()` already branches on the user's question (PHP version, theme, memory limit, ...) and returns a complete answer. The LLM adds nothing. |
| `security-scan` | Full pass/fail report grouped by severity. Re-rendering risks dropping findings. |
| `verify-core-checksums` | Emits fenced diff blocks. The LLM mangles fenced code, and diffs blow past 3000 chars. |
| `file-scan` | Lists every plugin, theme and mu-plugin scanned. A truncated security scan is worse than none. |

Selection criterion: the output is a **report**, not data the LLM needs to reason over or filter. I deliberately left `plugin-list`, `post-list`, `user-list` and friends alone, since #109 wants the LLM filtering those to match the question, which is the opposite requirement.

**Workflows are unaffected.** `preferSummarize` is only consulted by `react-agent.js` and `chat-orchestrator.js`; `workflow-orchestrator.js` does not look at it. The four workflows chaining these abilities (`check-if-hacked`, `performance-check`, `plugin-audit`, `site-cleanup`) read `r.abilityId` results directly and are untouched.

### Prerequisite: broken markdown

Enabling `preferSummarize` meant `summarize()` output goes to the user **verbatim**, with no LLM in between. Which surfaced this:

```js
return `Your PHP version is * * ${ result.php_version } * * .`;
```

`* * 8.2 * *` instead of `**8.2**`, so it renders as literal asterisks. Present throughout `site-health`, and also in `core-site-info`, `core-environment-info` and `plugin-list`. The LLM had been silently repairing it on the way out, which is exactly why nobody noticed.

Fixed in all four files. The last three do not get `preferSummarize` in this PR, but leaving known-broken markdown in place because it happens to be masked did not seem right.

---

## Testing

- **4 new unit tests** on the gating: not constrained while thinking is on, constrained when `disableThinking` is set, constrained on the follow-up turn once `disableThinkingAfterTool` fires, and `structuredOutput: false` honoured.
- **95 unit tests pass** (was 91).
- `npx wp-scripts lint-js` clean on every modified file. The 4 remaining `model-loader.js` warnings (nested ternary, JSDoc) are pre-existing and outside this diff.
- `npx wp-scripts build` succeeds. Only the pre-existing bundle-size warnings.
- No PHP touched.

## What is NOT verified, and why

**Item 2 is not empirically validated.** The tests above prove the request is shaped correctly and gated correctly; they do not prove the model behaves better, because they run against a mocked LLM.

The Ollama ability harness **cannot** validate it either. Verified rather than assumed:

- `tests/abilities/runner.js` imports nothing from `src/extensions/services/`. Its own comments say it *mirrors* `react-agent.js`'s system prompt builder (line 168) and JSON parser (line 211). It is a reimplementation, so it never executes the `response_format` path.
- `tests/abilities/load-abilities.js` extracts only `{ id, label, description }` by regex. This PR changes engine request params, post-tool rendering and docs, none of which the harness can see.

So the harness measures **tool selection** only, and this PR cannot move that number in either direction. What it can do is catch a regression in the regex loader, since I edited seven ability files. That check passed without needing Ollama: **35 abilities extracted on this branch, identical to `main`**, with all seven edited files parsing correctly.

Genuinely validating item 2 needs WebGPU in a real browser, which means the E2E suite, not the Ollama harness.

## What this does not do

It does not touch the engine, the model, or the WebLLM version, and it does not address the "7B struggles" question at the model level. If these three do not move the needle, the next honest step is the cloud fallback already on the roadmap, not a different small model.

Refs #228
