### PR TITLE
fix: address WP.org T4 review items (#228)

### DIFF
--- a/includes/abilities/security/uploads-scan.php
+++ b/includes/abilities/security/uploads-scan.php
@@ -172,7 +172,12 @@ function agentic_admin_execute_uploads_scan( array $input = array() ): array {
 	// 3. Scan .well-known directory (recursive).
 	// Attackers hide backdoors in .well-known/ because admins rarely check it
 	// and some security scanners skip dotfiles/dotdirs.
-	$well_known_dir = ABSPATH . '.well-known';
+	// .well-known lives at the site root (document root), which is get_home_path()
+	// and can differ from ABSPATH on subdirectory installs.
+	if ( ! function_exists( 'get_home_path' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+	}
+	$well_known_dir = trailingslashit( get_home_path() ) . '.well-known';
 	if ( is_dir( $well_known_dir ) ) {
 		$areas_scanned[] = '.well-known';
 		agentic_admin_scan_directory_for_dangerous_files(

--- a/src/extensions/services/vector-store.js
+++ b/src/extensions/services/vector-store.js
@@ -14,7 +14,7 @@ import { createLogger } from '../utils/logger';
 const log = createLogger( 'VectorStore' );
 
 const TRANSFORMERS_CDN =
-	'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3';
+	'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.8.1';
 const MODEL_NAME = 'Xenova/all-MiniLM-L6-v2';
 const DB_NAME = 'wp-agentic-rag-db';
 const DB_VERSION = 1;


### PR DESCRIPTION
Addresses the two concrete code changes flagged in WP.org review `R agentic-admin/schmitzoide/1Jun26/T4`, tracked in #228.

## Changes

- **`uploads-scan.php`** — resolve the `.well-known` scan path via `get_home_path()` instead of `ABSPATH`. On subdirectory installs the site root (document root, where `.well-known` lives) differs from the WordPress core directory, so `ABSPATH . '.well-known'` scanned the wrong place. Guards the `wp-admin/includes/file.php` require so `get_home_path()` is available in the ability's REST load path.
- **`vector-store.js`** — pin the Transformers.js jsDelivr URL to `@3.8.1` (was floating `@3`). Now matches `indexing-worker.js` and makes the existing readme changelog claim accurate; a privacy-first plugin should not depend on a CDN range that can ship new code without a deliberate bump.

## Not in this PR (decisions in #228)

- The remote-loading answer (item 1) is a **reply to the reviewer**, not a code change — the feature is kept to avoid breaking functionality; the pin above strengthens the "static, deliberate asset" position.
- voy `.module.wasm` (item 2) — keeping the upstream reference for now; vendoring is the fallback if a T5 pushes back.

## Verification

- `composer lint` / `wp-scripts lint-js` clean on both files
- `npm run build` compiles
- Version stays at `0.11.0` (submission is pinned there)

Part of #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
